### PR TITLE
fix(tls): name runtime uid/gid in cert/key permission errors (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **TLS file permission errors now name the runtime uid/gid.** The container
+  drops privileges to the unprivileged `dnsweaver` user (uid/gid `1000`) via
+  `su-exec`, so a CA bundle, client certificate, or private key mounted
+  `root:root 0600` fails with `permission denied` even when the container is
+  started as root. The error message now reports the uid/gid the process
+  actually runs as and points at the fix, so operators no longer burn time
+  thinking "but I AM root." ([#90](https://github.com/maxfield-allison/dnsweaver/issues/90))
+
+### Documentation
+- Added a **TLS Certificate File Permissions** section to the environment
+  reference (chown / group-readable / Docker secrets recipes), linked from the
+  README TLS section and every provider's mTLS example (Technitium, AdGuard,
+  Cloudflare, Pi-hole, Webhook) plus the Proxmox source. ([#90](https://github.com/maxfield-allison/dnsweaver/issues/90))
+
 ## [2.2.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Every HTTP-based provider (Technitium, AdGuard Home, Cloudflare, OVHcloud, Power
 
 The Proxmox source uses the same keys under `DNSWEAVER_PROXMOX_TLS_*`. The legacy `*_INSECURE_SKIP_VERIFY` and `DNSWEAVER_PROXMOX_VERIFY_TLS` variables are still accepted but emit a deprecation warning at startup — migrate to the unified `TLS_SKIP_VERIFY` keys. See the [Environment Reference](https://maxfield-allison.github.io/dnsweaver/configuration/environment/) and [SECURITY.md](SECURITY.md) for full details and recipes.
 
+> **Mounting certs?** The container drops privileges to uid/gid `1000`, so cert/key files must be readable by that user — a `root:root 0600` key yields `permission denied`. See [TLS Certificate File Permissions](https://maxfield-allison.github.io/dnsweaver/configuration/environment/#tls-certificate-file-permissions).
+
+
 ## Kubernetes Quick Start
 
 Deploy dnsweaver to watch Kubernetes resources for DNS management:

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -120,6 +120,74 @@ Replace `{NAME}` with your instance name. For example, instance `internal-dns` u
 | `DNSWEAVER_{NAME}_TLS_SKIP_VERIFY` | No | Skip TLS certificate verification (`true`/`false`, default: `false`). **Warning:** disables MITM protection — prefer `TLS_CA_FILE`. |
 | `DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY` | No | **Deprecated** — alias of `TLS_SKIP_VERIFY`. Will be removed in v2.0. |
 
+### TLS Certificate File Permissions
+
+The official container **drops privileges to an unprivileged user** (`dnsweaver`,
+uid/gid `1000`) before starting, even when you launch the container as root. The
+entrypoint needs root only briefly to auto-detect the Docker socket group, then
+hands off to uid `1000` via `su-exec`. The long-running process therefore reads
+your CA bundle, client certificate, and **private key as uid/gid 1000 — not as
+root and not as the host user that owns the files.**
+
+If a mounted key is owned `root:root` with mode `0600` (or `0640`), the process
+gets `permission denied` even though the file "looks" readable on the host:
+
+```text
+TLS configuration failed to build, falling back to stdlib defaults
+  error="loading TLS client keypair (cert=\"/etc/certs/cert.crt\" key=\"/etc/certs/key.pem\"):
+  open /etc/certs/key.pem: permission denied
+  (dnsweaver runs as uid=1000 gid=1000 after dropping privileges; the file must be
+  readable by that user — chown it to that uid/gid, make it group-readable, or mount
+  it as a Docker secret: .../#tls-certificate-file-permissions)"
+```
+
+Pick **one** of these fixes (do **not** `chmod 0666` a private key — that makes it
+world-readable inside the container, a real downgrade):
+
+=== "Chown to uid/gid 1000 (recommended)"
+
+    ```bash
+    sudo chown 1000:1000 cert.crt key.pem
+    sudo chmod 0644 cert.crt   # cert is public
+    sudo chmod 0600 key.pem    # key stays private, but now owned by uid 1000
+    ```
+
+=== "Group-readable"
+
+    ```bash
+    sudo chgrp 1000 key.pem
+    sudo chmod 0640 key.pem    # readable by gid 1000, still not world-readable
+    ```
+
+=== "Docker secrets (no chown needed)"
+
+    Files under `/run/secrets/` are readable by the in-container user by design,
+    so mounting certs as secrets sidesteps host ownership entirely:
+
+    ```yaml
+    services:
+      dnsweaver:
+        image: ghcr.io/maxfield-allison/dnsweaver:latest
+        environment:
+          - DNSWEAVER_TECHNITIUM_TLS_CERT_FILE=/run/secrets/dnsweaver_crt
+          - DNSWEAVER_TECHNITIUM_TLS_KEY_FILE=/run/secrets/dnsweaver_key
+        secrets:
+          - dnsweaver_crt
+          - dnsweaver_key
+    secrets:
+      dnsweaver_crt:
+        file: ./cert.crt
+      dnsweaver_key:
+        file: ./key.pem
+    ```
+
+!!! note "Kubernetes"
+    When the pod sets `securityContext.runAsUser`, certs projected from a
+    `Secret` volume are already readable by that user. Match the uid/gid you
+    run as, or rely on the default projected-secret mode (`0644`) for the cert
+    and a `defaultMode` of `0640` for the key with an `fsGroup` that the
+    container belongs to.
+
 ## Source Settings
 
 | Variable | Default | Description |

--- a/docs/providers/adguard.md
+++ b/docs/providers/adguard.md
@@ -189,6 +189,12 @@ AdGuard Home is often fronted by a reverse proxy with a private CA or self-signe
 
 The legacy `DNSWEAVER_ADGUARD_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in v2.0. See the [environment reference](../configuration/environment.md) for complete recipes.
 
+!!! warning "Mounted certs must be readable by uid/gid 1000"
+    The container drops privileges to the unprivileged `dnsweaver` user, so a
+    client key mounted `root:root 0600` yields `permission denied`. See
+    [TLS Certificate File Permissions](../configuration/environment.md#tls-certificate-file-permissions).
+
+
 ## Troubleshooting
 
 ### Authentication Failed

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -127,6 +127,12 @@ Cloudflare's public API uses publicly-trusted certificates so the defaults work 
 
 The legacy `DNSWEAVER_CLOUDFLARE_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in v2.0.
 
+!!! warning "Mounted certs must be readable by uid/gid 1000"
+    The container drops privileges to the unprivileged `dnsweaver` user, so a
+    client key mounted `root:root 0600` yields `permission denied`. See
+    [TLS Certificate File Permissions](../configuration/environment.md#tls-certificate-file-permissions).
+
+
 ## Troubleshooting
 
 ### Authentication Error

--- a/docs/providers/pihole.md
+++ b/docs/providers/pihole.md
@@ -167,6 +167,12 @@ When using API mode against a Pi-hole instance served over HTTPS — typically t
 
 The legacy `DNSWEAVER_PIHOLE_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in v2.0. File mode does not perform HTTP requests so these keys have no effect there.
 
+!!! warning "Mounted certs must be readable by uid/gid 1000"
+    The container drops privileges to the unprivileged `dnsweaver` user, so a
+    client key mounted `root:root 0600` yields `permission denied`. See
+    [TLS Certificate File Permissions](../configuration/environment.md#tls-certificate-file-permissions).
+
+
 ## Troubleshooting
 
 ### API Authentication Failed

--- a/docs/providers/technitium.md
+++ b/docs/providers/technitium.md
@@ -159,6 +159,12 @@ For mutual-TLS (server requires a client cert):
 - DNSWEAVER_TECHNITIUM_TLS_KEY_FILE=/run/secrets/dnsweaver.key
 ```
 
+!!! warning "Mounted certs must be readable by uid/gid 1000"
+    The container drops privileges to the unprivileged `dnsweaver` user. A key
+    mounted `root:root 0600` produces `permission denied`. Mounting via
+    `/run/secrets/` (as above) avoids this; for bind-mounts, see
+    [TLS Certificate File Permissions](../configuration/environment.md#tls-certificate-file-permissions).
+
 If the server's certificate CN/SAN differs from the URL host (e.g. you connect
 by IP but the cert is issued for a hostname), set an SNI override:
 

--- a/docs/providers/webhook.md
+++ b/docs/providers/webhook.md
@@ -180,6 +180,12 @@ Webhook endpoints frequently live on internal services with private CAs or mTLS 
 
 The legacy `DNSWEAVER_WEBHOOK_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in v2.0.
 
+!!! warning "Mounted certs must be readable by uid/gid 1000"
+    The container drops privileges to the unprivileged `dnsweaver` user, so a
+    client key mounted `root:root 0600` yields `permission denied`. See
+    [TLS Certificate File Permissions](../configuration/environment.md#tls-certificate-file-permissions).
+
+
 ## Troubleshooting
 
 ### Connection Refused

--- a/docs/sources/proxmox.md
+++ b/docs/sources/proxmox.md
@@ -296,6 +296,11 @@ DNSWEAVER_PROXMOX_TLS_CERT_FILE=/run/secrets/dnsweaver.crt
 DNSWEAVER_PROXMOX_TLS_KEY_FILE=/run/secrets/dnsweaver.key
 ```
 
+!!! warning "Mounted certs must be readable by uid/gid 1000"
+    The container drops privileges to the unprivileged `dnsweaver` user, so a
+    client key mounted `root:root 0600` yields `permission denied`. See
+    [TLS Certificate File Permissions](../configuration/environment.md#tls-certificate-file-permissions).
+
 As a last resort for self-signed certificates that cannot be provided as a CA
 bundle, you can disable verification entirely — this removes MITM protection
 and is **not recommended for production**:

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -4,8 +4,10 @@ package httputil
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -105,7 +107,7 @@ func (t TLSConfig) Build() (*tls.Config, error) {
 	if t.CAFile != "" {
 		pem, err := os.ReadFile(t.CAFile)
 		if err != nil {
-			return nil, fmt.Errorf("reading TLS CA file %q: %w", t.CAFile, err)
+			return nil, permissionHint(fmt.Errorf("reading TLS CA file %q: %w", t.CAFile, err))
 		}
 		// Clone the system pool so we add to system trust rather than
 		// replacing it. SystemCertPool may fail on platforms without a
@@ -130,12 +132,33 @@ func (t TLSConfig) Build() (*tls.Config, error) {
 	if certSet {
 		cert, err := tls.LoadX509KeyPair(t.CertFile, t.KeyFile)
 		if err != nil {
-			return nil, fmt.Errorf("loading TLS client keypair (cert=%q key=%q): %w", t.CertFile, t.KeyFile, err)
+			return nil, permissionHint(fmt.Errorf("loading TLS client keypair (cert=%q key=%q): %w", t.CertFile, t.KeyFile, err))
 		}
 		out.Certificates = []tls.Certificate{cert}
 	}
 
 	return out, nil
+}
+
+// permissionHint augments a file-access error with the uid/gid the process is
+// actually running as. The container entrypoint drops privileges to the
+// unprivileged "dnsweaver" user (uid/gid 1000) via su-exec even when the
+// container is started as root, so a "permission denied" on a cert/key mounted
+// root:root 0600 is a common and confusing failure: the operator sees root on
+// the host but the binary is not root inside the container. The hint points at
+// the actual runtime uid/gid and the docs so the fix (chown to that uid/gid, or
+// make the file group-readable, or use Docker secrets) is obvious.
+//
+// Returns the error unchanged when it is nil or not a permission error.
+func permissionHint(err error) error {
+	if err == nil || !errors.Is(err, fs.ErrPermission) {
+		return err
+	}
+	return fmt.Errorf("%w (dnsweaver runs as uid=%d gid=%d after dropping privileges; "+
+		"the file must be readable by that user — chown it to that uid/gid, make it group-readable, "+
+		"or mount it as a Docker secret: "+
+		"https://maxfield-allison.github.io/dnsweaver/configuration/environment/#tls-certificate-file-permissions)",
+		err, os.Getuid(), os.Getgid())
 }
 
 // ParseTLSMinVersion converts a user-facing version string (e.g. "1.2", "1.3",

--- a/pkg/httputil/tls_test.go
+++ b/pkg/httputil/tls_test.go
@@ -9,13 +9,17 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -300,5 +304,65 @@ func TestNewClient_TLSSkipVerify_PreservesTransportClone(t *testing.T) {
 	}
 	if tr.MaxIdleConns == 0 {
 		t.Error("MaxIdleConns is zero — transport was not cloned from DefaultTransport")
+	}
+}
+
+// TestPermissionHint verifies that a permission-denied file error is annotated
+// with the uid/gid the process actually runs as. This is the user-facing half
+// of the fix for issue #90: the container drops privileges to the unprivileged
+// dnsweaver user, so "permission denied" on a root-owned cert/key needs to spell
+// out the runtime uid/gid or operators waste time thinking "but I AM root."
+func TestPermissionHint(t *testing.T) {
+	// A wrapped fs.ErrPermission gets the uid/gid annotation while preserving
+	// the original error chain.
+	base := fmt.Errorf("open /etc/certs/key.pem: %w", fs.ErrPermission)
+	got := permissionHint(base)
+	if got == nil {
+		t.Fatal("expected non-nil error")
+	}
+	msg := got.Error()
+	if !strings.Contains(msg, fmt.Sprintf("uid=%d", os.Getuid())) {
+		t.Errorf("hint missing runtime uid: %q", msg)
+	}
+	if !strings.Contains(msg, fmt.Sprintf("gid=%d", os.Getgid())) {
+		t.Errorf("hint missing runtime gid: %q", msg)
+	}
+	if !errors.Is(got, fs.ErrPermission) {
+		t.Error("permissionHint must preserve the wrapped error for errors.Is")
+	}
+
+	// Non-permission errors pass through untouched (identity).
+	other := errors.New("some other failure")
+	if permissionHint(other) != other { //nolint:errorlint // identity check is intentional
+		t.Error("non-permission error should pass through unchanged")
+	}
+
+	// nil stays nil.
+	if permissionHint(nil) != nil {
+		t.Error("nil should pass through unchanged")
+	}
+}
+
+// TestTLSConfig_Build_KeyPermissionDenied is an end-to-end check that Build()
+// routes the keypair load error through permissionHint. Skipped when running as
+// root, which can read 0000-mode files and would never hit the permission path.
+func TestTLSConfig_Build_KeyPermissionDenied(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: cannot reproduce a permission-denied read")
+	}
+	certPEM, keyPEM, _, _ := genCert(t, []string{"x"}, true)
+	dir := t.TempDir()
+	certPath := writeTemp(t, dir, "c.crt", certPEM)
+	keyPath := writeTemp(t, dir, "c.key", keyPEM)
+	if err := os.Chmod(keyPath, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	_, err := (&TLSConfig{CertFile: certPath, KeyFile: keyPath}).Build()
+	if err == nil {
+		t.Fatal("expected a permission error loading an unreadable key")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("uid=%d", os.Getuid())) {
+		t.Errorf("Build error not annotated with uid: %q", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #90. The official container drops privileges to the unprivileged `dnsweaver` user (uid/gid `1000`) via `su-exec` even when started as root. As a result, a CA bundle, client certificate, or **private key** mounted `root:root 0600` (or `0640`) fails with `permission denied` — which is confusing because the operator correctly observes they *are* root on the host.

This makes the failure self-explanatory and documents the fix.

## Changes

**Error message (`pkg/httputil/client.go`)**
- Wraps `fs.ErrPermission` from both the CA-file read and the client keypair load with the **actual runtime uid/gid** (`os.Getuid()`/`os.Getgid()`) plus a pointer to the docs.
- Preserves the error chain so `errors.Is(err, fs.ErrPermission)` still holds.

Before:
```
open /etc/certs/key.pem: permission denied
```
After:
```
loading TLS client keypair (...): open /etc/certs/key.pem: permission denied
  (dnsweaver runs as uid=1000 gid=1000 after dropping privileges; the file must be
  readable by that user — chown it to that uid/gid, make it group-readable, or mount
  it as a Docker secret: .../#tls-certificate-file-permissions)
```

**Docs**
- New **TLS Certificate File Permissions** section in the environment reference with three recipes (chown to `1000:1000`, group-readable, Docker secrets) and an explicit "don't `chmod 0666` a private key" warning.
- Linked from the README TLS section and **every** provider mTLS example (Technitium, AdGuard, Cloudflare, Pi-hole, Webhook) plus the Proxmox source.

**Tests**
- `TestPermissionHint` — annotation contains the runtime uid/gid, wrapped error preserved, non-permission/nil errors pass through unchanged.
- `TestTLSConfig_Build_KeyPermissionDenied` — end-to-end `Build()` permission path (skipped when running as root, which can read `0000` files).

## Validation
- `gofmt`, `go vet`, `golangci-lint`, `go test ./pkg/httputil/...`, `go build ./...` — all green.
- `mkdocs build` — clean.

No behavior change beyond the error text; this is a no-functional-risk, docs+DX fix.