### PR TITLE
fix(rfc2136): clamp lower bound on record TTL conversion

### DIFF
--- a/providers/rfc2136/provider.go
+++ b/providers/rfc2136/provider.go
@@ -357,10 +357,12 @@ func (p *Provider) toRFC2136Record(record provider.Record) (dnsupdate.Record, er
 		}
 	}
 
-	// Determine TTL (clamp to valid uint32 range for DNS wire format)
+	// Determine TTL (clamp to valid uint32 range for DNS wire format).
+	// max(0, ...) guards the lower bound so a negative value can never wrap to a
+	// large uint32; min(..., MaxUint32) guards the upper bound.
 	ttl := uint32(min(max(0, p.ttl), math.MaxUint32))
 	if record.TTL > 0 {
-		ttl = uint32(min(record.TTL, math.MaxUint32))
+		ttl = uint32(min(max(0, record.TTL), math.MaxUint32))
 	}
 
 	r := dnsupdate.Record{


### PR DESCRIPTION
Resolves CodeQL code-scanning alert #1 (`go/incorrect-integer-conversion`, high).

## Problem
`record.TTL` is a platform `int`. When converting to `uint32` for the DNS wire format, line 363 clamped only the upper bound with `min(..., MaxUint32)`. A negative value would wrap to a large uint32. The `p.ttl` path on line 361 already guarded both bounds with `max(0, ...)`.

## Fix
Add `max(0, ...)` to the `record.TTL` conversion so both paths clamp identically. The outer `if record.TTL > 0` already prevents negatives in practice; this makes the conversion provably safe and silences the analyzer.

No behavior change for valid TTLs. Tests pass.