### PR TITLE
ci(sync): compare peeled commits for tag idempotency

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -55,18 +55,28 @@ jobs:
 
           if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
             tag="${GITHUB_REF_NAME}"
-            local_sha="$(git rev-parse "${GITHUB_REF}")"
-            remote_sha="$(git ls-remote gitlab "refs/tags/${tag}" | cut -f1)"
-            if [ -z "${remote_sha}" ]; then
+            # Peel both sides to the commit they reference. The runner's local
+            # tag ref (written by actions/checkout) is typically lightweight and
+            # resolves straight to the commit, whereas an annotated tag on GitLab
+            # has a distinct tag-object SHA. Comparing raw SHAs would therefore
+            # always mismatch for annotated tags; comparing peeled commits is the
+            # correct immutability check.
+            local_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
+            remote_object="$(git ls-remote gitlab "refs/tags/${tag}" | cut -f1)"
+            remote_commit="$(git ls-remote gitlab "refs/tags/${tag}^{}" | cut -f1)"
+            # Lightweight remote tags have no peeled (^{}) entry; fall back to the
+            # object SHA, which is the commit itself in that case.
+            remote_commit="${remote_commit:-$remote_object}"
+            if [ -z "${remote_object}" ]; then
               echo "Syncing tag ${tag} -> GitLab"
               git push gitlab "refs/tags/${tag}:refs/tags/${tag}"
-            elif [ "${remote_sha}" = "${local_sha}" ]; then
+            elif [ "${remote_commit}" = "${local_commit}" ]; then
               # Tag already mirrored (e.g. pushed to both remotes during a
               # release cut). Idempotent success — tags are immutable, so never
               # force-overwrite them.
-              echo "Tag ${tag} already on GitLab at ${local_sha}; nothing to do."
+              echo "Tag ${tag} already on GitLab pointing at ${local_commit}; nothing to do."
             else
-              echo "::error::Tag ${tag} exists on GitLab at ${remote_sha} but GitHub has ${local_sha}. Refusing to overwrite an existing tag."
+              echo "::error::Tag ${tag} exists on GitLab at commit ${remote_commit} but GitHub has ${local_commit}. Refusing to overwrite an existing tag."
               exit 1
             fi
           else


### PR DESCRIPTION
## Summary

Fixes a false-positive failure in the **Sync to GitLab** workflow that fired on the `v2.2.0` tag push.

## Root cause

The tag-sync idempotency guard compared raw SHAs:

```sh
local_sha="$(git rev-parse "${GITHUB_REF}")"          # runner: lightweight ref → commit SHA
remote_sha="$(git ls-remote gitlab "refs/tags/${tag}")" # GitLab: annotated tag-object SHA
```

On the runner, `actions/checkout` writes a **lightweight** local tag ref that resolves straight to the commit, while an **annotated** tag on GitLab has a distinct tag-object SHA. For annotated release tags these two values never match, so when a tag is pushed to both remotes during a release cut, the guard wrongly reported:

```
Tag v2.2.0 exists on GitLab at 37b2df24… but GitHub has bb1743e2…. Refusing to overwrite.
```

The release itself was correct — both remotes hold the identical annotated tag object `37b2df24` peeling to commit `bb1743e`.

## Fix

Peel **both** sides to the commit they reference before comparing, with a fallback to the object SHA for lightweight remote tags:

```sh
local_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
remote_object="$(git ls-remote gitlab "refs/tags/${tag}" | cut -f1)"
remote_commit="$(git ls-remote gitlab "refs/tags/${tag}^{}" | cut -f1)"
remote_commit="${remote_commit:-$remote_object}"
```

This keeps the immutability check (refuse to overwrite a tag that points at a different commit) while correctly treating an already-mirrored annotated tag as an idempotent no-op.

## Validation

- Workflow YAML parses; embedded shell passes `bash -n`.
- Verified against the live `v2.2.0` tag: `remote_commit == local_commit == bb1743e` → idempotent no-op (the previously failing case).