### PR TITLE
docs: improve discoverability and SEO

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,3 +445,31 @@ github:release:
   rules:
     - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/
   tags: [docker]
+
+# Sync the Docker Hub repository "Overview" (full_description) from docker/DOCKERHUB.md.
+# Runs on release tags and whenever the description file changes on the default branch.
+# Reuses the existing $DOCKERHUB_USERNAME / $DOCKERHUB_TOKEN CI variables.
+github:dockerhub-description:
+  stage: github-release
+  image: alpine:3.21
+  before_script:
+    - apk add --no-cache curl jq
+  script:
+    - |
+      JWT=$(curl -s -H "Content-Type: application/json" -X POST \
+        -d "$(jq -n --arg u "$DOCKERHUB_USERNAME" --arg p "$DOCKERHUB_TOKEN" '{username:$u,password:$p}')" \
+        https://hub.docker.com/v2/users/login/ | jq -r .token)
+      if [ -z "$JWT" ] || [ "$JWT" = "null" ]; then echo "Docker Hub login failed"; exit 1; fi
+      CODE=$(curl -s -o /tmp/resp.json -w '%{http_code}' -X PATCH \
+        -H "Authorization: JWT $JWT" -H "Content-Type: application/json" \
+        --data "$(jq -n --rawfile d docker/DOCKERHUB.md '{full_description:$d}')" \
+        "https://hub.docker.com/v2/repositories/$DOCKERHUB_USERNAME/dnsweaver/")
+      echo "Docker Hub PATCH HTTP $CODE"
+      [ "$CODE" = "200" ] || { cat /tmp/resp.json; exit 1; }
+      echo "Synced full_description ($(wc -c < docker/DOCKERHUB.md) bytes)"
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      changes: ["docker/DOCKERHUB.md"]
+  tags: [docker]
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ dnsweaver watches Docker events, Kubernetes resources, and Proxmox VE clusters t
 
 📚 **[Full Documentation](https://maxfield-allison.github.io/dnsweaver/)**
 
+## Why dnsweaver?
+
+Think of dnsweaver as **external-dns for the homelab**. Where most tools solve a slice of the problem, dnsweaver covers the parts self-hosters actually run into:
+
+- **It does Proxmox.** Auto-create A records for VMs and LXCs from the PVE API — something almost no other DNS automation tool offers.
+- **It speaks self-hosted DNS.** First-class [Technitium](https://maxfield-allison.github.io/dnsweaver/providers/technitium/), [Pi-hole](https://maxfield-allison.github.io/dnsweaver/providers/pihole/), [AdGuard Home](https://maxfield-allison.github.io/dnsweaver/providers/adguard/), and [dnsmasq](https://maxfield-allison.github.io/dnsweaver/providers/dnsmasq/) support — not an afterthought, and not alpha.
+- **It's multi-platform.** Docker, Docker Swarm, Kubernetes, and Proxmox in one binary. Run one or all of them at once. `external-dns` is Kubernetes-only.
+- **It does split-horizon out of the box.** Internal and external records from the *same* labels — route private hostnames to Technitium and public ones to Cloudflare simultaneously.
+- **It's a single static Go binary.** ~15 MB, multi-arch (amd64/arm64), zero runtime dependencies. No Node.js, no sidecars.
+
+If you manage a homelab with Traefik, Proxmox, and a self-hosted resolver and you're still creating DNS records by hand, dnsweaver is built for you.
+
 ## Features
 
 - 🔀 **Multi-Provider Support** — Route different domains to different DNS providers
@@ -197,6 +209,12 @@ With this configuration, when `app.example.com` starts:
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING](https://maxfield-allison.github.io/dnsweaver/contributing/) for guidelines.
+
+## Star History
+
+If dnsweaver saves you time, a ⭐ helps others find it.
+
+[![Star History Chart](https://api.star-history.com/svg?repos=maxfield-allison/dnsweaver&type=Date)](https://star-history.com/#maxfield-allison/dnsweaver&Date)
 
 ## License
 

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -1,0 +1,72 @@
+# dnsweaver
+
+**Automatic DNS record management for Docker, Kubernetes, and Proxmox VE — with multi-provider and split-horizon support.**
+
+dnsweaver watches Docker events, Kubernetes resources, and Proxmox VE clusters and automatically creates and deletes DNS records from the labels you already have. Think of it as **external-dns for the homelab**.
+
+📚 **[Documentation](https://maxfield-allison.github.io/dnsweaver/)** · 🐙 **[GitHub](https://github.com/maxfield-allison/dnsweaver)** · 🔖 **[Releases](https://github.com/maxfield-allison/dnsweaver/releases)**
+
+---
+
+## Why dnsweaver?
+
+- **Proxmox VE auto-DNS** — A records for VMs and LXCs from the PVE API. Almost nothing else does this.
+- **Self-hosted DNS, first-class** — Technitium, Pi-hole, AdGuard Home, dnsmasq, RFC 2136, Cloudflare, and webhook.
+- **Multi-platform** — Docker, Docker Swarm, Kubernetes, and Proxmox in one binary. Run one or all at once.
+- **Split-horizon** — Internal and external records from the *same* labels (e.g. Technitium internally, Cloudflare externally).
+- **Single static Go binary** — ~15 MB, multi-arch (amd64/arm64), zero runtime dependencies.
+
+## Supported Providers
+
+| Provider | Record Types |
+|----------|--------------|
+| Technitium | A, AAAA, CNAME, SRV, TXT |
+| Cloudflare | A, AAAA, CNAME, SRV, TXT (optional proxy) |
+| RFC 2136 (BIND, Windows DNS, PowerDNS, Knot) | A, AAAA, CNAME, SRV, TXT |
+| Pi-hole | A, CNAME |
+| AdGuard Home | A, AAAA, CNAME |
+| dnsmasq | A, CNAME |
+| Webhook | Any (custom integrations) |
+
+## Tags
+
+- `latest` — latest stable release
+- `vX.Y.Z` — specific release (recommended for production)
+
+Multi-arch images are published for `linux/amd64` and `linux/arm64`.
+
+Also available on GitHub Container Registry: `ghcr.io/maxfield-allison/dnsweaver`.
+
+## Quick Start
+
+```yaml
+services:
+  dnsweaver:
+    image: maxamill/dnsweaver:latest
+    restart: unless-stopped
+    environment:
+      - DNSWEAVER_INSTANCES=internal-dns
+      - DNSWEAVER_INTERNAL_DNS_TYPE=technitium
+      - DNSWEAVER_INTERNAL_DNS_URL=http://dns.internal:5380
+      - DNSWEAVER_INTERNAL_DNS_TOKEN_FILE=/run/secrets/technitium_token
+      - DNSWEAVER_INTERNAL_DNS_ZONE=home.example.com
+      - DNSWEAVER_INTERNAL_DNS_RECORD_TYPE=A
+      - DNSWEAVER_INTERNAL_DNS_TARGET=192.0.2.100
+      - DNSWEAVER_INTERNAL_DNS_DOMAINS=*.home.example.com
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    secrets:
+      - technitium_token
+
+secrets:
+  technitium_token:
+    external: true
+```
+
+A container with the label `traefik.http.routers.myapp.rule=Host(myapp.home.example.com)` gets an A record created automatically. When the container stops, the record is removed.
+
+See the **[Getting Started guide](https://maxfield-allison.github.io/dnsweaver/getting-started/)** for the full walkthrough, Kubernetes and Proxmox setup, and provider-specific configuration.
+
+## License
+
+[MIT](https://github.com/maxfield-allison/dnsweaver/blob/main/LICENSE) · Maintained by [Maxfield Allison](https://github.com/maxfield-allison)

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -1,3 +1,8 @@
+---
+title: Environment Variables Reference
+description: Complete reference for every dnsweaver environment variable — instances, providers, sources, TLS, and secrets configuration with the DNSWEAVER_ prefix.
+---
+
 # Environment Variables Reference
 
 All configuration is via environment variables with the `DNSWEAVER_` prefix. Variables support the `_FILE` suffix for [secrets management](secrets.md) (Docker secrets, Kubernetes Secrets, or any file-based injection).

--- a/docs/deployment/split-horizon.md
+++ b/docs/deployment/split-horizon.md
@@ -1,3 +1,8 @@
+---
+title: Split-Horizon DNS
+description: Set up split-horizon (split-brain) DNS for your homelab with dnsweaver — route internal hostnames to Technitium or Pi-hole and public ones to Cloudflare from the same labels.
+---
+
 # Split-Horizon DNS
 
 Split-horizon DNS (also called split-brain DNS) allows the same hostname to resolve to different addresses depending on where the query originates. dnsweaver makes this easy with multi-provider support.

--- a/docs/deployment/swarm.md
+++ b/docs/deployment/swarm.md
@@ -1,3 +1,8 @@
+---
+title: Docker Swarm Deployment
+description: Production deployment guide for running dnsweaver on Docker Swarm clusters with automatic DNS record management.
+---
+
 # Docker Swarm Deployment
 
 Production deployment for Docker Swarm clusters.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,3 +1,8 @@
+---
+title: FAQ
+description: Frequently asked questions about dnsweaver — how it compares to external-dns, supported providers and platforms, ownership tracking, and troubleshooting.
+---
+
 # Frequently Asked Questions
 
 ## General

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,8 @@
+---
+title: Getting Started
+description: Install dnsweaver and set up automatic DNS for Docker, Kubernetes, or Proxmox in minutes — first provider configuration and your first auto-created record.
+---
+
 # Getting Started
 
 This guide walks you through installing dnsweaver and setting up your first DNS provider on Docker or Kubernetes.

--- a/docs/providers/adguard.md
+++ b/docs/providers/adguard.md
@@ -1,3 +1,8 @@
+---
+title: AdGuard Home DNS Provider
+description: Automate AdGuard Home DNS rewrites from Docker, Kubernetes, and Proxmox with dnsweaver — managed A, AAAA, and CNAME records via the AdGuard Home API.
+---
+
 # AdGuard Home
 
 AdGuard Home is a network-wide ad blocker and DNS server. dnsweaver manages DNS records via AdGuard Home's DNS Rewrite API.

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -1,3 +1,8 @@
+---
+title: Cloudflare DNS Provider
+description: Automate Cloudflare DNS records from Docker, Kubernetes, and Proxmox with dnsweaver — A, AAAA, CNAME, SRV, and TXT records with optional proxying.
+---
+
 # Cloudflare
 
 Cloudflare provides public DNS with optional proxy/CDN capabilities. dnsweaver supports Cloudflare's API for automated record management.

--- a/docs/providers/dnsmasq.md
+++ b/docs/providers/dnsmasq.md
@@ -1,3 +1,8 @@
+---
+title: dnsmasq DNS Provider
+description: Automatically manage dnsmasq A and CNAME records from Docker and Kubernetes with dnsweaver through file-based configuration.
+---
+
 # dnsmasq
 
 dnsmasq is a lightweight DNS/DHCP server commonly used in routers and containers. dnsweaver manages dnsmasq through configuration files.

--- a/docs/providers/pihole.md
+++ b/docs/providers/pihole.md
@@ -1,3 +1,8 @@
+---
+title: Pi-hole DNS Provider
+description: Automatically create and delete Pi-hole local DNS records from Docker containers and Kubernetes with dnsweaver — Pi-hole v6 API or file mode.
+---
+
 # Pi-hole
 
 Pi-hole is a network-wide ad blocker that also serves as a local DNS server. dnsweaver supports Pi-hole through its API or by direct file manipulation.

--- a/docs/providers/rfc2136.md
+++ b/docs/providers/rfc2136.md
@@ -1,3 +1,8 @@
+---
+title: RFC 2136 Dynamic DNS Provider
+description: Automate DNS records on BIND, Windows DNS, PowerDNS, and Knot with dnsweaver via RFC 2136 dynamic updates from Docker, Kubernetes, and Proxmox.
+---
+
 # RFC 2136 (Dynamic DNS)
 
 RFC 2136 is the industry-standard protocol for programmatic DNS updates, supported by virtually all authoritative DNS servers. This provider enables dnsweaver to manage records on any RFC 2136-compliant server.

--- a/docs/providers/technitium.md
+++ b/docs/providers/technitium.md
@@ -1,3 +1,8 @@
+---
+title: Technitium DNS Provider
+description: Automatically manage Technitium DNS records from Docker, Kubernetes, and Proxmox with dnsweaver — A, AAAA, CNAME, SRV, and TXT support via the Technitium API.
+---
+
 # Technitium DNS
 
 Technitium is a self-hosted DNS server with a REST API. It's the most full-featured provider in dnsweaver with support for all record types.

--- a/docs/providers/webhook.md
+++ b/docs/providers/webhook.md
@@ -1,3 +1,8 @@
+---
+title: Webhook DNS Provider
+description: Integrate dnsweaver with any DNS system using the webhook provider — send HTTP requests to custom endpoints for record create, update, and delete.
+---
+
 # Webhook Provider
 
 The webhook provider sends HTTP requests to custom endpoints, enabling integration with any DNS system.

--- a/docs/sources/docker.md
+++ b/docs/sources/docker.md
@@ -1,3 +1,8 @@
+---
+title: Docker Labels Source
+description: dnsweaver watches Docker containers and extracts hostnames from Traefik, Caddy, nginx-proxy, and native labels to create DNS records automatically.
+---
+
 # Docker Labels
 
 dnsweaver watches Docker containers and services for hostname information, extracting them from labels to create DNS records.

--- a/docs/sources/swarm.md
+++ b/docs/sources/swarm.md
@@ -1,3 +1,8 @@
+---
+title: Docker Swarm Source
+description: Automate DNS records for Docker Swarm services with dnsweaver — cluster-wide service discovery with multi-instance-safe ownership tracking.
+---
+
 # Docker Swarm
 
 Docker Swarm mode provides service discovery across a cluster. dnsweaver integrates with Swarm to manage DNS for services.

--- a/docs/sources/traefik-files.md
+++ b/docs/sources/traefik-files.md
@@ -1,3 +1,8 @@
+---
+title: Traefik File Source
+description: dnsweaver reads Traefik dynamic configuration files to discover hostnames and manage DNS records for non-Docker workloads.
+---
+
 # Traefik File Provider
 
 dnsweaver can read Traefik configuration files to discover hostnames, enabling DNS management for non-Docker workloads.


### PR DESCRIPTION
Visibility/SEO pass (Session A of the growth project).

- README: add "Why dnsweaver?" positioning (external-dns for the homelab) + Star History chart
- Add Docker Hub overview (docker/DOCKERHUB.md) + GitLab CI job to sync it to Docker Hub full_description on release/file change
- Add SEO meta descriptions to all high-intent provider/source/deployment/getting-started/faq pages (was 10/46)
- Docs sitemap verified live for Search Console submission