### PR TITLE
feat(sources): add Incus platform source (system containers + VMs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Incus platform source** (`DNSWEAVER_SOURCES=incus`). Discovers running Incus
+  system containers and virtual machines and creates DNS `A` records mapping
+  each instance to its resolved IP address. Connects either to a local Unix
+  socket (`DNSWEAVER_INCUS_SOCKET_PATH`) or a remote HTTPS endpoint
+  (`DNSWEAVER_INCUS_URL`) secured with a client certificate — the two are
+  mutually exclusive. Per-source configuration:
+  - `DNSWEAVER_INCUS_PROJECT` — restrict discovery to a single Incus project.
+  - `DNSWEAVER_INCUS_STATE_FILTER` — instance status filter (default `running`).
+  - `DNSWEAVER_INCUS_DOMAIN_SUFFIX` — domain appended to instance names
+    (e.g. `webserver` → `webserver.home.example.com`).
+  - `DNSWEAVER_INCUS_TARGET_MODE` — `guest-ip` (default, A record per instance
+    IP) or `instance` (defer record type/target to the matching provider, for
+    CNAME-to-reverse-proxy setups).
+  - `DNSWEAVER_INCUS_TLS_*` — unified TLS surface (custom CA, mTLS client cert,
+    SNI override, configurable minimum version) for remote HTTPS access.
+
+  Hostname precedence: a `user.dnsweaver.hostname` instance config key (verbatim
+  override) > an instance name that is already an FQDN > `<name>.<domain>`.
+  Instances with no resolvable IP are skipped as a liveness gate. The source is
+  auto-registered when an Incus endpoint is configured.
+
 ## [2.1.0] - 2026-06-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ dnsweaver watches Docker events, Kubernetes resources, and Proxmox VE clusters t
 - 🐳 **Docker & Swarm** — Works with standalone Docker and Docker Swarm clusters
 - ☸️ **Kubernetes Native** — Watches Ingress, IngressRoute, HTTPRoute, and Service resources via Helm or Kustomize
 - 🖥️ **Proxmox VE** — Auto-creates A records for VMs (via QEMU guest agent) and LXC containers
+- 📦 **Incus** — Auto-creates A records for system containers and VMs via local socket or remote HTTPS
 - 🏗️ **Multi-Instance Safe** — Run multiple dnsweaver instances on the same DNS zone without conflicts
 - 🔒 **Socket Proxy Compatible** — Connect via TCP to a Docker socket proxy for improved security
 - 🛡️ **Hardened TLS** — Unified per-instance TLS controls (custom CA, mTLS client certs, SNI override, configurable min version; TLS 1.2 floor by default) for every HTTP-based provider and the Proxmox source
@@ -86,6 +87,7 @@ flowchart LR
     A["Docker / Swarm"] --> B["dnsweaver"]
     D["Kubernetes"] --> B
     P["Proxmox VE"] --> B
+    I["Incus"] --> B
     B --> C["DNS Providers<br/>(create / update / delete)"]
 ```
 
@@ -110,9 +112,10 @@ flowchart LR
 | [Getting Started](https://maxfield-allison.github.io/dnsweaver/getting-started/) | Installation and first configuration |
 | [Configuration](https://maxfield-allison.github.io/dnsweaver/configuration/environment/) | Environment variables reference |
 | [Providers](https://maxfield-allison.github.io/dnsweaver/providers/) | Provider-specific setup guides |
-| [Sources](https://maxfield-allison.github.io/dnsweaver/sources/) | Docker, Kubernetes, Proxmox, Traefik file sources |
+| [Sources](https://maxfield-allison.github.io/dnsweaver/sources/) | Docker, Kubernetes, Proxmox, Incus, Traefik file sources |
 | [Kubernetes](https://maxfield-allison.github.io/dnsweaver/deployment/kubernetes/) | Kubernetes deployment with Helm/Kustomize |
 | [Proxmox VE](https://maxfield-allison.github.io/dnsweaver/sources/proxmox/) | Auto-DNS for VMs and LXC containers |
+| [Incus](https://maxfield-allison.github.io/dnsweaver/sources/incus/) | Auto-DNS for system containers and VMs |
 | [Split-Horizon DNS](https://maxfield-allison.github.io/dnsweaver/deployment/split-horizon/) | Internal + external records |
 | [Docker Swarm](https://maxfield-allison.github.io/dnsweaver/deployment/swarm/) | Swarm deployment guide |
 | [Observability](https://maxfield-allison.github.io/dnsweaver/observability/) | Metrics, logging, and health checks |

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/maxfield-allison/dnsweaver/internal/config"
 	"github.com/maxfield-allison/dnsweaver/internal/docker"
 	"github.com/maxfield-allison/dnsweaver/internal/health"
+	incusclient "github.com/maxfield-allison/dnsweaver/internal/incus"
 	k8s "github.com/maxfield-allison/dnsweaver/internal/kubernetes"
 	"github.com/maxfield-allison/dnsweaver/internal/metrics"
 	proxmoxclient "github.com/maxfield-allison/dnsweaver/internal/proxmox"
@@ -304,8 +305,30 @@ func run() error {
 		)
 	}
 
+	// Initialize Incus lister when DNSWEAVER_INCUS_URL or _SOCKET_PATH is set.
+	if cfg.UseIncus() {
+		incusClient, err := incusclient.NewClient(incusclient.ClientConfig{
+			BaseURL:    cfg.IncusURL(),
+			SocketPath: cfg.IncusSocketPath(),
+			Project:    cfg.IncusProject(),
+			TLS:        cfg.IncusTLS(),
+			Logger:     logger,
+		})
+		if err != nil {
+			return fmt.Errorf("creating incus client: %w", err)
+		}
+		incusLister := incusclient.NewWorkloadListerAdapter(incusClient, incusclient.AdapterConfig{
+			StateFilter: cfg.IncusStateFilter(),
+		}, logger)
+		listers = append(listers, incusLister)
+		logger.Info("incus lister configured",
+			slog.String("endpoint", incusEndpoint(cfg)),
+			slog.String("project", cfg.IncusProject()),
+		)
+	}
+
 	if len(listers) == 0 {
-		return fmt.Errorf("no platform watchers configured: set DNSWEAVER_PLATFORM to docker, kubernetes, or both, or set DNSWEAVER_PROXMOX_URL for Proxmox VE")
+		return fmt.Errorf("no platform watchers configured: set DNSWEAVER_PLATFORM to docker, kubernetes, or both, set DNSWEAVER_PROXMOX_URL for Proxmox VE, or set DNSWEAVER_INCUS_URL/DNSWEAVER_INCUS_SOCKET_PATH for Incus")
 	}
 
 	rec := reconciler.New(listers, sourceRegistry, providerRegistry,

--- a/cmd/dnsweaver/setup.go
+++ b/cmd/dnsweaver/setup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/maxfield-allison/dnsweaver/providers/webhook"
 	"github.com/maxfield-allison/dnsweaver/sources/caddy"
 	dnsweaversource "github.com/maxfield-allison/dnsweaver/sources/dnsweaver"
+	incussource "github.com/maxfield-allison/dnsweaver/sources/incus"
 	k8ssource "github.com/maxfield-allison/dnsweaver/sources/kubernetes"
 	"github.com/maxfield-allison/dnsweaver/sources/nginxproxy"
 	proxmoxsource "github.com/maxfield-allison/dnsweaver/sources/proxmox"
@@ -161,6 +162,18 @@ func registerSources(registry *source.Registry, cfg *config.Config, logger *slog
 			logger.Info("registered source",
 				slog.String("name", name),
 			)
+		case "incus":
+			src := incussource.New(
+				incussource.WithDomain(cfg.IncusDomainSuffix()),
+				incussource.WithTargetMode(incusTargetMode(cfg)),
+				incussource.WithLogger(logger),
+			)
+			if err := registry.Register(src); err != nil {
+				return fmt.Errorf("registering incus source: %w", err)
+			}
+			logger.Info("registered source",
+				slog.String("name", name),
+			)
 		default:
 			logger.Warn("unknown source, skipping", slog.String("source", name))
 		}
@@ -196,6 +209,22 @@ func registerSources(registry *source.Registry, cfg *config.Config, logger *slog
 		}
 	}
 
+	// Auto-register incus source when Incus is enabled.
+	// Mirrors the Proxmox auto-registration pattern.
+	if cfg.UseIncus() {
+		if registry.Get("incus") == nil {
+			src := incussource.New(
+				incussource.WithDomain(cfg.IncusDomainSuffix()),
+				incussource.WithTargetMode(incusTargetMode(cfg)),
+				incussource.WithLogger(logger),
+			)
+			if err := registry.Register(src); err != nil {
+				return fmt.Errorf("registering incus source: %w", err)
+			}
+			logger.Info("auto-registered incus source for Incus platform")
+		}
+	}
+
 	return nil
 }
 
@@ -208,6 +237,26 @@ func proxmoxTargetMode(cfg *config.Config) proxmoxsource.TargetMode {
 		return proxmoxsource.TargetModeGuestIP
 	}
 	return mode
+}
+
+// incusTargetMode resolves the Incus target mode from config. Validation
+// happens during config load — this returns the default for any unrecognized
+// value to keep the source constructor strict-typed.
+func incusTargetMode(cfg *config.Config) incussource.TargetMode {
+	mode, err := incussource.ParseTargetMode(cfg.IncusTargetMode())
+	if err != nil {
+		return incussource.TargetModeGuestIP
+	}
+	return mode
+}
+
+// incusEndpoint returns a human-readable description of the configured Incus
+// endpoint (remote URL or local socket path) for logging.
+func incusEndpoint(cfg *config.Config) string {
+	if url := cfg.IncusURL(); url != "" {
+		return url
+	}
+	return "unix:" + cfg.IncusSocketPath()
 }
 
 // createTraefikSource creates a Traefik label parser with optional file discovery.

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,14 @@ dnsweaver watches Docker events, Kubernetes resources, and Proxmox VE clusters t
 
     [:octicons-arrow-right-24: Proxmox Source](sources/proxmox.md)
 
+-   :material-cube-outline:{ .lg .middle } **Incus**
+
+    ---
+
+    Auto-creates A records for Incus system containers and VMs over a local socket or remote HTTPS.
+
+    [:octicons-arrow-right-24: Incus Source](sources/incus.md)
+
 -   :material-chart-line:{ .lg .middle } **Observable**
 
     ---
@@ -64,6 +72,7 @@ flowchart LR
     A["Docker / Swarm"] --> B["dnsweaver"]
     D["Kubernetes"] --> B
     P["Proxmox VE"] --> B
+    I["Incus"] --> B
     B --> C["DNS Providers<br/>(create / update / delete)"]
 ```
 
@@ -126,6 +135,23 @@ flowchart LR
         - **A record**: `myvm.home.example.com → 192.0.2.10`
 
     4. When the VM or LXC is stopped or deleted, the DNS record is automatically cleaned up
+
+=== "Incus"
+
+    1. An Incus system container or VM is running with a resolvable IP:
+
+        ```bash
+        # Example: incus launch images:debian/12 myinstance # (1)!
+        ```
+
+        1. dnsweaver polls the Incus API (local socket or remote HTTPS) and discovers instances via their network state
+
+    2. dnsweaver extracts the instance hostname and IP, then matches against configured provider domain patterns
+
+    3. The matching provider creates the DNS record:
+        - **A record**: `myinstance.home.example.com → 192.0.2.20`
+
+    4. When the instance is stopped or deleted, the DNS record is automatically cleaned up
 
 ## Quick Start
 
@@ -205,6 +231,7 @@ flowchart LR
 | Docker support | :material-check: | :material-close: | :material-check: |
 | Kubernetes support | :material-check: | :material-check: | :material-close: |
 | Proxmox VE support | :material-check: | :material-close: | :material-close: |
+| Incus support | :material-check: | :material-close: | :material-close: |
 | Multiple providers | :material-check: | :material-close: | :material-close: |
 | Split-horizon DNS | :material-check: | :material-close: | :material-close: |
 | Self-hosted DNS focus | :material-check: | :material-close: | :material-close: |

--- a/docs/sources/incus.md
+++ b/docs/sources/incus.md
@@ -1,0 +1,268 @@
+---
+title: Incus Source
+description: Automatic DNS A record creation for Incus system containers and virtual machines
+icon: material/cube-outline
+---
+
+# Incus Source
+
+The Incus source creates DNS A records for running [Incus](https://linuxcontainers.org/incus/) system containers and virtual machines. It polls the Incus REST API to discover instances, resolves each instance's IP address from its network state, then registers an A record mapping `<instance-name>.<domain>` to that IP.
+
+It connects either to a **local Unix socket** (agent running on the Incus host) or to a **remote HTTPS endpoint** secured with a client certificate.
+
+## How It Works
+
+```mermaid
+flowchart LR
+    A["Incus API<br/>/1.0/instances?recursion=2"] -->|"Poll interval"| B["List containers / VMs"]
+    B -->|"Filter: state"| C["Resolve IP"]
+    C -->|"InstanceState.Network<br/>(first global inet addr)"| D["Hostname + IP"]
+    D --> E["Incus Source"]
+    E -->|"A record"| F["Reconciler → DNS"]
+```
+
+1. **Lister** polls `/1.0/instances?recursion=2` and applies the state filter
+2. **IP resolver** scans each instance's network interfaces, skipping loopback and non-routable addresses, and selects the first global IPv4 address
+3. **Source** maps the instance name + configured domain suffix to a fully-qualified hostname
+4. **Reconciler** creates or updates A records via the matching DNS provider
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+| :------- | :------- | :------ | :---------- |
+| `DNSWEAVER_INCUS_URL` | Alt | — | Remote Incus API base URL, e.g. `https://incus-host:8443`. Mutually exclusive with `DNSWEAVER_INCUS_SOCKET_PATH`. |
+| `DNSWEAVER_INCUS_SOCKET_PATH` | Alt | — | Path to the local Incus Unix socket, e.g. `/var/lib/incus/unix.socket`. Mutually exclusive with `DNSWEAVER_INCUS_URL`. |
+| `DNSWEAVER_INCUS_PROJECT` | No | _(all / default)_ | Restrict discovery to a single Incus project |
+| `DNSWEAVER_INCUS_STATE_FILTER` | No | `running` | Instance status filter (`running`, `stopped`, etc.) |
+| `DNSWEAVER_INCUS_DOMAIN_SUFFIX` | No | — | Domain suffix appended to instance names, e.g. `home.example.com` |
+| `DNSWEAVER_INCUS_TARGET_MODE` | No | `guest-ip` | Target resolution mode. `guest-ip` (default) emits an A record per instance IP. `instance` defers record type and target to the matching provider instance — useful for pointing all instances at a reverse proxy via CNAME. |
+| `DNSWEAVER_INCUS_TLS_CA_FILE` | No | — | Path to PEM CA bundle that issued the Incus server certificate (remote HTTPS). |
+| `DNSWEAVER_INCUS_TLS_CERT_FILE` | No | — | Client certificate for mutual TLS against the Incus API (pair with `TLS_KEY_FILE`). |
+| `DNSWEAVER_INCUS_TLS_KEY_FILE` | No | — | Client private key for mutual TLS. |
+| `DNSWEAVER_INCUS_TLS_SERVER_NAME` | No | — | SNI / verification hostname override. |
+| `DNSWEAVER_INCUS_TLS_MIN_VERSION` | No | `1.2` | Minimum TLS protocol version (`1.2` or `1.3`). |
+| `DNSWEAVER_INCUS_TLS_SKIP_VERIFY` | No | `false` | Skip Incus TLS certificate verification. Prefer `TLS_CA_FILE`. |
+
+!!! warning "Pick exactly one endpoint"
+    Set **either** `DNSWEAVER_INCUS_URL` (remote HTTPS) **or**
+    `DNSWEAVER_INCUS_SOCKET_PATH` (local socket) — never both. Setting both is a
+    configuration error and dnsweaver will refuse to start.
+
+### Source Registration
+
+Add `incus` to `DNSWEAVER_SOURCES`:
+
+```bash
+DNSWEAVER_SOURCES=incus
+```
+
+!!! tip "Auto-registration"
+    When `DNSWEAVER_INCUS_URL` or `DNSWEAVER_INCUS_SOCKET_PATH` is set, the Incus
+    source is **automatically registered** even if not listed in
+    `DNSWEAVER_SOURCES`. You only need to list it explicitly if you want to
+    control source ordering relative to other sources.
+
+## Hostname Resolution
+
+The source determines the DNS hostname for each instance using this logic, in order of precedence:
+
+1. **`user.dnsweaver.hostname` config key** — set on the instance, its value is used verbatim as the hostname (e.g. `incus config set web user.dnsweaver.hostname=app.example.net`)
+2. **Instance name contains a dot** — used directly as an FQDN (e.g., `db.home.example.com`)
+3. **Domain suffix configured** — appended to the instance name (e.g., `web` + `home.example.com` → `web.home.example.com`)
+4. **None of the above** — the instance is skipped; a debug log entry is emitted
+
+!!! warning "Domain suffix is strongly recommended"
+    Without a domain suffix, only instances whose names already contain a dot (or
+    that set `user.dnsweaver.hostname`) will produce DNS records. Set
+    `DNSWEAVER_INCUS_DOMAIN_SUFFIX` to ensure all instances are registered.
+
+### Per-instance hostname override
+
+Pin an arbitrary FQDN to any instance with a config key:
+
+```bash
+incus config set webserver user.dnsweaver.hostname=shop.example.com
+```
+
+This takes precedence over the derived `<name>.<domain>` hostname.
+
+## IP Address Resolution
+
+The resolver reads each instance's live network state (`InstanceState.Network`) and selects an address by:
+
+1. Sorting interface names for deterministic selection
+2. Skipping loopback interfaces (`lo`, `lo0`)
+3. Selecting the first **global** IPv4 (`inet`) address
+4. Skipping non-routable addresses (link-local, etc.)
+
+!!! note "Tailscale / CGNAT addresses are kept"
+    Addresses in the `100.64.0.0/10` CGNAT range (used by Tailscale) are treated
+    as valid targets, so Tailscale-connected instances resolve to their tailnet IP.
+
+Instances with no resolvable IP are skipped in **both** target modes — the IP existence acts as a liveness gate.
+
+## Target Mode
+
+`DNSWEAVER_INCUS_TARGET_MODE` controls what the source emits for each discovered instance:
+
+| Mode | Record Type | Target | Use Case |
+| :--- | :---------- | :----- | :------- |
+| `guest-ip` *(default)* | `A` | Instance's resolved IP | Direct DNS resolution to each container/VM |
+| `instance` | _from instance_ | _from instance_ | Point all Incus-discovered hostnames at a reverse proxy |
+
+In `instance` mode, the source emits the hostname only (no record-type or target hints).
+The matching provider instance's `RECORD_TYPE` and `TARGET` drive the resulting record,
+so a CNAME instance pointed at NPMplus / Traefik / Caddy will create CNAME records for
+every Incus instance that matches its `DOMAINS` filter.
+
+### Example: CNAME everything to a reverse proxy
+
+```bash
+DNSWEAVER_SOURCES=incus
+DNSWEAVER_INCUS_SOCKET_PATH=/var/lib/incus/unix.socket
+DNSWEAVER_INCUS_DOMAIN_SUFFIX=home.example.com
+DNSWEAVER_INCUS_TARGET_MODE=instance         # opt in
+
+DNSWEAVER_INSTANCES=npmplus
+DNSWEAVER_NPMPLUS_TYPE=technitium
+DNSWEAVER_NPMPLUS_RECORD_TYPE=CNAME
+DNSWEAVER_NPMPLUS_TARGET=npmplus.home.example.com   # all instances point here
+DNSWEAVER_NPMPLUS_DOMAINS=*.home.example.com
+DNSWEAVER_NPMPLUS_URL=https://technitium.home.example.com
+DNSWEAVER_NPMPLUS_TOKEN_FILE=/run/secrets/technitium_token
+```
+
+Every Incus instance matching `*.home.example.com` will get a CNAME pointing to
+`npmplus.home.example.com` instead of an A record pointing at the instance's own IP.
+
+## Remote HTTPS Access
+
+To reach Incus over the network, add a trust certificate to the Incus server and point dnsweaver at the API with a matching client certificate:
+
+```bash
+# On the Incus host: expose the API and trust dnsweaver's client cert
+incus config set core.https_address :8443
+incus config trust add-certificate dnsweaver.crt
+```
+
+Then configure dnsweaver:
+
+```bash
+DNSWEAVER_INCUS_URL=https://incus-host.home.example.com:8443
+DNSWEAVER_INCUS_TLS_CERT_FILE=/run/secrets/incus_client_cert
+DNSWEAVER_INCUS_TLS_KEY_FILE=/run/secrets/incus_client_key
+DNSWEAVER_INCUS_TLS_CA_FILE=/run/secrets/incus_server_ca
+```
+
+!!! tip "Local socket needs no TLS"
+    When using `DNSWEAVER_INCUS_SOCKET_PATH`, no TLS configuration is required —
+    access is governed by Unix socket file permissions. Mount the socket into the
+    container and ensure the dnsweaver process can read it.
+
+## Workload Metadata
+
+Each Incus instance is mapped to a workload with the following metadata:
+
+| Field | Value |
+| :---- | :---- |
+| `Platform` | `incus` |
+| `Kind` | `incus-container` or `incus-vm` |
+| `ID` / `Router` | `<project>/<instance-name>` |
+| Labels | The instance's `config` keys, verbatim (e.g. `user.dnsweaver.hostname`) |
+
+## Example: Docker Compose (local socket)
+
+```yaml
+services:
+  dnsweaver:
+    image: ghcr.io/maxfield-allison/dnsweaver:latest
+    environment:
+      DNSWEAVER_SOURCES: incus
+      DNSWEAVER_INCUS_SOCKET_PATH: /var/lib/incus/unix.socket
+      DNSWEAVER_INCUS_DOMAIN_SUFFIX: home.example.com
+    volumes:
+      # Mount the host's Incus socket read-only
+      - /var/lib/incus/unix.socket:/var/lib/incus/unix.socket:ro
+```
+
+## Example: Docker Compose (remote HTTPS)
+
+```yaml
+services:
+  dnsweaver:
+    image: ghcr.io/maxfield-allison/dnsweaver:latest
+    environment:
+      DNSWEAVER_SOURCES: incus
+      DNSWEAVER_INCUS_URL: https://incus-host.home.example.com:8443
+      DNSWEAVER_INCUS_TLS_CERT_FILE: /run/secrets/incus_client_cert
+      DNSWEAVER_INCUS_TLS_KEY_FILE: /run/secrets/incus_client_key
+      DNSWEAVER_INCUS_TLS_CA_FILE: /run/secrets/incus_server_ca
+      DNSWEAVER_INCUS_DOMAIN_SUFFIX: home.example.com
+    secrets:
+      - incus_client_cert
+      - incus_client_key
+      - incus_server_ca
+
+secrets:
+  incus_client_cert:
+    file: ./secrets/incus_client.crt
+  incus_client_key:
+    file: ./secrets/incus_client.key
+  incus_server_ca:
+    file: ./secrets/incus_server_ca.pem
+```
+
+## Example: Kubernetes Secret (remote HTTPS)
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dnsweaver-incus
+  namespace: dnsweaver
+type: Opaque
+stringData:
+  client.crt: |
+    -----BEGIN CERTIFICATE-----
+    ...
+  client.key: |
+    -----BEGIN PRIVATE KEY-----
+    ...
+  server-ca.pem: |
+    -----BEGIN CERTIFICATE-----
+    ...
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dnsweaver
+  namespace: dnsweaver
+spec:
+  template:
+    spec:
+      containers:
+        - name: dnsweaver
+          env:
+            - name: DNSWEAVER_SOURCES
+              value: incus
+            - name: DNSWEAVER_INCUS_URL
+              value: https://incus-host.home.example.com:8443
+            - name: DNSWEAVER_INCUS_TLS_CERT_FILE
+              value: /etc/dnsweaver/incus/client.crt
+            - name: DNSWEAVER_INCUS_TLS_KEY_FILE
+              value: /etc/dnsweaver/incus/client.key
+            - name: DNSWEAVER_INCUS_TLS_CA_FILE
+              value: /etc/dnsweaver/incus/server-ca.pem
+            - name: DNSWEAVER_INCUS_DOMAIN_SUFFIX
+              value: home.example.com
+          volumeMounts:
+            - name: incus-tls
+              mountPath: /etc/dnsweaver/incus
+              readOnly: true
+      volumes:
+        - name: incus-tls
+          secret:
+            secretName: dnsweaver-incus
+```

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -1,12 +1,12 @@
 ---
 title: Sources
-description: How dnsweaver discovers hostnames from Docker containers, Kubernetes resources, and Proxmox VE workloads
+description: How dnsweaver discovers hostnames from Docker containers, Kubernetes resources, Proxmox VE, and Incus workloads
 icon: material/source-branch
 ---
 
 # Sources
 
-dnsweaver discovers hostnames to manage from multiple **sources**. Each source type extracts hostnames differently, allowing dnsweaver to work with existing reverse proxy configurations on Docker and Kubernetes, and with VMs and LXC containers on Proxmox VE.
+dnsweaver discovers hostnames to manage from multiple **sources**. Each source type extracts hostnames differently, allowing dnsweaver to work with existing reverse proxy configurations on Docker and Kubernetes, and with VMs and containers on Proxmox VE and Incus.
 
 ## Available Sources
 
@@ -76,6 +76,14 @@ dnsweaver discovers hostnames to manage from multiple **sources**. Each source t
 
     [:octicons-arrow-right-24: Proxmox](proxmox.md)
 
+-   :material-cube-outline:{ .lg .middle } **Incus**
+
+    ---
+
+    Discover Incus system containers and VMs over a local socket or remote HTTPS and create A records from instance names.
+
+    [:octicons-arrow-right-24: Incus](incus.md)
+
 </div>
 
 ## Source Priority
@@ -89,6 +97,7 @@ When multiple sources provide the same hostname, dnsweaver uses the following pr
 5. **Traefik files** (dynamic configuration)
 6. **Kubernetes** (resource spec hostnames)
 7. **Proxmox VE** (VM/LXC name + domain suffix)
+8. **Incus** (instance name + domain suffix)
 
 ## Hostname Extraction
 
@@ -104,6 +113,7 @@ Each source extracts hostnames differently:
 | Native | `dnsweaver.hostname` | `dnsweaver.hostname=app.example.com` |
 | Kubernetes | Resource spec fields | `.spec.rules[].host` (Ingress) |
 | Proxmox VE | VM/LXC name + domain suffix | `webserver` + `home.example.com` |
+| Incus | Instance name + domain suffix | `webserver` + `home.example.com` |
 
 !!! info "Multiple hostnames"
     Containers and Kubernetes resources can expose multiple hostnames. All discovered hostnames are processed independently and matched against configured provider domains.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -381,6 +381,73 @@ func (c *Config) ProxmoxTLS() *httputil.TLSConfig {
 	return &tls
 }
 
+// UseIncus returns true if Incus is configured (either a remote URL or a local
+// Unix socket path is set).
+func (c *Config) UseIncus() bool {
+	return c.Global.IncusURL != "" || c.Global.IncusSocketPath != ""
+}
+
+// IncusURL returns the remote Incus API base URL (empty for socket mode).
+func (c *Config) IncusURL() string {
+	return c.Global.IncusURL
+}
+
+// IncusSocketPath returns the local Incus Unix socket path (empty for remote mode).
+func (c *Config) IncusSocketPath() string {
+	return c.Global.IncusSocketPath
+}
+
+// IncusProject returns the Incus project to query. Empty string means use the
+// Incus default project.
+func (c *Config) IncusProject() string {
+	return c.Global.IncusProject
+}
+
+// IncusStateFilter returns the instance state filter (default: "running").
+func (c *Config) IncusStateFilter() string {
+	return c.Global.IncusStateFilter
+}
+
+// IncusDomainSuffix returns the domain suffix appended to instance names.
+func (c *Config) IncusDomainSuffix() string {
+	return c.Global.IncusDomainSuffix
+}
+
+// IncusTargetMode returns the configured target resolution mode
+// ("guest-ip" or "instance"). Empty string means use the default.
+func (c *Config) IncusTargetMode() string {
+	return c.Global.IncusTargetMode
+}
+
+// IncusTLS returns the unified TLS configuration for the remote Incus API
+// client. Returns nil when no DNSWEAVER_INCUS_TLS_* env vars are set — in that
+// case the client uses stdlib defaults (system roots, verification on, TLS 1.2
+// floor). Socket mode does not use TLS.
+func (c *Config) IncusTLS() *httputil.TLSConfig {
+	g := c.Global
+	tls := httputil.TLSConfig{
+		CAFile:       g.IncusTLSCAFile,
+		CertFile:     g.IncusTLSCertFile,
+		KeyFile:      g.IncusTLSKeyFile,
+		ServerName:   g.IncusTLSServerName,
+		InsecureSkip: g.IncusTLSSkipVerify,
+	}
+	if g.IncusTLSMinVersion != "" {
+		if parsed, err := httputil.ParseTLSMinVersion(g.IncusTLSMinVersion); err == nil {
+			tls.MinVersion = parsed
+		} else {
+			slog.Warn("ignoring invalid DNSWEAVER_INCUS_TLS_MIN_VERSION, using default",
+				slog.String("value", g.IncusTLSMinVersion),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+	if tls.IsZero() {
+		return nil
+	}
+	return &tls
+}
+
 // GetProviderInstance returns the configuration for a specific provider instance.
 func (c *Config) GetProviderInstance(name string) (*ProviderInstanceConfig, bool) {
 	for _, inst := range c.ProviderInstances {

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -102,6 +102,24 @@ type GlobalConfig struct {
 	ProxmoxTLSSkipVerify bool
 	ProxmoxTLSMinVersion string
 
+	// Incus settings
+	IncusURL          string // Remote Incus API base URL (e.g., https://incus.example.com:8443)
+	IncusSocketPath   string // Local Incus Unix socket path (e.g., /var/lib/incus/unix.socket)
+	IncusProject      string // Incus project to query (default: "default")
+	IncusStateFilter  string // Filter by instance status (default: "running")
+	IncusDomainSuffix string // Domain suffix to append to instance names (e.g., "home.example.com")
+	IncusTargetMode   string // Target resolution mode: "guest-ip" (default) or "instance"
+
+	// Unified Incus TLS configuration for remote HTTPS endpoints. Populated from
+	// DNSWEAVER_INCUS_TLS_* env vars and consumed by internal/incus via httputil.TLSConfig.
+	// Incus remote authentication uses a TLS client certificate/key pair.
+	IncusTLSCAFile     string
+	IncusTLSCertFile   string
+	IncusTLSKeyFile    string
+	IncusTLSServerName string
+	IncusTLSSkipVerify bool
+	IncusTLSMinVersion string
+
 	// Multi-instance coordination
 	InstanceID string // Unique identifier for this dnsweaver instance (for shared zone management)
 }
@@ -399,6 +417,46 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 		slog.Warn("DNSWEAVER_PROXMOX_VERIFY_TLS is deprecated; use DNSWEAVER_PROXMOX_TLS_SKIP_VERIFY instead (legacy alias will be removed in v2.0)")
 		// Invert polarity: VERIFY_TLS=true → TLS_SKIP_VERIFY=false
 		cfg.ProxmoxTLSSkipVerify = !cfg.ProxmoxVerifyTLS
+	}
+
+	// Incus settings
+	cfg.IncusURL = getEnv("DNSWEAVER_INCUS_URL")
+	cfg.IncusSocketPath = getEnv("DNSWEAVER_INCUS_SOCKET_PATH")
+	cfg.IncusProject = getEnv("DNSWEAVER_INCUS_PROJECT")
+	cfg.IncusStateFilter = getEnv("DNSWEAVER_INCUS_STATE_FILTER")
+	cfg.IncusDomainSuffix = getEnv("DNSWEAVER_INCUS_DOMAIN_SUFFIX")
+	cfg.IncusTargetMode = getEnv("DNSWEAVER_INCUS_TARGET_MODE")
+	if cfg.IncusTargetMode != "" {
+		switch strings.ToLower(strings.TrimSpace(cfg.IncusTargetMode)) {
+		case "guest-ip", "instance":
+			// valid
+		default:
+			errs = append(errs, configErrFull(
+				"DNSWEAVER_INCUS_TARGET_MODE",
+				fmt.Sprintf("invalid value %q", cfg.IncusTargetMode),
+				"Must be one of: guest-ip (default, A record per guest IP), instance (defer to instance TARGET/RECORD_TYPE)",
+				"DNSWEAVER_INCUS_TARGET_MODE=instance",
+			))
+		}
+	}
+	if cfg.IncusURL != "" && cfg.IncusSocketPath != "" {
+		errs = append(errs, configErrFull(
+			"DNSWEAVER_INCUS_URL",
+			"both DNSWEAVER_INCUS_URL and DNSWEAVER_INCUS_SOCKET_PATH are set",
+			"Set exactly one: URL for a remote HTTPS endpoint, or SOCKET_PATH for the local Unix socket.",
+			"DNSWEAVER_INCUS_SOCKET_PATH=/var/lib/incus/unix.socket",
+		))
+	}
+
+	// Unified Incus TLS env vars for remote HTTPS endpoints. Remote Incus
+	// authentication uses a TLS client certificate/key pair (CERT_FILE/KEY_FILE).
+	cfg.IncusTLSCAFile = getEnv("DNSWEAVER_INCUS_TLS_CA_FILE")
+	cfg.IncusTLSCertFile = getEnv("DNSWEAVER_INCUS_TLS_CERT_FILE")
+	cfg.IncusTLSKeyFile = getEnv("DNSWEAVER_INCUS_TLS_KEY_FILE")
+	cfg.IncusTLSServerName = getEnv("DNSWEAVER_INCUS_TLS_SERVER_NAME")
+	cfg.IncusTLSMinVersion = getEnv("DNSWEAVER_INCUS_TLS_MIN_VERSION")
+	if v := getEnv("DNSWEAVER_INCUS_TLS_SKIP_VERIFY"); v != "" {
+		cfg.IncusTLSSkipVerify = parseBool(v, false)
 	}
 
 	return cfg, errs

--- a/internal/incus/adapter.go
+++ b/internal/incus/adapter.go
@@ -1,0 +1,133 @@
+package incus
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+)
+
+const (
+	instanceTypeContainer = "container"
+	instanceTypeVM        = "virtual-machine"
+)
+
+// AdapterConfig holds filtering options for the WorkloadListerAdapter.
+type AdapterConfig struct {
+	// StateFilter restricts listing to instances in the given state. Typical
+	// values: "running", "stopped". Matching is case-insensitive. Defaults to
+	// "running" if empty.
+	StateFilter string
+}
+
+// WorkloadListerAdapter wraps an Incus Client to implement the workload.Lister
+// interface. It lists instances (containers and VMs), applies configured
+// filters, resolves IP addresses from the instance state, and converts each
+// instance to a platform-agnostic workload.Workload.
+type WorkloadListerAdapter struct {
+	client *Client
+	cfg    AdapterConfig
+	logger *slog.Logger
+}
+
+// NewWorkloadListerAdapter creates a new adapter that wraps an Incus Client.
+func NewWorkloadListerAdapter(c *Client, cfg AdapterConfig, logger *slog.Logger) *WorkloadListerAdapter {
+	stateFilter := cfg.StateFilter
+	if stateFilter == "" {
+		stateFilter = "running"
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &WorkloadListerAdapter{
+		client: c,
+		cfg:    AdapterConfig{StateFilter: stateFilter},
+		logger: logger,
+	}
+}
+
+// ListWorkloads returns Incus instances as platform-agnostic workloads. Applies
+// the state filter and resolves each instance's IP address from its runtime
+// network state.
+func (a *WorkloadListerAdapter) ListWorkloads(ctx context.Context) ([]workload.Workload, error) {
+	instances, err := a.client.ListInstances(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing incus instances: %w", err)
+	}
+
+	var result []workload.Workload
+
+	for _, inst := range instances {
+		if !a.matchesFilters(inst) {
+			continue
+		}
+
+		ip := ResolveIP(inst)
+		if ip == "" {
+			a.logger.Debug("no routable IPv4 resolved for incus instance",
+				slog.String("name", inst.Name),
+				slog.String("project", inst.Project),
+				slog.String("type", inst.Type),
+			)
+		}
+
+		result = append(result, toWorkload(inst, ip))
+	}
+
+	return result, nil
+}
+
+// Platform returns PlatformIncus, identifying this adapter as an Incus source.
+func (a *WorkloadListerAdapter) Platform() workload.Platform {
+	return workload.PlatformIncus
+}
+
+// matchesFilters returns true if the given instance passes all configured filters.
+func (a *WorkloadListerAdapter) matchesFilters(inst Instance) bool {
+	if a.cfg.StateFilter != "" && !strings.EqualFold(inst.Status, a.cfg.StateFilter) {
+		return false
+	}
+	return true
+}
+
+// toWorkload converts an Instance and its resolved IP into a platform-agnostic
+// Workload. Instance config keys (including user.* keys) are exposed as labels
+// so sources can act on them.
+func toWorkload(inst Instance, ip string) workload.Workload {
+	kind := workload.KindIncusVM
+	if inst.Type == instanceTypeContainer {
+		kind = workload.KindIncusContainer
+	}
+
+	project := inst.Project
+	if project == "" {
+		project = "default"
+	}
+
+	meta := map[string]string{
+		"project": project,
+		"type":    inst.Type,
+		"status":  inst.Status,
+	}
+	if ip != "" {
+		meta["ip"] = ip
+	}
+
+	// Expose instance config keys directly as labels so sources can read
+	// operator-supplied keys such as "user.dnsweaver.hostname".
+	labels := make(map[string]string, len(inst.Config))
+	for k, v := range inst.Config {
+		labels[k] = v
+	}
+
+	return workload.Workload{
+		ID:       fmt.Sprintf("%s/%s", project, inst.Name),
+		Name:     inst.Name,
+		Labels:   labels,
+		Platform: workload.PlatformIncus,
+		Kind:     kind,
+		Metadata: meta,
+	}
+}

--- a/internal/incus/adapter_test.go
+++ b/internal/incus/adapter_test.go
@@ -1,0 +1,134 @@
+package incus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+)
+
+func newAdapterTestServer(t *testing.T, instances []map[string]any) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(instancesEnvelope(t, instances))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(ClientConfig{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}
+
+func TestAdapterListWorkloads(t *testing.T) {
+	client := newAdapterTestServer(t, []map[string]any{
+		{
+			"name":    "web",
+			"type":    "container",
+			"status":  "Running",
+			"project": "default",
+			"config":  map[string]string{"user.dnsweaver.hostname": "web.lan"},
+			"state": map[string]any{
+				"network": map[string]any{
+					"eth0": map[string]any{
+						"addresses": []map[string]any{
+							{"family": "inet", "address": "10.0.0.5", "scope": "global"},
+						},
+					},
+				},
+			},
+		},
+		{
+			"name":    "vmguest",
+			"type":    "virtual-machine",
+			"status":  "Running",
+			"project": "default",
+			"state": map[string]any{
+				"network": map[string]any{
+					"enp5s0": map[string]any{
+						"addresses": []map[string]any{
+							{"family": "inet", "address": "10.0.0.6", "scope": "global"},
+						},
+					},
+				},
+			},
+		},
+		{
+			"name":    "stopped-box",
+			"type":    "container",
+			"status":  "Stopped",
+			"project": "default",
+		},
+	})
+
+	adapter := NewWorkloadListerAdapter(client, AdapterConfig{}, nil)
+	if adapter.Platform() != workload.PlatformIncus {
+		t.Errorf("Platform = %q, want incus", adapter.Platform())
+	}
+
+	workloads, err := adapter.ListWorkloads(context.Background())
+	if err != nil {
+		t.Fatalf("ListWorkloads: %v", err)
+	}
+
+	// Stopped instance filtered out by default "running" state filter.
+	if len(workloads) != 2 {
+		t.Fatalf("expected 2 workloads, got %d: %+v", len(workloads), workloads)
+	}
+
+	byName := make(map[string]workload.Workload, len(workloads))
+	for _, w := range workloads {
+		byName[w.Name] = w
+	}
+
+	web, ok := byName["web"]
+	if !ok {
+		t.Fatal("web workload missing")
+	}
+	if web.Kind != workload.KindIncusContainer {
+		t.Errorf("web Kind = %q, want incus-container", web.Kind)
+	}
+	if web.Platform != workload.PlatformIncus {
+		t.Errorf("web Platform = %q, want incus", web.Platform)
+	}
+	if web.ID != "default/web" {
+		t.Errorf("web ID = %q, want default/web", web.ID)
+	}
+	if web.Metadata["ip"] != "10.0.0.5" {
+		t.Errorf("web ip = %q, want 10.0.0.5", web.Metadata["ip"])
+	}
+	if web.Metadata["type"] != "container" {
+		t.Errorf("web type = %q, want container", web.Metadata["type"])
+	}
+	if web.Labels["user.dnsweaver.hostname"] != "web.lan" {
+		t.Errorf("web label missing: %v", web.Labels)
+	}
+
+	vm, ok := byName["vmguest"]
+	if !ok {
+		t.Fatal("vmguest workload missing")
+	}
+	if vm.Kind != workload.KindIncusVM {
+		t.Errorf("vmguest Kind = %q, want incus-vm", vm.Kind)
+	}
+}
+
+func TestAdapterStateFilter(t *testing.T) {
+	client := newAdapterTestServer(t, []map[string]any{
+		{"name": "a", "type": "container", "status": "Running", "project": "default"},
+		{"name": "b", "type": "container", "status": "Stopped", "project": "default"},
+	})
+
+	adapter := NewWorkloadListerAdapter(client, AdapterConfig{StateFilter: "stopped"}, nil)
+	workloads, err := adapter.ListWorkloads(context.Background())
+	if err != nil {
+		t.Fatalf("ListWorkloads: %v", err)
+	}
+	if len(workloads) != 1 || workloads[0].Name != "b" {
+		t.Fatalf("expected only stopped instance b, got %+v", workloads)
+	}
+}

--- a/internal/incus/client.go
+++ b/internal/incus/client.go
@@ -1,0 +1,280 @@
+// Package incus provides a client for interacting with the Incus REST API.
+//
+// Incus (https://linuxcontainers.org/incus/) is the LinuxContainers fork of LXD
+// and manages system containers and virtual machines over a RESTful API. The
+// API is exposed two ways:
+//
+//   - A local Unix socket (e.g. /var/lib/incus/unix.socket) for unauthenticated
+//     local access. This is the simplest mode when dnsweaver runs on the Incus
+//     host itself.
+//   - A remote HTTPS endpoint (default port 8443) authenticated with a TLS
+//     client certificate/key pair. Use this when dnsweaver runs off-host.
+//
+// The client only performs read-only GETs against the instances collection, so
+// it deliberately avoids the official Incus Go SDK (and its large transitive
+// dependency tree) in favor of the standard library plus the shared httputil
+// TLS helpers.
+//
+// Example usage:
+//
+//	client, err := incus.NewClient(incus.ClientConfig{
+//	    SocketPath: "/var/lib/incus/unix.socket",
+//	    Project:    "default",
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	instances, err := client.ListInstances(ctx)
+package incus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
+)
+
+// socketBaseURL is the placeholder base URL used in Unix-socket mode. The host
+// is irrelevant because the custom dialer ignores it and always connects to the
+// configured socket path; only the request path matters.
+const socketBaseURL = "http://incus"
+
+// ClientConfig holds configuration for the Incus API client.
+type ClientConfig struct {
+	// BaseURL is the remote Incus API base URL (e.g. "https://incus.example.com:8443").
+	// Must not have a trailing slash. Mutually exclusive with SocketPath.
+	BaseURL string
+
+	// SocketPath is the local Incus Unix socket path
+	// (e.g. "/var/lib/incus/unix.socket"). Mutually exclusive with BaseURL.
+	SocketPath string
+
+	// Project is the Incus project to query. Empty string uses the Incus
+	// default project ("default").
+	Project string
+
+	// TLS is the unified TLS configuration for remote HTTPS endpoints. Incus
+	// remote authentication uses a client certificate/key pair (CertFile and
+	// KeyFile). Ignored in socket mode.
+	TLS *httputil.TLSConfig
+
+	// HTTPTimeout is the HTTP client timeout. Defaults to 15 seconds if zero.
+	HTTPTimeout time.Duration
+
+	// Logger is the slog logger. Defaults to slog.Default() if nil.
+	Logger *slog.Logger
+}
+
+// Client is an Incus REST API client.
+type Client struct {
+	baseURL string
+	project string
+	http    *http.Client
+	logger  *slog.Logger
+}
+
+// NewClient creates a new Incus API client from the given config. Exactly one
+// of BaseURL or SocketPath must be set. Returns an error otherwise.
+func NewClient(cfg ClientConfig) (*Client, error) {
+	switch {
+	case cfg.BaseURL == "" && cfg.SocketPath == "":
+		return nil, fmt.Errorf("incus: either BaseURL or SocketPath is required")
+	case cfg.BaseURL != "" && cfg.SocketPath != "":
+		return nil, fmt.Errorf("incus: set exactly one of BaseURL or SocketPath, not both")
+	}
+
+	timeout := cfg.HTTPTimeout
+	if timeout == 0 {
+		timeout = 15 * time.Second
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	var (
+		httpClient *http.Client
+		baseURL    string
+	)
+
+	if cfg.SocketPath != "" {
+		socket := cfg.SocketPath
+		transport := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socket)
+			},
+		}
+		httpClient = &http.Client{Timeout: timeout, Transport: transport}
+		baseURL = socketBaseURL
+	} else {
+		httpClient = httputil.NewClient(&httputil.ClientConfig{
+			Timeout:   timeout,
+			TLS:       cfg.TLS,
+			UserAgent: httputil.DefaultUserAgent,
+			Logger:    logger,
+		})
+		baseURL = strings.TrimRight(cfg.BaseURL, "/")
+	}
+
+	return &Client{
+		baseURL: baseURL,
+		project: cfg.Project,
+		http:    httpClient,
+		logger:  logger,
+	}, nil
+}
+
+// apiResponse is the standard Incus REST API response envelope. Synchronous
+// reads return their payload in Metadata; errors set Type to "error" and
+// populate Error.
+type apiResponse struct {
+	Type       string          `json:"type"`
+	StatusCode int             `json:"status_code"`
+	Error      string          `json:"error"`
+	Metadata   json.RawMessage `json:"metadata"`
+}
+
+// Instance represents a single Incus instance (system container or VM) as
+// returned by GET /1.0/instances with recursion. Only fields relevant to DNS
+// hostname extraction are modeled.
+type Instance struct {
+	// Name is the instance name (e.g. "web-server").
+	Name string `json:"name"`
+
+	// Type is "container" for system containers or "virtual-machine" for VMs.
+	Type string `json:"type"`
+
+	// Status is the human-readable status (e.g. "Running", "Stopped").
+	Status string `json:"status"`
+
+	// StatusCode is the numeric status code (103 == Running).
+	StatusCode int `json:"status_code"`
+
+	// Project is the Incus project the instance belongs to.
+	Project string `json:"project"`
+
+	// Config holds the instance configuration keys (including user.* keys).
+	Config map[string]string `json:"config"`
+
+	// State holds runtime state, including resolved network addresses. Present
+	// only when the instance list is requested with recursion>=2.
+	State *InstanceState `json:"state"`
+}
+
+// InstanceState holds the runtime state of an instance.
+type InstanceState struct {
+	// Network maps interface names (e.g. "eth0", "lo") to their network state.
+	Network map[string]InstanceNetwork `json:"network"`
+}
+
+// InstanceNetwork holds the network state of a single interface.
+type InstanceNetwork struct {
+	// Addresses are the IP addresses assigned to this interface.
+	Addresses []InstanceAddress `json:"addresses"`
+}
+
+// InstanceAddress represents a single IP address on an interface.
+type InstanceAddress struct {
+	// Family is "inet" (IPv4) or "inet6" (IPv6).
+	Family string `json:"family"`
+
+	// Address is the IP address string (without prefix length).
+	Address string `json:"address"`
+
+	// Netmask is the network prefix length as a string (e.g. "24").
+	Netmask string `json:"netmask"`
+
+	// Scope is "global", "link", or "local".
+	Scope string `json:"scope"`
+}
+
+// ListInstances returns all instances (containers and VMs) in the configured
+// project, including their runtime network state. The state is required for
+// IP resolution, so recursion=2 is always requested.
+func (c *Client) ListInstances(ctx context.Context) ([]Instance, error) {
+	q := url.Values{}
+	q.Set("recursion", "2")
+	if c.project != "" {
+		q.Set("project", c.project)
+	}
+
+	var instances []Instance
+	if err := c.get(ctx, "/1.0/instances?"+q.Encode(), &instances); err != nil {
+		return nil, fmt.Errorf("listing instances: %w", err)
+	}
+
+	return instances, nil
+}
+
+// get performs a GET request to the given API path, unwraps the Incus response
+// envelope, and decodes the metadata payload into dst. The path must start
+// with "/".
+func (c *Client) get(ctx context.Context, path string, dst any) error {
+	reqURL := c.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", httputil.DefaultUserAgent)
+
+	c.logger.Debug("incus api request", slog.String("path", path))
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("performing request to %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response body from %s: %w", path, err)
+	}
+
+	var env apiResponse
+	// Always attempt to decode the envelope; Incus returns it for both success
+	// and error responses, and it carries a more useful message than the raw
+	// status line.
+	decodeErr := json.Unmarshal(body, &env)
+
+	if resp.StatusCode != http.StatusOK {
+		if decodeErr == nil && env.Error != "" {
+			return fmt.Errorf("incus api error: status %d for %s: %s", resp.StatusCode, path, env.Error)
+		}
+		return fmt.Errorf("incus api error: status %d for %s: %s", resp.StatusCode, path, truncate(string(body), 200))
+	}
+
+	if decodeErr != nil {
+		return fmt.Errorf("decoding response envelope from %s: %w", path, decodeErr)
+	}
+	if env.Type == "error" {
+		return fmt.Errorf("incus api error for %s: %s", path, env.Error)
+	}
+
+	if err := json.Unmarshal(env.Metadata, dst); err != nil {
+		return fmt.Errorf("decoding metadata from %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// truncate returns s truncated to at most n bytes, appending an ellipsis when
+// truncation occurs.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/incus/client_test.go
+++ b/internal/incus/client_test.go
@@ -1,0 +1,169 @@
+package incus
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+// instancesEnvelope wraps the given metadata in the standard Incus sync response.
+func instancesEnvelope(t *testing.T, instances []map[string]any) []byte {
+	t.Helper()
+	meta, err := json.Marshal(instances)
+	if err != nil {
+		t.Fatalf("marshaling metadata: %v", err)
+	}
+	env := map[string]any{
+		"type":        "sync",
+		"status":      "Success",
+		"status_code": 200,
+		"metadata":    json.RawMessage(meta),
+	}
+	body, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshaling envelope: %v", err)
+	}
+	return body
+}
+
+func TestNewClientValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ClientConfig
+		wantErr bool
+	}{
+		{name: "neither set", cfg: ClientConfig{}, wantErr: true},
+		{name: "both set", cfg: ClientConfig{BaseURL: "https://x:8443", SocketPath: "/run/incus.sock"}, wantErr: true},
+		{name: "url only", cfg: ClientConfig{BaseURL: "https://x:8443"}, wantErr: false},
+		{name: "socket only", cfg: ClientConfig{SocketPath: "/run/incus.sock"}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewClient(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewClient err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestListInstancesHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1.0/instances" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("recursion") != "2" {
+			t.Errorf("expected recursion=2, got %q", r.URL.RawQuery)
+		}
+		if r.URL.Query().Get("project") != "prod" {
+			t.Errorf("expected project=prod, got %q", r.URL.Query().Get("project"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(instancesEnvelope(t, []map[string]any{
+			{
+				"name":    "web",
+				"type":    "container",
+				"status":  "Running",
+				"project": "prod",
+				"config":  map[string]string{"user.dnsweaver.hostname": "web.example.com"},
+				"state": map[string]any{
+					"network": map[string]any{
+						"eth0": map[string]any{
+							"addresses": []map[string]any{
+								{"family": "inet", "address": "10.0.0.5", "scope": "global"},
+							},
+						},
+					},
+				},
+			},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(ClientConfig{BaseURL: srv.URL, Project: "prod"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	instances, err := client.ListInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ListInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(instances))
+	}
+	inst := instances[0]
+	if inst.Name != "web" {
+		t.Errorf("Name = %q, want web", inst.Name)
+	}
+	if inst.Type != "container" {
+		t.Errorf("Type = %q, want container", inst.Type)
+	}
+	if inst.Config["user.dnsweaver.hostname"] != "web.example.com" {
+		t.Errorf("config not parsed: %v", inst.Config)
+	}
+	if got := ResolveIP(inst); got != "10.0.0.5" {
+		t.Errorf("ResolveIP = %q, want 10.0.0.5", got)
+	}
+}
+
+func TestListInstancesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"type":"error","status_code":403,"error":"not authorized"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(ClientConfig{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if _, err := client.ListInstances(context.Background()); err == nil {
+		t.Fatal("expected error for 403 response, got nil")
+	}
+}
+
+func TestListInstancesSocket(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "incus.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := &http.Server{ //nolint:gosec // test server, no timeouts needed
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/1.0/instances" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(instancesEnvelope(t, []map[string]any{
+				{"name": "db", "type": "virtual-machine", "status": "Running"},
+			}))
+		}),
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	client, err := NewClient(ClientConfig{SocketPath: socketPath})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	instances, err := client.ListInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ListInstances over socket: %v", err)
+	}
+	if len(instances) != 1 || instances[0].Name != "db" {
+		t.Fatalf("unexpected instances: %+v", instances)
+	}
+	if instances[0].Type != "virtual-machine" {
+		t.Errorf("Type = %q, want virtual-machine", instances[0].Type)
+	}
+}

--- a/internal/incus/ip_resolver.go
+++ b/internal/incus/ip_resolver.go
@@ -1,0 +1,113 @@
+package incus
+
+import (
+	"net"
+	"sort"
+)
+
+// ResolveIP returns the primary global-scope IPv4 address for an instance,
+// read from its runtime network state.
+//
+// Interface names are iterated in sorted order so the result is deterministic
+// across reconciles even when an instance has multiple interfaces — a map's
+// non-deterministic iteration order would otherwise cause DNS records to flap.
+// Loopback interfaces, non-global scopes, and non-routable addresses are
+// skipped.
+//
+// Returns an empty string if no suitable address is found. The empty string
+// acts as a liveness gate: the source skips instances with no resolvable IP.
+func ResolveIP(inst Instance) string {
+	if inst.State == nil {
+		return ""
+	}
+
+	names := make([]string, 0, len(inst.State.Network))
+	for name := range inst.State.Network {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if isLoopback(name) {
+			continue
+		}
+		for _, addr := range inst.State.Network[name].Addresses {
+			if addr.Family != "inet" {
+				continue
+			}
+			// Incus reports scope as "global", "link", or "local". Treat an
+			// empty scope as acceptable for forward compatibility.
+			if addr.Scope != "" && addr.Scope != "global" {
+				continue
+			}
+			if isNonRoutableIP(addr.Address) {
+				continue
+			}
+			return addr.Address
+		}
+	}
+
+	return ""
+}
+
+// isLoopback returns true for known loopback interface names.
+func isLoopback(name string) bool {
+	return name == "lo" || name == "lo0"
+}
+
+// nonRoutableRanges contains IPv4 CIDR blocks that are reserved or not suitable
+// for use as DNS record targets. These supplement the ranges already handled by
+// net.IP's built-in methods (IsLoopback, IsLinkLocalUnicast, IsUnspecified,
+// IsMulticast).
+var nonRoutableRanges = func() []*net.IPNet {
+	cidrs := []string{
+		// 100.64.0.0/10 (RFC 6598 CGNAT) is intentionally NOT filtered:
+		// Tailscale assigns addresses from this range, and DNS records pointing
+		// to an instance's Tailscale IP are a common, legitimate homelab use case.
+		"192.0.0.0/24",       // IETF Protocol Assignments (RFC 6890)
+		"192.0.2.0/24",       // TEST-NET-1 (RFC 5737)
+		"198.18.0.0/15",      // Network interconnect benchmarking (RFC 2544)
+		"198.51.100.0/24",    // TEST-NET-2 (RFC 5737)
+		"203.0.113.0/24",     // TEST-NET-3 (RFC 5737)
+		"240.0.0.0/4",        // Reserved for future use (RFC 1112)
+		"255.255.255.255/32", // Limited broadcast
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, n, _ := net.ParseCIDR(cidr)
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+// isNonRoutableIP reports whether ip should be skipped as a DNS record target.
+//
+// It rejects addresses that are non-routable or not suitable for external
+// resolution:
+//   - Loopback (127.0.0.0/8)
+//   - Link-local / APIPA (169.254.0.0/16)
+//   - Unspecified (0.0.0.0)
+//   - Multicast (224.0.0.0/4)
+//   - Reserved, documentation, and benchmarking ranges (see nonRoutableRanges)
+//   - Any address that cannot be parsed
+//
+// RFC 1918 private addresses (10/8, 172.16/12, 192.168/16) are intentionally
+// kept as valid targets — these are the addresses most homelab instances use.
+func isNonRoutableIP(ip string) bool {
+	if ip == "" {
+		return true
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return true
+	}
+	if parsed.IsLoopback() || parsed.IsLinkLocalUnicast() || parsed.IsUnspecified() || parsed.IsMulticast() {
+		return true
+	}
+	for _, n := range nonRoutableRanges {
+		if n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/incus/ip_resolver_test.go
+++ b/internal/incus/ip_resolver_test.go
@@ -1,0 +1,104 @@
+package incus
+
+import "testing"
+
+func TestResolveIP(t *testing.T) {
+	tests := []struct {
+		name string
+		inst Instance
+		want string
+	}{
+		{
+			name: "nil state",
+			inst: Instance{Name: "x"},
+			want: "",
+		},
+		{
+			name: "global ipv4 on eth0",
+			inst: Instance{State: &InstanceState{Network: map[string]InstanceNetwork{
+				"eth0": {Addresses: []InstanceAddress{
+					{Family: "inet", Address: "192.168.1.10", Scope: "global"},
+				}},
+			}}},
+			want: "192.168.1.10",
+		},
+		{
+			name: "skips loopback interface",
+			inst: Instance{State: &InstanceState{Network: map[string]InstanceNetwork{
+				"lo": {Addresses: []InstanceAddress{
+					{Family: "inet", Address: "127.0.0.1", Scope: "local"},
+				}},
+				"eth0": {Addresses: []InstanceAddress{
+					{Family: "inet", Address: "10.0.0.7", Scope: "global"},
+				}},
+			}}},
+			want: "10.0.0.7",
+		},
+		{
+			name: "skips link-local and ipv6, picks global ipv4",
+			inst: Instance{State: &InstanceState{Network: map[string]InstanceNetwork{
+				"eth0": {Addresses: []InstanceAddress{
+					{Family: "inet6", Address: "fe80::1", Scope: "link"},
+					{Family: "inet", Address: "169.254.1.1", Scope: "link"},
+					{Family: "inet", Address: "10.1.2.3", Scope: "global"},
+				}},
+			}}},
+			want: "10.1.2.3",
+		},
+		{
+			name: "deterministic across multiple interfaces (sorted)",
+			inst: Instance{State: &InstanceState{Network: map[string]InstanceNetwork{
+				"eth1": {Addresses: []InstanceAddress{
+					{Family: "inet", Address: "10.0.0.20", Scope: "global"},
+				}},
+				"eth0": {Addresses: []InstanceAddress{
+					{Family: "inet", Address: "10.0.0.10", Scope: "global"},
+				}},
+			}}},
+			want: "10.0.0.10",
+		},
+		{
+			name: "no routable address",
+			inst: Instance{State: &InstanceState{Network: map[string]InstanceNetwork{
+				"eth0": {Addresses: []InstanceAddress{
+					{Family: "inet", Address: "127.0.0.1", Scope: "global"},
+				}},
+			}}},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveIP(tt.inst); got != tt.want {
+				t.Errorf("ResolveIP = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNonRoutableIP(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		{"10.0.0.1", false},
+		{"192.168.1.1", false},
+		{"172.16.5.5", false},
+		{"100.64.0.1", false}, // CGNAT / Tailscale kept
+		{"127.0.0.1", true},
+		{"169.254.1.1", true},
+		{"0.0.0.0", true},
+		{"224.0.0.1", true},
+		{"203.0.113.5", true}, // TEST-NET-3
+		{"", true},
+		{"not-an-ip", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			if got := isNonRoutableIP(tt.ip); got != tt.want {
+				t.Errorf("isNonRoutableIP(%q) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
       - Native Labels: sources/native-labels.md
       - Kubernetes: sources/kubernetes.md
       - Proxmox VE: sources/proxmox.md
+      - Incus: sources/incus.md
   - Deployment:
       - deployment/index.md
       - Docker Compose: deployment/docker-compose.md

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -45,6 +45,8 @@ const (
 	PlatformKubernetes Platform = "kubernetes"
 	// PlatformProxmox represents workloads from Proxmox VE (VMs and LXC containers).
 	PlatformProxmox Platform = "proxmox"
+	// PlatformIncus represents workloads from Incus (system containers and VMs).
+	PlatformIncus Platform = "incus"
 	// PlatformStatic represents workloads from static file configuration.
 	PlatformStatic Platform = "static"
 )
@@ -57,6 +59,11 @@ func (p Platform) String() string {
 // IsProxmox returns true if the platform is Proxmox VE.
 func (p Platform) IsProxmox() bool {
 	return p == PlatformProxmox
+}
+
+// IsIncus returns true if the platform is Incus.
+func (p Platform) IsIncus() bool {
+	return p == PlatformIncus
 }
 
 // Kind identifies the specific resource type within a platform.
@@ -89,6 +96,13 @@ const (
 	KindVM Kind = "vm"
 	// KindLXC represents a Proxmox LXC container.
 	KindLXC Kind = "lxc"
+
+	// Incus kinds.
+
+	// KindIncusContainer represents an Incus system container.
+	KindIncusContainer Kind = "incus-container"
+	// KindIncusVM represents an Incus virtual machine.
+	KindIncusVM Kind = "incus-vm"
 )
 
 // String returns the string representation of the kind.

--- a/sources/incus/incus.go
+++ b/sources/incus/incus.go
@@ -1,0 +1,221 @@
+// Package incus provides a Source implementation for extracting hostnames from
+// Incus workloads (system containers and virtual machines).
+//
+// This source constructs DNS A records mapping each running Incus instance to
+// its resolved IP address. Three hostname strategies are supported, in order of
+// precedence:
+//
+//  1. Per-instance override: If the instance has a "user.dnsweaver.hostname"
+//     config key (surfaced as a workload label), its value is used verbatim as
+//     the hostname. This lets operators pin an arbitrary FQDN to an instance.
+//
+//  2. Domain suffix (recommended): Set a domain via WithDomain("home.example.com").
+//     Each instance is registered as "<instance-name>.<domain>"
+//     (e.g., webserver.home.example.com).
+//
+//  3. Bare FQDN: If the instance name already contains a dot, it is used
+//     directly as the hostname without appending a domain suffix.
+//
+// The resolved IP (populated in w.Metadata["ip"] by the adapter) is used as the
+// A record target by default. When WithTargetMode(TargetModeInstance) is set,
+// the source emits the hostname only and defers record type and target to the
+// matching provider instance — useful for pointing all instances at a reverse
+// proxy via CNAME. Instances with no resolved IP are skipped in both modes (the
+// IP acts as a liveness gate).
+//
+// Supported workload platforms: [PlatformIncus]
+package incus
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+)
+
+const sourceName = "incus"
+
+// hostnameLabel is the instance config key (surfaced as a workload label) that
+// overrides the derived hostname with an explicit value.
+const hostnameLabel = "user.dnsweaver.hostname"
+
+// TargetMode controls how the Incus source builds DNS record targets.
+type TargetMode string
+
+const (
+	// TargetModeGuestIP emits an A record per workload pointing at the
+	// instance's resolved IP. This is the default.
+	TargetModeGuestIP TargetMode = "guest-ip"
+
+	// TargetModeInstance defers record type and target to the matching
+	// provider instance. The source emits the hostname only (no RecordHints),
+	// so DNSWEAVER_{INSTANCE}_RECORD_TYPE and DNSWEAVER_{INSTANCE}_TARGET
+	// drive the resulting record. This enables pointing all Incus-discovered
+	// hostnames at a reverse proxy via CNAME or A records.
+	TargetModeInstance TargetMode = "instance"
+)
+
+// ParseTargetMode parses a string into a TargetMode value. Empty input maps to
+// the default (TargetModeGuestIP). Returns an error for unrecognized values.
+func ParseTargetMode(s string) (TargetMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", string(TargetModeGuestIP):
+		return TargetModeGuestIP, nil
+	case string(TargetModeInstance):
+		return TargetModeInstance, nil
+	default:
+		return "", fmt.Errorf("invalid incus target mode %q (must be one of: guest-ip, instance)", s)
+	}
+}
+
+// Incus implements the source.Source interface for Incus workloads.
+type Incus struct {
+	domain     string
+	targetMode TargetMode
+	logger     *slog.Logger
+}
+
+// Option is a functional option for configuring Incus.
+type Option func(*Incus)
+
+// WithLogger sets a custom logger.
+func WithLogger(logger *slog.Logger) Option {
+	return func(s *Incus) {
+		s.logger = logger
+	}
+}
+
+// WithDomain sets the DNS domain suffix used when constructing hostnames from
+// instance names. For example, WithDomain("home.example.com") causes an
+// instance named "webserver" to be registered as "webserver.home.example.com".
+//
+// If not set (or set to empty string), only instance names that already contain
+// a dot are used as hostnames. Plain instance names without a domain suffix are
+// skipped (unless overridden by the "user.dnsweaver.hostname" config key).
+func WithDomain(domain string) Option {
+	return func(s *Incus) {
+		s.domain = strings.TrimPrefix(strings.TrimSpace(domain), ".")
+	}
+}
+
+// WithTargetMode sets the target resolution strategy. See TargetMode for
+// supported values. Defaults to TargetModeGuestIP.
+func WithTargetMode(mode TargetMode) Option {
+	return func(s *Incus) {
+		s.targetMode = mode
+	}
+}
+
+// New creates a new Incus source.
+func New(opts ...Option) *Incus {
+	s := &Incus{
+		logger:     slog.Default(),
+		targetMode: TargetModeGuestIP,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.targetMode == "" {
+		s.targetMode = TargetModeGuestIP
+	}
+	return s
+}
+
+// Name returns the source identifier.
+func (s *Incus) Name() string {
+	return sourceName
+}
+
+// SupportedPlatforms returns the platforms this source handles.
+// The Incus source only processes workloads with PlatformIncus.
+func (s *Incus) SupportedPlatforms() []workload.Platform {
+	return []workload.Platform{workload.PlatformIncus}
+}
+
+// SupportsDiscovery returns false — the Incus source does not support static
+// file discovery. All hostnames come from live workload extraction.
+func (s *Incus) SupportsDiscovery() bool {
+	return false
+}
+
+// Discover is a no-op for the Incus source.
+func (s *Incus) Discover(_ context.Context) ([]source.Hostname, error) {
+	return nil, nil
+}
+
+// Extract builds DNS A records for an Incus workload.
+//
+// Extraction logic:
+//  1. Skip non-Incus workloads (wrong platform).
+//  2. Look up the resolved IP in w.Metadata["ip"]. Skip if empty.
+//  3. Determine the hostname:
+//     a. If the "user.dnsweaver.hostname" label is set, use it verbatim.
+//     b. If w.Name contains a dot, use it directly (already FQDN).
+//     c. If a domain suffix is configured, append: "<name>.<domain>".
+//     d. Otherwise, skip (no valid hostname can be determined).
+//  4. Return a single source.Hostname with an A record hint (guest-ip mode).
+func (s *Incus) Extract(_ context.Context, w workload.Workload) ([]source.Hostname, error) {
+	if !w.Platform.IsIncus() {
+		return nil, nil
+	}
+
+	ip := w.Metadata["ip"]
+	if ip == "" {
+		s.logger.Debug("incus workload has no resolved IP; skipping",
+			slog.String("workload", w.Name),
+			slog.String("project", w.Metadata["project"]),
+		)
+		return nil, nil
+	}
+
+	hostname, err := s.resolveHostname(w)
+	if err != nil {
+		s.logger.Debug("could not determine hostname for incus workload; skipping",
+			slog.String("workload", w.Name),
+			slog.String("reason", err.Error()),
+		)
+		return nil, nil //nolint:nilerr // not a configuration error; silently skip
+	}
+
+	h := source.Hostname{
+		Name:   hostname,
+		Source: sourceName,
+		Router: fmt.Sprintf("%s/%s", w.Metadata["project"], w.Name),
+	}
+
+	// In guest-ip mode (default) emit an A record hint targeting the instance's
+	// IP. In instance mode, leave RecordHints nil so the matching provider
+	// instance's RECORD_TYPE and TARGET drive the resulting record. The IP
+	// lookup above still acts as a liveness gate — workloads with no resolved
+	// IP are skipped in both modes.
+	if s.targetMode == TargetModeGuestIP {
+		h.RecordHints = &source.RecordHints{
+			Type:   "A",
+			Target: ip,
+		}
+	}
+
+	return []source.Hostname{h}, nil
+}
+
+// resolveHostname determines the FQDN for an Incus workload.
+//
+// Precedence: explicit "user.dnsweaver.hostname" label > FQDN instance name >
+// "<name>.<domain>". Returns an error (logged as debug, not surfaced to the
+// caller) when no hostname can be determined.
+func (s *Incus) resolveHostname(w workload.Workload) (string, error) {
+	if override := strings.TrimSpace(w.GetLabel(hostnameLabel)); override != "" {
+		return override, nil
+	}
+	if strings.Contains(w.Name, ".") {
+		// Instance name already looks like an FQDN — use it directly.
+		return w.Name, nil
+	}
+	if s.domain != "" {
+		return w.Name + "." + s.domain, nil
+	}
+	return "", fmt.Errorf("instance name %q is not an FQDN and no domain suffix is configured", w.Name)
+}

--- a/sources/incus/incus_test.go
+++ b/sources/incus/incus_test.go
@@ -1,0 +1,170 @@
+package incus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+)
+
+func incusWorkload(name, ip string, labels map[string]string) workload.Workload {
+	return workload.Workload{
+		Platform: workload.PlatformIncus,
+		Name:     name,
+		Labels:   labels,
+		Metadata: map[string]string{"ip": ip, "project": "default", "type": "container"},
+	}
+}
+
+func TestExtract_SkipsNonIncus(t *testing.T) {
+	src := New(WithDomain("home.example.com"))
+	w := workload.Workload{
+		Platform: workload.PlatformDocker,
+		Name:     "some-container",
+		Metadata: map[string]string{"ip": "10.0.0.5"},
+	}
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no hostnames for non-incus workload, got %d", len(got))
+	}
+}
+
+func TestExtract_SkipsNoIP(t *testing.T) {
+	src := New(WithDomain("home.example.com"))
+	w := workload.Workload{
+		Platform: workload.PlatformIncus,
+		Name:     "web",
+		Metadata: map[string]string{"project": "default"},
+	}
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no hostnames when IP missing, got %d", len(got))
+	}
+}
+
+func TestExtract_NoDomainPlainName_Skips(t *testing.T) {
+	src := New()
+	w := incusWorkload("web", "10.0.0.5", nil)
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no hostnames when no domain and name not FQDN, got %d", len(got))
+	}
+}
+
+func TestExtract_WithDomain(t *testing.T) {
+	src := New(WithDomain("home.example.com"))
+	w := incusWorkload("web", "10.0.0.5", nil)
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 hostname, got %d", len(got))
+	}
+	if got[0].Name != "web.home.example.com" {
+		t.Errorf("Name = %q, want web.home.example.com", got[0].Name)
+	}
+	if got[0].Source != "incus" {
+		t.Errorf("Source = %q, want incus", got[0].Source)
+	}
+	if got[0].Router != "default/web" {
+		t.Errorf("Router = %q, want default/web", got[0].Router)
+	}
+	if got[0].RecordHints == nil || got[0].RecordHints.Type != "A" || got[0].RecordHints.Target != "10.0.0.5" {
+		t.Errorf("RecordHints = %+v, want A/10.0.0.5", got[0].RecordHints)
+	}
+}
+
+func TestExtract_FQDNNameUsedDirectly(t *testing.T) {
+	src := New(WithDomain("home.example.com"))
+	w := incusWorkload("db.corp.example.com", "10.0.0.6", nil)
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "db.corp.example.com" {
+		t.Fatalf("expected FQDN name used directly, got %+v", got)
+	}
+}
+
+func TestExtract_HostnameLabelOverride(t *testing.T) {
+	src := New(WithDomain("home.example.com"))
+	w := incusWorkload("web", "10.0.0.5", map[string]string{
+		hostnameLabel: "custom.example.net",
+	})
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "custom.example.net" {
+		t.Fatalf("expected override hostname, got %+v", got)
+	}
+}
+
+func TestExtract_InstanceTargetMode_NoRecordHints(t *testing.T) {
+	src := New(WithDomain("home.example.com"), WithTargetMode(TargetModeInstance))
+	w := incusWorkload("web", "10.0.0.5", nil)
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 hostname, got %d", len(got))
+	}
+	if got[0].RecordHints != nil {
+		t.Errorf("expected nil RecordHints in instance mode, got %+v", got[0].RecordHints)
+	}
+}
+
+func TestParseTargetMode(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    TargetMode
+		wantErr bool
+	}{
+		{"", TargetModeGuestIP, false},
+		{"guest-ip", TargetModeGuestIP, false},
+		{"instance", TargetModeInstance, false},
+		{"INSTANCE", TargetModeInstance, false},
+		{"bogus", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := ParseTargetMode(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSourceMetadata(t *testing.T) {
+	src := New()
+	if src.Name() != "incus" {
+		t.Errorf("Name = %q, want incus", src.Name())
+	}
+	if src.SupportsDiscovery() {
+		t.Error("SupportsDiscovery should be false")
+	}
+	platforms := src.SupportedPlatforms()
+	if len(platforms) != 1 || platforms[0] != workload.PlatformIncus {
+		t.Errorf("SupportedPlatforms = %v, want [incus]", platforms)
+	}
+	if got, _ := src.Discover(context.Background()); got != nil {
+		t.Errorf("Discover should return nil, got %v", got)
+	}
+	var _ source.Source = src
+}


### PR DESCRIPTION
## Summary

Adds a new **Incus** platform source that discovers running Incus system containers and virtual machines and creates DNS `A` records mapping each instance to its resolved IP address. Connects either to a local Unix socket or a remote HTTPS endpoint secured with a client certificate.

Closes #95.

## What's included

**Phase 1 — internal plumbing** (`0cdca25`)
- `internal/incus`: REST client (`/1.0/instances?recursion=2`), workload adapter/lister, IP resolver (first global IPv4, CGNAT kept for Tailscale), and config plumbing for `DNSWEAVER_INCUS_*` env vars.
- `pkg/workload`: `PlatformIncus`, `IsIncus()`, `KindIncusContainer`/`KindIncusVM`.

**Phase 2 — source + command wiring** (`e24abfe`)
- `sources/incus`: `Source` implementation. Hostname precedence: `user.dnsweaver.hostname` config-key override → FQDN instance name → `<name>.<domain>`. `guest-ip` (default) and `instance` target modes.
- `cmd/dnsweaver`: initialize the Incus lister when `DNSWEAVER_INCUS_URL`/`_SOCKET_PATH` is set; auto-register the source.

**Phase 3 — documentation** (`e4718bd`)
- New `docs/sources/incus.md`, mkdocs nav entry, sources index card/priority/extraction row, landing-page feature card + How It Works + comparison row, README references, and a CHANGELOG `[Unreleased]` entry.

## Configuration

| Variable | Description |
| :--- | :--- |
| `DNSWEAVER_INCUS_URL` / `DNSWEAVER_INCUS_SOCKET_PATH` | Remote HTTPS endpoint or local Unix socket (mutually exclusive) |
| `DNSWEAVER_INCUS_PROJECT` | Restrict to a single project |
| `DNSWEAVER_INCUS_STATE_FILTER` | Instance status filter (default `running`) |
| `DNSWEAVER_INCUS_DOMAIN_SUFFIX` | Domain appended to instance names |
| `DNSWEAVER_INCUS_TARGET_MODE` | `guest-ip` (default) or `instance` |
| `DNSWEAVER_INCUS_TLS_*` | Unified TLS surface for remote HTTPS |

## Testing

- `gofmt`, `go vet`, `golangci-lint`, `go test ./...`, and `go build ./...` all green.
- New table-driven tests in `internal/incus` (including a real Unix socket listener) and `sources/incus`.
- `mkdocs build` clean.

## Design notes (approved)

- Supports both local Unix socket and remote HTTPS client-cert from day one.
- Standard-library `net/http`, no Incus SDK dependency.
- A record from the resolved guest IP by default; `instance` mode defers record type/target to the matching provider (CNAME-to-reverse-proxy setups).
- Targets `v2.2.0` (SemVer MINOR).