### PR TITLE
feat(providers): add OPNsense provider with Unbound + Dnsmasq engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OPNsense provider** with pluggable engine backend for **Unbound** and
+  **Dnsmasq** (OPNsense 24.7+), driven by the OPNsense REST API
+  ([GitHub #114](https://github.com/maxfield-allison/dnsweaver/issues/114),
+  GitLab #188). One provider covers both DNS engines OPNsense ships with;
+  pick with `DNSWEAVER_{NAME}_ENGINE=unbound|dnsmasq` (default `unbound`).
+  Ownership is tracked via a `dnsweaver:{instance}` prefix on the host
+  override's description field, since neither engine's host overrides support
+  TXT records — dnsweaver only lists and mutates rows it owns, so
+  operator-managed host overrides in the OPNsense GUI are always safe.
+  Post-write reload behavior is controlled by
+  `DNSWEAVER_{NAME}_RECONFIGURE_MODE` (`per_write` default, or `never`).
+  Supports A/AAAA in v1; see
+  [docs/providers/opnsense.md](docs/providers/opnsense.md).
+
 ## [2.2.1] - 2026-07-03
 
 Patch release rolling up TLS diagnostics, RFC 2136 TTL hardening, a Go toolchain
@@ -170,6 +185,7 @@ release workflow.
   (GHCR + Docker Hub) and publishing GitHub Releases on version tags. `main` and
   tags are synced one-way GitHub→GitLab.
 - Removed the dead `advanced-git-sync` integration.
+## [1.6.0] - 2026-06-10
 
 ### Added
 - **SSH remote management for the dnsmasq provider is now functional**

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you manage a homelab with Traefik, Proxmox, and a self-hosted resolver and yo
 | [PowerDNS](https://maxfield-allison.github.io/dnsweaver/providers/powerdns/) | A, AAAA, CNAME, SRV, TXT | Native Authoritative HTTP API |
 | [Pi-hole](https://maxfield-allison.github.io/dnsweaver/providers/pihole/) | A, CNAME | API or file mode |
 | [AdGuard Home](https://maxfield-allison.github.io/dnsweaver/providers/adguard/) | A, AAAA, CNAME | DNS rewrite management |
+| [OPNsense](https://maxfield-allison.github.io/dnsweaver/providers/opnsense/) | A, AAAA | Unbound or Dnsmasq host overrides via REST API |
 | [dnsmasq](https://maxfield-allison.github.io/dnsweaver/providers/dnsmasq/) | A, CNAME | File-based configuration |
 | [Webhook](https://maxfield-allison.github.io/dnsweaver/providers/webhook/) | Any | Custom integrations |
 

--- a/cmd/dnsweaver/setup.go
+++ b/cmd/dnsweaver/setup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/maxfield-allison/dnsweaver/providers/adguard"
 	"github.com/maxfield-allison/dnsweaver/providers/cloudflare"
 	"github.com/maxfield-allison/dnsweaver/providers/dnsmasq"
+	"github.com/maxfield-allison/dnsweaver/providers/opnsense"
 	"github.com/maxfield-allison/dnsweaver/providers/ovh"
 	"github.com/maxfield-allison/dnsweaver/providers/pihole"
 	"github.com/maxfield-allison/dnsweaver/providers/powerdns"
@@ -313,6 +314,9 @@ func registerProviderFactories(registry *provider.Registry) {
 
 	// Register OVHcloud provider factory (public DNS)
 	registry.RegisterFactory("ovh", ovh.Factory())
+
+	// Register OPNsense provider factory (Unbound/Dnsmasq host overrides via REST API)
+	registry.RegisterFactory("opnsense", opnsense.Factory())
 }
 
 // initializeProviders initializes all configured providers using the manager.

--- a/docs/contributing/adding-provider.md
+++ b/docs/contributing/adding-provider.md
@@ -361,7 +361,7 @@ DNSWEAVER_{NAME}_ZONE_ID=...     # Or ZONE for name lookup
 DNSWEAVER_{NAME}_TTL=300
 ```
 
-### Private DNS Providers (Technitium, Pi-hole, dnsmasq, unbound)
+### Private DNS Providers (Technitium, Pi-hole, dnsmasq, unbound, OPNsense)
 
 Characteristics:
 - Local network access

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -84,6 +84,14 @@ dnsweaver supports multiple DNS providers, each with different capabilities and 
 
     [:octicons-arrow-right-24: Configuration](adguard.md)
 
+-   :material-firewall:{ .lg .middle } **OPNsense**
+
+    ---
+
+    Manage Unbound or Dnsmasq host overrides on OPNsense. REST API.
+
+    [:octicons-arrow-right-24: Configuration](opnsense.md)
+
 </div>
 
 ## Provider Comparison
@@ -97,6 +105,7 @@ dnsweaver supports multiple DNS providers, each with different capabilities and 
 | [PowerDNS](powerdns.md) | REST API | A, AAAA, CNAME, SRV, TXT | PowerDNS via native HTTP API |
 | [Pi-hole](pihole.md) | REST API or File | A, CNAME | Existing Pi-hole setups |
 | [AdGuard Home](adguard.md) | REST API | A, AAAA, CNAME | Existing AdGuard Home setups |
+| [OPNsense](opnsense.md) | REST API | A, AAAA | Unbound or Dnsmasq host overrides on OPNsense |
 | [dnsmasq](dnsmasq.md) | File | A, CNAME | Simple file-based DNS |
 | [Webhook](webhook.md) | HTTP Callback | Any | Custom integrations |
 

--- a/docs/providers/opnsense.md
+++ b/docs/providers/opnsense.md
@@ -1,0 +1,121 @@
+# OPNsense
+
+[OPNsense](https://opnsense.org/) is an open-source firewall and routing platform. dnsweaver manages **host override** records on OPNsense's DNS resolvers via its REST API.
+
+OPNsense ships with two DNS resolvers: **Unbound** (default) and **Dnsmasq** (24.7+). A single dnsweaver `opnsense` provider covers both — pick the resolver with the `ENGINE` setting.
+
+## Requirements
+
+- OPNsense with the target resolver enabled (Services → Unbound DNS, or Services → Dnsmasq DNS)
+- An API key + secret for a user with permission to manage the target resolver (System → Access → Users → *user* → **API keys**)
+- Network reachability from dnsweaver to the OPNsense web/GUI port
+
+## Why REST, not SSH?
+
+OPNsense manages state through `config.xml` and its own internal state machine. Writing to the underlying resolver's config files over SSH would work briefly, then break the moment HA sync, a firmware upgrade, or a backup/restore rewrites `config.xml`. The REST API is the only supported way to make changes.
+
+If you have a standalone Linux dnsmasq host (not fronted by OPNsense), use the [dnsmasq](dnsmasq.md) provider instead.
+
+## Configuration
+
+```yaml
+environment:
+  - DNSWEAVER_INSTANCES=opns
+
+  - DNSWEAVER_OPNS_TYPE=opnsense
+  - DNSWEAVER_OPNS_URL=https://opnsense.internal
+  - DNSWEAVER_OPNS_API_KEY_FILE=/run/secrets/opnsense_key
+  - DNSWEAVER_OPNS_API_SECRET_FILE=/run/secrets/opnsense_secret
+  - DNSWEAVER_OPNS_ENGINE=unbound        # or dnsmasq
+  - DNSWEAVER_OPNS_ZONE=home.example.com
+  - DNSWEAVER_OPNS_RECORD_TYPE=A
+  - DNSWEAVER_OPNS_TARGET=192.0.2.10
+  - DNSWEAVER_OPNS_DOMAINS=*.home.example.com
+```
+
+## Configuration Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TYPE` | Yes | – | Must be `opnsense` |
+| `URL` | Yes | – | OPNsense base URL (`https://opnsense.internal`) |
+| `API_KEY` | Yes | – | OPNsense API key (per-user) |
+| `API_SECRET` | Yes | – | OPNsense API secret (paired with `API_KEY`) |
+| `API_KEY_FILE` / `API_SECRET_FILE` | Alt | – | File-based alternatives for Docker/K8s secrets |
+| `ENGINE` | No | `unbound` | Target resolver: `unbound` or `dnsmasq` |
+| `ZONE` | No | – | DNS zone for record filtering |
+| `TTL` | No | `300` | Informational only — host overrides have no per-record TTL |
+| `RECONFIGURE_MODE` | No | `per_write` | `per_write` (reload after every change) or `never` |
+| `TLS_CA_FILE` | No | – | Path to a PEM CA bundle (for private CA on OPNsense) |
+| `TLS_SKIP_VERIFY` | No | `false` | Bypass certificate verification (**insecure**) |
+| `RECORD_TYPE` | Yes | – | `A` or `AAAA` |
+| `TARGET` | Yes | – | IP address |
+| `DOMAINS` | Yes | – | Glob patterns to match |
+| `EXCLUDE_DOMAINS` | No | – | Patterns to exclude |
+
+## Record Types (v1)
+
+Both engines support **A** and **AAAA** host overrides. CNAME and other record types are not implemented in the first release.
+
+## Ownership Marking
+
+Neither Unbound nor Dnsmasq host overrides expose TXT records, so dnsweaver cannot write its usual `_dnsweaver.*` ownership record.
+
+Instead, every record dnsweaver creates carries a marker in the OPNsense **description** field:
+
+```
+dnsweaver:{instance-name}
+```
+
+Two consequences:
+
+1. **Operator-managed host overrides are always safe.** dnsweaver's `List()` filters to rows that carry its marker, so orphan cleanup can never touch a host override you created by hand in the OPNsense GUI.
+2. **Editing a dnsweaver-managed record's description in the GUI unbinds it from dnsweaver.** If you want to add a note, keep the `dnsweaver:{instance}` prefix and separate your note with ` | ` — the parser tolerates that form.
+
+## Reconfigure Semantics
+
+OPNsense requires an explicit "reconfigure" call to reload the resolver after a change. That call fully restarts the daemon, so it's not free.
+
+| Mode | Behavior | When to use |
+|------|----------|-------------|
+| `per_write` (default) | Reconfigure after every Create/Delete | Small deployments; correctness over throughput |
+| `never` | Never auto-reconfigure | Large deployments; you reload externally (cron, orchestration) |
+
+Batched/debounced reconfigure is a planned follow-up.
+
+## TLS
+
+OPNsense typically presents a self-signed certificate. Prefer one of these approaches (in order of preference):
+
+1. **Trust the OPNsense CA properly** — export it from OPNsense (System → Trust → Authorities) and point `TLS_CA_FILE` at it.
+2. **Bypass verification** — set `TLS_SKIP_VERIFY=true`. dnsweaver will log a WARN at startup. Only acceptable on trusted management networks.
+
+## API Endpoints Used
+
+For reference (all POST):
+
+**Unbound:**
+- `/api/unbound/settings/searchHostOverride` — list rows
+- `/api/unbound/settings/addHostOverride` — create
+- `/api/unbound/settings/delHostOverride/{uuid}` — delete
+- `/api/unbound/service/reconfigure` — reload resolver
+
+**Dnsmasq (OPNsense 24.7+):**
+- `/api/dnsmasq/settings/searchHost`
+- `/api/dnsmasq/settings/addHost`
+- `/api/dnsmasq/settings/delHost/{uuid}`
+- `/api/dnsmasq/service/reconfigure`
+
+## Troubleshooting
+
+**`unauthorized`**
+: The API key/secret pair is wrong, or the user lacks permission for the target module. Verify in System → Access → Users → *user* → API keys.
+
+**`opnsense reachable but {engine} search response is unparseable (is the {engine} module enabled?)`**
+: The API responded but the payload doesn't match the expected shape. Most often this means the target resolver (Unbound or Dnsmasq) is disabled on OPNsense.
+
+**Records appear in dnsweaver logs but not in DNS answers**
+: OPNsense didn't reload. Check the reconfigure endpoint in dnsweaver logs, or if you're in `RECONFIGURE_MODE=never`, trigger the reload out of band.
+
+**`opnsense provider requires an IP target`**
+: The A/AAAA record's `TARGET` is not a parseable IP. Host overrides on both engines resolve names to IPs, so the target must be `10.1.2.3` or `2001:db8::1`, not another hostname.

--- a/internal/config/instance.go
+++ b/internal/config/instance.go
@@ -269,6 +269,9 @@ var providerConfigFields = []struct {
 	{"ACCESS_MODE", false},          // Pi-hole specific (api/file) — renamed from MODE in v0.10.0
 	{"USERNAME", false},             // AdGuard Home specific
 	{"PASSWORD", true},              // Pi-hole and AdGuard Home specific
+	{"API_SECRET", true},            // OPNsense specific: paired with API_KEY for basic auth
+	{"ENGINE", false},               // OPNsense specific: unbound|dnsmasq resolver selection
+	{"RECONFIGURE_MODE", false},     // OPNsense specific: per_write|never
 	{"INSECURE_SKIP_VERIFY", false}, // DEPRECATED: alias for TLS_SKIP_VERIFY, kept one release
 	// Unified TLS fields — consumed by pkg/provider/extractTLSConfig and
 	// passed to every HTTP-based provider via FactoryConfig.HTTP.TLS.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - PowerDNS: providers/powerdns.md
       - Pi-hole: providers/pihole.md
       - AdGuard Home: providers/adguard.md
+      - OPNsense: providers/opnsense.md
       - dnsmasq: providers/dnsmasq.md
       - Webhook: providers/webhook.md
   - Sources:

--- a/providers/opnsense/client.go
+++ b/providers/opnsense/client.go
@@ -1,0 +1,187 @@
+package opnsense
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// Client is a low-level HTTP client for the OPNsense REST API. It knows about
+// authentication, transport, and response envelopes, but not about DNS
+// concepts — those live on the Provider, which composes Client with an engine.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	apiSecret  string
+	httpClient *http.Client
+	logger     *slog.Logger
+}
+
+// ClientOption configures a Client at construction time.
+type ClientOption func(*Client)
+
+// WithHTTPClient overrides the HTTP client (primarily for tests and to inject
+// the framework-configured transport with unified TLS settings).
+func WithHTTPClient(h *http.Client) ClientOption {
+	return func(c *Client) { c.httpClient = h }
+}
+
+// WithLogger sets a structured logger.
+func WithLogger(logger *slog.Logger) ClientOption {
+	return func(c *Client) {
+		if logger != nil {
+			c.logger = logger
+		}
+	}
+}
+
+// NewClient constructs a Client. baseURL must be an absolute URL with scheme
+// (http:// or https://). Trailing slashes are trimmed so path concatenation
+// is unambiguous.
+func NewClient(baseURL, apiKey, apiSecret string, opts ...ClientOption) *Client {
+	c := &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiKey:     apiKey,
+		apiSecret:  apiSecret,
+		httpClient: httputil.DefaultClient(),
+		logger:     slog.Default(),
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// do POSTs a JSON request against the OPNsense API and returns the raw
+// response body plus status code. Callers own status-code interpretation
+// because "success" is endpoint-specific (200 with {"result":"failed"} is
+// a common OPNsense failure mode). All OPNsense API mutations use POST;
+// GET is never appropriate.
+func (c *Client) do(ctx context.Context, path string, body []byte) ([]byte, int, error) {
+	reqURL := c.baseURL + path
+
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, reader)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build request: %w", err)
+	}
+
+	req.SetBasicAuth(c.apiKey, c.apiSecret)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	c.logger.Debug("opnsense request",
+		slog.String("path", path),
+	)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := httputil.ReadBody(resp, 0)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("reading response body: %w", err)
+	}
+	return respBody, resp.StatusCode, nil
+}
+
+// mapStatusError translates common HTTP status codes into the framework's
+// provider-level sentinel errors so callers can use errors.Is checks.
+func mapStatusError(status int, body []byte) error {
+	switch {
+	case status == http.StatusUnauthorized, status == http.StatusForbidden:
+		return provider.ErrUnauthorized
+	case status == http.StatusNotFound:
+		return provider.ErrNotFound
+	case status >= 500:
+		return fmt.Errorf("%w: opnsense returned %d: %s",
+			provider.ErrProviderUnavailable, status, truncate(string(body)))
+	case status >= 400:
+		return fmt.Errorf("opnsense returned %d: %s", status, truncate(string(body)))
+	}
+	return nil
+}
+
+// resultEnvelope is the common OPNsense response wrapper for mutation
+// endpoints. "saved" and "deleted" indicate success; anything else is an
+// error the caller should surface.
+type resultEnvelope struct {
+	Result string `json:"result"`
+	UUID   string `json:"uuid"`
+	// Validations is set when OPNsense rejects a request due to field-level
+	// validation errors. Keys are dotted field paths (e.g. "host.hostname").
+	Validations map[string]string `json:"validations"`
+}
+
+// parseMutationResponse handles the common shape of add/delete/set responses.
+// Returns nil on success; a descriptive error otherwise. dnsweaver looks up
+// UUIDs via the search endpoint, so the assigned UUID from add responses is
+// deliberately discarded here.
+func parseMutationResponse(body []byte) error {
+	var env resultEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return fmt.Errorf("decoding opnsense response: %w (body: %s)",
+			err, truncate(string(body)))
+	}
+	switch strings.ToLower(env.Result) {
+	case "saved", "deleted", "ok":
+		return nil
+	case "failed", "":
+		if len(env.Validations) > 0 {
+			return fmt.Errorf("opnsense rejected request: %s",
+				formatValidations(env.Validations))
+		}
+		return fmt.Errorf("opnsense request failed: %s", truncate(string(body)))
+	default:
+		// Unknown result value — surface it verbatim.
+		return fmt.Errorf("opnsense returned unexpected result %q", env.Result)
+	}
+}
+
+// searchRequest is the standard OPNsense grid/search request body. rowCount
+// = -1 asks for all rows so the caller doesn't need to paginate.
+type searchRequest struct {
+	Current      int    `json:"current"`
+	RowCount     int    `json:"rowCount"`
+	SearchPhrase string `json:"searchPhrase"`
+}
+
+func newSearchRequest() []byte {
+	// Ignore error: struct only contains primitives, encoding cannot fail.
+	body, _ := json.Marshal(searchRequest{Current: 1, RowCount: -1})
+	return body
+}
+
+func formatValidations(v map[string]string) string {
+	parts := make([]string, 0, len(v))
+	for k, msg := range v {
+		parts = append(parts, fmt.Sprintf("%s: %s", k, msg))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// truncate caps a string for inclusion in error messages so a runaway HTML
+// error page or huge JSON body doesn't drown the logs.
+func truncate(s string) string {
+	const n = 200
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/providers/opnsense/config.go
+++ b/providers/opnsense/config.go
@@ -1,0 +1,235 @@
+package opnsense
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Engine identifies which DNS resolver on OPNsense this instance targets.
+type Engine string
+
+const (
+	// EngineUnbound is OPNsense's default recursive resolver.
+	EngineUnbound Engine = "unbound"
+	// EngineDnsmasq is OPNsense's alternative resolver (24.7+).
+	EngineDnsmasq Engine = "dnsmasq"
+)
+
+// ReconfigureMode controls when the provider calls the resolver's
+// reconfigure endpoint (which fully reloads the daemon).
+type ReconfigureMode string
+
+const (
+	// ReconfigureModePerWrite reloads after every Create/Delete. Correct
+	// but expensive on large batches; acceptable for typical homelab scale.
+	ReconfigureModePerWrite ReconfigureMode = "per_write"
+	// ReconfigureModeNever disables automatic reload. Operators must
+	// reload out of band (cron, manual, etc). Useful when many providers
+	// share the same OPNsense host and reload is coordinated externally.
+	ReconfigureModeNever ReconfigureMode = "never"
+)
+
+// DefaultTTL is informational only — OPNsense host overrides have no
+// per-record TTL; the resolver uses its global TTL.
+const DefaultTTL = 300
+
+// Config holds OPNsense-specific configuration.
+type Config struct {
+	// URL is the OPNsense base URL (e.g. "https://opnsense.internal").
+	URL string
+	// APIKey is the OPNsense API key.
+	APIKey string
+	// APISecret is the OPNsense API secret.
+	APISecret string
+	// Engine selects the DNS resolver backend (unbound or dnsmasq).
+	Engine Engine
+	// Zone optionally filters records to a specific DNS zone.
+	Zone string
+	// TTL is informational only.
+	TTL int
+	// ReconfigureMode controls automatic resolver reload after mutations.
+	ReconfigureMode ReconfigureMode
+}
+
+// Validate checks that all required configuration is present and correct.
+func (c *Config) Validate() error {
+	var errs []string
+
+	if c.URL == "" {
+		errs = append(errs, "URL is required")
+	} else {
+		parsed, err := url.Parse(c.URL)
+		switch {
+		case err != nil:
+			errs = append(errs, fmt.Sprintf("invalid URL: %v", err))
+		case parsed.Scheme != "http" && parsed.Scheme != "https":
+			errs = append(errs, "URL must start with http:// or https://")
+		case parsed.User != nil:
+			errs = append(errs, "URL must not contain embedded credentials")
+		}
+	}
+
+	if c.APIKey == "" {
+		errs = append(errs, "API_KEY is required")
+	}
+	if c.APISecret == "" {
+		errs = append(errs, "API_SECRET is required")
+	}
+
+	switch c.Engine {
+	case EngineUnbound, EngineDnsmasq:
+		// ok
+	case "":
+		errs = append(errs, "ENGINE is required (unbound or dnsmasq)")
+	default:
+		errs = append(errs, fmt.Sprintf("ENGINE must be %q or %q, got %q",
+			EngineUnbound, EngineDnsmasq, c.Engine))
+	}
+
+	switch c.ReconfigureMode {
+	case ReconfigureModePerWrite, ReconfigureModeNever:
+		// ok
+	default:
+		errs = append(errs, fmt.Sprintf("RECONFIGURE_MODE must be %q or %q, got %q",
+			ReconfigureModePerWrite, ReconfigureModeNever, c.ReconfigureMode))
+	}
+
+	if c.TTL < 0 {
+		errs = append(errs, "TTL must be non-negative")
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("opnsense config validation failed: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// LoadConfig loads OPNsense configuration from environment variables.
+// Environment variable pattern: DNSWEAVER_{INSTANCE_NAME}_{SETTING}
+//
+// Instance names are normalized: lowercase with hyphens becomes uppercase
+// with underscores. Example: "opnsense-fw" looks for DNSWEAVER_OPNSENSE_FW_*.
+func LoadConfig(instanceName string) (*Config, error) {
+	prefix := envPrefix(instanceName)
+
+	config := &Config{
+		URL:             getEnv(prefix + "URL"),
+		APIKey:          getEnvOrFile(prefix+"API_KEY", prefix+"API_KEY_FILE"),
+		APISecret:       getEnvOrFile(prefix+"API_SECRET", prefix+"API_SECRET_FILE"),
+		Engine:          engineFromString(getEnv(prefix + "ENGINE")),
+		Zone:            getEnv(prefix + "ZONE"),
+		TTL:             DefaultTTL,
+		ReconfigureMode: reconfigureModeFromString(getEnv(prefix + "RECONFIGURE_MODE")),
+	}
+
+	if ttlStr := getEnv(prefix + "TTL"); ttlStr != "" {
+		ttl, err := strconv.Atoi(ttlStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TTL value %q: %w", ttlStr, err)
+		}
+		config.TTL = ttl
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("configuration for %s: %w", instanceName, err)
+	}
+	return config, nil
+}
+
+// LoadConfigFromMap creates a Config from a map of key-value pairs, as
+// produced by the framework config loader.
+func LoadConfigFromMap(name string, m map[string]string) (*Config, error) {
+	config := &Config{
+		URL:             getMapValue(m, "URL"),
+		APIKey:          getMapValue(m, "API_KEY"),
+		APISecret:       getMapValue(m, "API_SECRET"),
+		Engine:          engineFromString(getMapValue(m, "ENGINE")),
+		Zone:            getMapValue(m, "ZONE"),
+		TTL:             DefaultTTL,
+		ReconfigureMode: reconfigureModeFromString(getMapValue(m, "RECONFIGURE_MODE")),
+	}
+
+	if ttlStr := getMapValue(m, "TTL"); ttlStr != "" {
+		ttl, err := strconv.Atoi(ttlStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TTL value %q: %w", ttlStr, err)
+		}
+		config.TTL = ttl
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("configuration for %s: %w", name, err)
+	}
+	return config, nil
+}
+
+// engineFromString parses an engine string, defaulting to unbound when empty
+// so operators who omit the setting get OPNsense's default resolver.
+func engineFromString(s string) Engine {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return EngineUnbound
+	case string(EngineUnbound):
+		return EngineUnbound
+	case string(EngineDnsmasq):
+		return EngineDnsmasq
+	default:
+		// Return the raw value so Validate() can report it accurately.
+		return Engine(s)
+	}
+}
+
+// reconfigureModeFromString parses a reconfigure mode string, defaulting
+// to per_write when empty.
+func reconfigureModeFromString(s string) ReconfigureMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return ReconfigureModePerWrite
+	case string(ReconfigureModePerWrite):
+		return ReconfigureModePerWrite
+	case string(ReconfigureModeNever):
+		return ReconfigureModeNever
+	default:
+		return ReconfigureMode(s)
+	}
+}
+
+func envPrefix(instanceName string) string {
+	normalized := strings.ToUpper(strings.ReplaceAll(instanceName, "-", "_"))
+	return "DNSWEAVER_" + normalized + "_"
+}
+
+func getEnv(key string) string {
+	return os.Getenv(key)
+}
+
+func getEnvOrFile(envKey, fileKey string) string {
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	if filePath := os.Getenv(fileKey); filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(data))
+	}
+	return ""
+}
+
+// getMapValue looks up a key case-insensitively.
+func getMapValue(m map[string]string, key string) string {
+	if v, ok := m[key]; ok {
+		return v
+	}
+	if v, ok := m[strings.ToUpper(key)]; ok {
+		return v
+	}
+	if v, ok := m[strings.ToLower(key)]; ok {
+		return v
+	}
+	return ""
+}

--- a/providers/opnsense/config_test.go
+++ b/providers/opnsense/config_test.go
@@ -1,0 +1,190 @@
+package opnsense
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string // empty = expect success
+	}{
+		{
+			name: "valid unbound",
+			cfg: Config{
+				URL:             "https://opnsense.test",
+				APIKey:          "k",
+				APISecret:       "s",
+				Engine:          EngineUnbound,
+				ReconfigureMode: ReconfigureModePerWrite,
+			},
+		},
+		{
+			name: "valid dnsmasq",
+			cfg: Config{
+				URL:             "http://opnsense.test",
+				APIKey:          "k",
+				APISecret:       "s",
+				Engine:          EngineDnsmasq,
+				ReconfigureMode: ReconfigureModeNever,
+			},
+		},
+		{
+			name:    "missing url",
+			cfg:     Config{APIKey: "k", APISecret: "s", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "URL is required",
+		},
+		{
+			name:    "bad scheme",
+			cfg:     Config{URL: "ftp://x", APIKey: "k", APISecret: "s", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "URL must start with http",
+		},
+		{
+			name:    "embedded credentials rejected",
+			cfg:     Config{URL: "https://u:p@opnsense.test", APIKey: "k", APISecret: "s", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "embedded credentials",
+		},
+		{
+			name:    "missing api key",
+			cfg:     Config{URL: "https://x", APISecret: "s", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "API_KEY is required",
+		},
+		{
+			name:    "missing api secret",
+			cfg:     Config{URL: "https://x", APIKey: "k", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "API_SECRET is required",
+		},
+		{
+			name:    "unknown engine",
+			cfg:     Config{URL: "https://x", APIKey: "k", APISecret: "s", Engine: Engine("bind"), ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "ENGINE must be",
+		},
+		{
+			name:    "unknown reconfigure mode",
+			cfg:     Config{URL: "https://x", APIKey: "k", APISecret: "s", Engine: EngineUnbound, ReconfigureMode: ReconfigureMode("cron")},
+			wantErr: "RECONFIGURE_MODE",
+		},
+		{
+			name:    "negative ttl",
+			cfg:     Config{URL: "https://x", APIKey: "k", APISecret: "s", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite, TTL: -1},
+			wantErr: "TTL must be non-negative",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfigFromMap_Defaults(t *testing.T) {
+	m := map[string]string{
+		"URL":        "https://opnsense.test",
+		"API_KEY":    "k",
+		"API_SECRET": "s",
+	}
+	cfg, err := LoadConfigFromMap("opns", m)
+	if err != nil {
+		t.Fatalf("LoadConfigFromMap error: %v", err)
+	}
+	if cfg.Engine != EngineUnbound {
+		t.Errorf("default engine = %q, want %q", cfg.Engine, EngineUnbound)
+	}
+	if cfg.ReconfigureMode != ReconfigureModePerWrite {
+		t.Errorf("default reconfigure mode = %q, want %q", cfg.ReconfigureMode, ReconfigureModePerWrite)
+	}
+	if cfg.TTL != DefaultTTL {
+		t.Errorf("default TTL = %d, want %d", cfg.TTL, DefaultTTL)
+	}
+}
+
+func TestLoadConfigFromMap_AllFields(t *testing.T) {
+	m := map[string]string{
+		"URL":              "https://opnsense.test",
+		"API_KEY":          "abc",
+		"API_SECRET":       "xyz",
+		"ENGINE":           "dnsmasq",
+		"ZONE":             "example.com",
+		"TTL":              "600",
+		"RECONFIGURE_MODE": "never",
+	}
+	cfg, err := LoadConfigFromMap("opns", m)
+	if err != nil {
+		t.Fatalf("LoadConfigFromMap error: %v", err)
+	}
+	if cfg.Engine != EngineDnsmasq {
+		t.Errorf("engine = %q, want %q", cfg.Engine, EngineDnsmasq)
+	}
+	if cfg.Zone != "example.com" {
+		t.Errorf("zone = %q", cfg.Zone)
+	}
+	if cfg.TTL != 600 {
+		t.Errorf("ttl = %d", cfg.TTL)
+	}
+	if cfg.ReconfigureMode != ReconfigureModeNever {
+		t.Errorf("mode = %q", cfg.ReconfigureMode)
+	}
+}
+
+func TestLoadConfigFromMap_InvalidTTL(t *testing.T) {
+	m := map[string]string{
+		"URL":        "https://opnsense.test",
+		"API_KEY":    "k",
+		"API_SECRET": "s",
+		"TTL":        "abc",
+	}
+	_, err := LoadConfigFromMap("opns", m)
+	if err == nil || !strings.Contains(err.Error(), "invalid TTL") {
+		t.Fatalf("expected invalid TTL error, got %v", err)
+	}
+}
+
+func TestLoadConfigFromMap_InvalidEngineSurfaces(t *testing.T) {
+	m := map[string]string{
+		"URL":        "https://opnsense.test",
+		"API_KEY":    "k",
+		"API_SECRET": "s",
+		"ENGINE":     "powerdns",
+	}
+	_, err := LoadConfigFromMap("opns", m)
+	if err == nil || !strings.Contains(err.Error(), "ENGINE must be") {
+		t.Fatalf("expected engine validation error, got %v", err)
+	}
+}
+
+func TestEngineFromString(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Engine
+	}{
+		{"", EngineUnbound},
+		{"unbound", EngineUnbound},
+		{"UNBOUND", EngineUnbound},
+		{" dnsmasq", EngineDnsmasq}, // leading whitespace must be trimmed
+		{"dnsmasq", EngineDnsmasq},
+	}
+	for _, tc := range cases {
+		if got := engineFromString(tc.in); got != tc.want {
+			t.Errorf("engineFromString(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// Unknown values surface verbatim so Validate() reports them.
+	if got := engineFromString("bind"); got != Engine("bind") {
+		t.Errorf("engineFromString(bind) = %q, want %q", got, Engine("bind"))
+	}
+}

--- a/providers/opnsense/doc.go
+++ b/providers/opnsense/doc.go
@@ -1,0 +1,56 @@
+// Package opnsense implements the DNSWeaver provider interface for OPNsense
+// firewalls, driven by the OPNsense REST API.
+//
+// OPNsense ships with two DNS resolvers: Unbound (default) and Dnsmasq (24.7+).
+// Both expose "host override" records through mirror-shaped REST endpoints, so
+// a single provider covers both via an ENGINE setting.
+//
+// The provider is strictly REST-based. It never SSH's into OPNsense or edits
+// config.xml directly — those approaches fight OPNsense's own state machine
+// and break under HA sync, firmware upgrades, and backup/restore. Operators
+// who want file-level access to a standalone Linux dnsmasq should use the
+// dedicated dnsmasq provider instead.
+//
+// # Configuration
+//
+// Required environment variables (with DNSWEAVER_{INSTANCE}_ prefix):
+//
+//	URL         OPNsense base URL (e.g. https://opnsense.internal)
+//	API_KEY     OPNsense API key (per-user, generated in System > Access > Users)
+//	API_SECRET  OPNsense API secret (paired with API_KEY)
+//	ENGINE      "unbound" (default) or "dnsmasq"
+//
+// Optional:
+//
+//	ZONE              DNS zone for record filtering (e.g. "example.com")
+//	TTL               Informational only — host overrides have no per-record TTL
+//	RECONFIGURE_MODE  "per_write" (default) or "never"
+//	TLS_*             Unified framework TLS knobs (CA file, skip verify, etc.)
+//
+// Credentials support the _FILE suffix (Docker secrets):
+//
+//	API_KEY_FILE=/run/secrets/opnsense_key
+//	API_SECRET_FILE=/run/secrets/opnsense_secret
+//
+// # Ownership
+//
+// Neither Unbound nor Dnsmasq host overrides expose TXT records, so ownership
+// TXT records are unavailable (Capabilities.SupportsOwnershipTXT is false).
+// The provider tags each record it manages with a `dnsweaver:{instance}` marker
+// in the OPNsense description field, and List returns only records carrying
+// that marker — so operator-managed host overrides are never touched.
+//
+// # Reconfigure semantics
+//
+// OPNsense requires a "reconfigure" call to actually reload the resolver
+// after mutations. The reconfigure endpoint fully reloads the daemon, so:
+//
+//   - per_write (default): reconfigure after every Create/Delete
+//   - never: skip auto-reconfigure entirely (operator triggers it out of band)
+//
+// v1 does not batch/debounce reconfigure calls; that is a planned follow-up.
+//
+// # Record types (v1)
+//
+// A and AAAA on both engines. CNAME and other types are deferred.
+package opnsense

--- a/providers/opnsense/engine.go
+++ b/providers/opnsense/engine.go
@@ -1,0 +1,68 @@
+package opnsense
+
+// hostRecord is the engine-agnostic representation of a single OPNsense
+// host override. Both the Unbound and Dnsmasq engines map their native
+// payload shapes to and from this struct.
+type hostRecord struct {
+	// UUID is OPNsense's internal identifier for the row. Empty on records
+	// we are about to create; populated on records returned by search.
+	UUID string
+	// Hostname is the short hostname (no domain). "web" in "web.example.com".
+	Hostname string
+	// Domain is the parent domain. "example.com" in "web.example.com".
+	Domain string
+	// Type is the DNS record type: "A" or "AAAA". CNAME and other types are
+	// deferred to a future release.
+	Type string
+	// Target is the IP address for A/AAAA records.
+	Target string
+	// Description is a free-form field. dnsweaver stores its ownership marker here.
+	Description string
+	// Enabled reflects the OPNsense "enabled" toggle on the row.
+	Enabled bool
+}
+
+// engine adapts the shared OPNsense REST surface (search / add / delete /
+// reconfigure) to the per-resolver endpoint paths and JSON payload shapes.
+//
+// Each concrete engine (unbound, dnsmasq) is a stateless value: the client
+// holds all mutable state (HTTP transport, credentials, logger).
+type engine interface {
+	// Name returns the engine identifier ("unbound" or "dnsmasq"). Used in
+	// logs and errors; does not affect wire behavior.
+	Name() Engine
+
+	// SearchPath is the API path for listing host overrides.
+	// e.g. "/api/unbound/settings/searchHostOverride".
+	SearchPath() string
+
+	// AddPath is the API path for creating a new host override.
+	AddPath() string
+
+	// DelPath returns the API path for deleting a host override by UUID.
+	DelPath(uuid string) string
+
+	// ReconfigurePath is the API path that reloads the resolver so newly
+	// written records take effect.
+	ReconfigurePath() string
+
+	// EncodeAddPayload marshals a hostRecord into the engine's add-request
+	// JSON body.
+	EncodeAddPayload(rec hostRecord) ([]byte, error)
+
+	// DecodeSearchResponse parses the engine's search response into
+	// hostRecords. Errors from malformed responses surface as-is so the
+	// caller can attach transport context.
+	DecodeSearchResponse(body []byte) ([]hostRecord, error)
+}
+
+// newEngine returns the engine implementation for the given identifier.
+// The caller must have already validated the Engine value via Config.Validate.
+func newEngine(e Engine) engine {
+	switch e {
+	case EngineDnsmasq:
+		return dnsmasqEngine{}
+	default:
+		return unboundEngine{}
+	}
+}

--- a/providers/opnsense/engine_dnsmasq.go
+++ b/providers/opnsense/engine_dnsmasq.go
@@ -1,0 +1,105 @@
+package opnsense
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// dnsmasqEngine implements engine for OPNsense's Dnsmasq resolver (24.7+).
+//
+// Endpoints:
+//
+//	POST /api/dnsmasq/settings/searchHost
+//	POST /api/dnsmasq/settings/addHost
+//	POST /api/dnsmasq/settings/delHost/{uuid}
+//	POST /api/dnsmasq/service/reconfigure
+//
+// Add payload wraps the host in a top-level "host" key with dnsmasq's
+// field names ("host", "ip", "descr" — not "hostname", "server",
+// "description" like Unbound uses). Dnsmasq host entries do not carry an
+// explicit record-type field: the resolver picks A or AAAA based on the
+// IP address family.
+type dnsmasqEngine struct{}
+
+func (dnsmasqEngine) Name() Engine { return EngineDnsmasq }
+
+func (dnsmasqEngine) SearchPath() string      { return "/api/dnsmasq/settings/searchHost" }
+func (dnsmasqEngine) AddPath() string         { return "/api/dnsmasq/settings/addHost" }
+func (dnsmasqEngine) ReconfigurePath() string { return "/api/dnsmasq/service/reconfigure" }
+
+func (dnsmasqEngine) DelPath(uuid string) string {
+	return "/api/dnsmasq/settings/delHost/" + uuid
+}
+
+type dnsmasqHostPayload struct {
+	Host dnsmasqHostFields `json:"host"`
+}
+
+type dnsmasqHostFields struct {
+	Enabled string `json:"enabled"`
+	Host    string `json:"host"`
+	Domain  string `json:"domain"`
+	IP      string `json:"ip"`
+	Descr   string `json:"descr"`
+}
+
+func (dnsmasqEngine) EncodeAddPayload(rec hostRecord) ([]byte, error) {
+	enabled := "0"
+	if rec.Enabled {
+		enabled = "1"
+	}
+	// Dnsmasq infers the record type from the IP family, so we don't
+	// serialize rec.Type. We do validate that Target parses as an IP so
+	// we fail early instead of pushing garbage to OPNsense.
+	if net.ParseIP(rec.Target) == nil {
+		return nil, fmt.Errorf("dnsmasq engine requires an IP target, got %q", rec.Target)
+	}
+	return json.Marshal(dnsmasqHostPayload{
+		Host: dnsmasqHostFields{
+			Enabled: enabled,
+			Host:    rec.Hostname,
+			Domain:  rec.Domain,
+			IP:      rec.Target,
+			Descr:   rec.Description,
+		},
+	})
+}
+
+type dnsmasqSearchResponse struct {
+	Rows []dnsmasqSearchRow `json:"rows"`
+}
+
+type dnsmasqSearchRow struct {
+	UUID    string `json:"uuid"`
+	Enabled string `json:"enabled"`
+	Host    string `json:"host"`
+	Domain  string `json:"domain"`
+	IP      string `json:"ip"`
+	Descr   string `json:"descr"`
+}
+
+func (dnsmasqEngine) DecodeSearchResponse(body []byte) ([]hostRecord, error) {
+	var resp dnsmasqSearchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decoding dnsmasq search response: %w", err)
+	}
+	records := make([]hostRecord, 0, len(resp.Rows))
+	for _, row := range resp.Rows {
+		rrType := "A"
+		if ip := net.ParseIP(strings.TrimSpace(row.IP)); ip != nil && ip.To4() == nil {
+			rrType = "AAAA"
+		}
+		records = append(records, hostRecord{
+			UUID:        row.UUID,
+			Hostname:    row.Host,
+			Domain:      row.Domain,
+			Type:        rrType,
+			Target:      row.IP,
+			Description: row.Descr,
+			Enabled:     row.Enabled == "1",
+		})
+	}
+	return records, nil
+}

--- a/providers/opnsense/engine_test.go
+++ b/providers/opnsense/engine_test.go
@@ -1,0 +1,167 @@
+package opnsense
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestUnboundEngine_Paths(t *testing.T) {
+	e := unboundEngine{}
+	if got := e.SearchPath(); got != "/api/unbound/settings/searchHostOverride" {
+		t.Errorf("SearchPath = %q", got)
+	}
+	if got := e.AddPath(); got != "/api/unbound/settings/addHostOverride" {
+		t.Errorf("AddPath = %q", got)
+	}
+	if got := e.DelPath("uu-id"); got != "/api/unbound/settings/delHostOverride/uu-id" {
+		t.Errorf("DelPath = %q", got)
+	}
+	if got := e.ReconfigurePath(); got != "/api/unbound/service/reconfigure" {
+		t.Errorf("ReconfigurePath = %q", got)
+	}
+}
+
+func TestUnboundEngine_EncodeAddPayload(t *testing.T) {
+	e := unboundEngine{}
+	body, err := e.EncodeAddPayload(hostRecord{
+		Hostname: "web", Domain: "example.com", Type: "A",
+		Target: "10.0.0.5", Description: "dnsweaver:opns", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("EncodeAddPayload error: %v", err)
+	}
+
+	var decoded map[string]map[string]string
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	host := decoded["host"]
+	if host == nil {
+		t.Fatalf("payload missing host key: %s", body)
+	}
+	// Boolean-as-string: OPNsense form endpoints require "1"/"0".
+	if host["enabled"] != "1" {
+		t.Errorf("enabled = %q, want %q", host["enabled"], "1")
+	}
+	if host["hostname"] != "web" || host["domain"] != "example.com" {
+		t.Errorf("hostname/domain wrong: %+v", host)
+	}
+	if host["rr"] != "A" || host["server"] != "10.0.0.5" {
+		t.Errorf("rr/server wrong: %+v", host)
+	}
+	if host["description"] != "dnsweaver:opns" {
+		t.Errorf("description wrong: %+v", host)
+	}
+}
+
+func TestUnboundEngine_DecodeSearchResponse(t *testing.T) {
+	e := unboundEngine{}
+	// OPNsense occasionally returns "A (IPv4 Address)" style RR labels;
+	// the decoder should normalize to the token.
+	body := []byte(`{"rows":[
+	  {"uuid":"u1","enabled":"1","hostname":"a","domain":"example.com","rr":"A (IPv4 Address)","server":"10.0.0.1","description":"dnsweaver:opns"},
+	  {"uuid":"u2","enabled":"0","hostname":"b","domain":"example.com","rr":"AAAA","server":"2001:db8::1","description":"manual"}
+	],"rowCount":2,"total":2,"current":1}`)
+	recs, err := e.DecodeSearchResponse(body)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2", len(recs))
+	}
+	if recs[0].UUID != "u1" || recs[0].Type != "A" || !recs[0].Enabled {
+		t.Errorf("row 0 unexpected: %+v", recs[0])
+	}
+	if recs[1].Type != "AAAA" || recs[1].Enabled {
+		t.Errorf("row 1 unexpected: %+v", recs[1])
+	}
+}
+
+func TestDnsmasqEngine_Paths(t *testing.T) {
+	e := dnsmasqEngine{}
+	if got := e.SearchPath(); got != "/api/dnsmasq/settings/searchHost" {
+		t.Errorf("SearchPath = %q", got)
+	}
+	if got := e.AddPath(); got != "/api/dnsmasq/settings/addHost" {
+		t.Errorf("AddPath = %q", got)
+	}
+	if got := e.DelPath("u"); got != "/api/dnsmasq/settings/delHost/u" {
+		t.Errorf("DelPath = %q", got)
+	}
+}
+
+func TestDnsmasqEngine_EncodeAddPayload_A(t *testing.T) {
+	e := dnsmasqEngine{}
+	body, err := e.EncodeAddPayload(hostRecord{
+		Hostname: "web", Domain: "example.com", Type: "A",
+		Target: "10.0.0.5", Description: "dnsweaver:opns", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var decoded map[string]map[string]string
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	host := decoded["host"]
+	// Dnsmasq uses different field names than Unbound.
+	if host["host"] != "web" || host["domain"] != "example.com" {
+		t.Errorf("host/domain wrong: %+v", host)
+	}
+	if host["ip"] != "10.0.0.5" {
+		t.Errorf("ip = %q, want %q", host["ip"], "10.0.0.5")
+	}
+	if host["descr"] != "dnsweaver:opns" {
+		t.Errorf("descr wrong: %+v", host)
+	}
+	if _, hasRR := host["rr"]; hasRR {
+		t.Errorf("dnsmasq payload should not carry rr field: %+v", host)
+	}
+}
+
+func TestDnsmasqEngine_EncodeAddPayload_RejectsNonIPTarget(t *testing.T) {
+	e := dnsmasqEngine{}
+	_, err := e.EncodeAddPayload(hostRecord{
+		Hostname: "web", Domain: "example.com", Type: "A",
+		Target: "not-an-ip", Description: "dnsweaver:opns", Enabled: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for non-IP target")
+	}
+	if !strings.Contains(err.Error(), "IP target") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestDnsmasqEngine_DecodeSearchResponse_InfersType(t *testing.T) {
+	e := dnsmasqEngine{}
+	body := []byte(`{"rows":[
+	  {"uuid":"u1","enabled":"1","host":"a","domain":"example.com","ip":"10.0.0.1","descr":"dnsweaver:opns"},
+	  {"uuid":"u2","enabled":"1","host":"b","domain":"example.com","ip":"2001:db8::1","descr":"dnsweaver:opns"}
+	]}`)
+	recs, err := e.DecodeSearchResponse(body)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if recs[0].Type != "A" {
+		t.Errorf("row 0 type = %q, want A", recs[0].Type)
+	}
+	if recs[1].Type != "AAAA" {
+		t.Errorf("row 1 type = %q, want AAAA", recs[1].Type)
+	}
+}
+
+func TestNewEngine_Dispatch(t *testing.T) {
+	if newEngine(EngineUnbound).Name() != EngineUnbound {
+		t.Error("unbound dispatch")
+	}
+	if newEngine(EngineDnsmasq).Name() != EngineDnsmasq {
+		t.Error("dnsmasq dispatch")
+	}
+	// Unknown engines default to unbound so Validate can still catch
+	// misconfiguration without the engine dispatcher panicking.
+	if newEngine(Engine("bogus")).Name() != EngineUnbound {
+		t.Error("default dispatch")
+	}
+}

--- a/providers/opnsense/engine_unbound.go
+++ b/providers/opnsense/engine_unbound.go
@@ -1,0 +1,106 @@
+package opnsense
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// unboundEngine implements engine for OPNsense's Unbound resolver.
+//
+// Endpoints (as of OPNsense 24.x):
+//
+//	POST /api/unbound/settings/searchHostOverride
+//	POST /api/unbound/settings/addHostOverride
+//	POST /api/unbound/settings/delHostOverride/{uuid}
+//	POST /api/unbound/service/reconfigure
+//
+// Add payload wraps the host in a top-level "host" key:
+//
+//	{"host": {"enabled":"1","hostname":"web","domain":"example.com",
+//	          "rr":"A","server":"10.0.0.1","description":"dnsweaver:foo"}}
+type unboundEngine struct{}
+
+func (unboundEngine) Name() Engine { return EngineUnbound }
+
+func (unboundEngine) SearchPath() string      { return "/api/unbound/settings/searchHostOverride" }
+func (unboundEngine) AddPath() string         { return "/api/unbound/settings/addHostOverride" }
+func (unboundEngine) ReconfigurePath() string { return "/api/unbound/service/reconfigure" }
+
+func (unboundEngine) DelPath(uuid string) string {
+	return "/api/unbound/settings/delHostOverride/" + uuid
+}
+
+// unboundHostPayload is the JSON body shape OPNsense's Unbound API expects.
+// All fields are strings — OPNsense's API is stringly-typed for form-style
+// endpoints, including the "enabled" boolean which is "0" or "1".
+type unboundHostPayload struct {
+	Host unboundHostFields `json:"host"`
+}
+
+type unboundHostFields struct {
+	Enabled     string `json:"enabled"`
+	Hostname    string `json:"hostname"`
+	Domain      string `json:"domain"`
+	RR          string `json:"rr"`
+	Server      string `json:"server"`
+	Description string `json:"description"`
+}
+
+func (unboundEngine) EncodeAddPayload(rec hostRecord) ([]byte, error) {
+	enabled := "0"
+	if rec.Enabled {
+		enabled = "1"
+	}
+	return json.Marshal(unboundHostPayload{
+		Host: unboundHostFields{
+			Enabled:     enabled,
+			Hostname:    rec.Hostname,
+			Domain:      rec.Domain,
+			RR:          rec.Type,
+			Server:      rec.Target,
+			Description: rec.Description,
+		},
+	})
+}
+
+// unboundSearchResponse mirrors the OPNsense grid response shape.
+type unboundSearchResponse struct {
+	Rows []unboundSearchRow `json:"rows"`
+}
+
+type unboundSearchRow struct {
+	UUID        string `json:"uuid"`
+	Enabled     string `json:"enabled"`
+	Hostname    string `json:"hostname"`
+	Domain      string `json:"domain"`
+	RR          string `json:"rr"`
+	Server      string `json:"server"`
+	Description string `json:"description"`
+}
+
+func (unboundEngine) DecodeSearchResponse(body []byte) ([]hostRecord, error) {
+	var resp unboundSearchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decoding unbound search response: %w", err)
+	}
+	records := make([]hostRecord, 0, len(resp.Rows))
+	for _, row := range resp.Rows {
+		// OPNsense sometimes returns the RR name with a trailing description,
+		// e.g. "A (IPv4 Address)". Trim to the token to normalize.
+		rrType := strings.TrimSpace(row.RR)
+		if idx := strings.Index(rrType, " "); idx >= 0 {
+			rrType = rrType[:idx]
+		}
+		records = append(records, hostRecord{
+			UUID:        row.UUID,
+			Hostname:    row.Hostname,
+			Domain:      row.Domain,
+			Type:        strings.ToUpper(rrType),
+			Target:      row.Server,
+			Description: row.Description,
+			Enabled:     row.Enabled == "1",
+		})
+	}
+	return records, nil
+}

--- a/providers/opnsense/factory.go
+++ b/providers/opnsense/factory.go
@@ -1,0 +1,34 @@
+package opnsense
+
+import (
+	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// Factory returns a provider.Factory for creating OPNsense provider instances.
+// The framework calls this once per configured DNSWEAVER_INSTANCES entry of
+// type "opnsense".
+//
+// TLS is configured framework-wide via cfg.HTTP.TLS — this provider does not
+// re-interpret TLS settings. httputil.NewClient itself emits the WARN when
+// verification is disabled, so no duplicate warning here.
+func Factory() provider.Factory {
+	return func(cfg provider.FactoryConfig) (provider.Provider, error) {
+		providerCfg, err := LoadConfigFromMap(cfg.Name, cfg.ProviderConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		httpClient := httputil.NewClient(&httputil.ClientConfig{
+			Timeout:   cfg.HTTP.Timeout,
+			TLS:       cfg.HTTP.TLS,
+			UserAgent: cfg.HTTP.UserAgent,
+			Logger:    cfg.HTTP.Logger,
+		})
+
+		return New(cfg.Name, providerCfg,
+			WithProviderHTTPClient(httpClient),
+			WithProviderLogger(cfg.HTTP.Logger),
+		)
+	}
+}

--- a/providers/opnsense/ownership.go
+++ b/providers/opnsense/ownership.go
@@ -1,0 +1,48 @@
+package opnsense
+
+import (
+	"strings"
+)
+
+// ownershipPrefix marks a host override description as dnsweaver-managed.
+// Format: "dnsweaver:{instance}[ | user-supplied text]"
+//
+// Neither Unbound nor Dnsmasq host overrides expose TXT records, so we
+// piggy-back ownership signaling on the description field. The prefix lets
+// operators see at a glance which OPNsense records dnsweaver owns, and lets
+// List() ignore operator-managed host overrides so orphan cleanup can never
+// delete them.
+const ownershipPrefix = "dnsweaver:"
+
+// ownershipDescription returns the description string to write on records
+// this instance manages. Operators viewing the OPNsense UI see the marker
+// plus the instance name — enough to answer "why does this record exist?"
+func ownershipDescription(instanceName string) string {
+	return ownershipPrefix + instanceName
+}
+
+// isOwnedBy returns true if a description was written by any dnsweaver
+// instance. Used by List() to filter to dnsweaver-managed records only.
+func isOwnedBy(description string) bool {
+	return strings.HasPrefix(strings.TrimSpace(description), ownershipPrefix)
+}
+
+// ownedByInstance returns true if a description was written by the given
+// dnsweaver instance specifically.
+func ownedByInstance(description, instanceName string) bool {
+	trimmed := strings.TrimSpace(description)
+	if !strings.HasPrefix(trimmed, ownershipPrefix) {
+		return false
+	}
+	rest := trimmed[len(ownershipPrefix):]
+	// Match "{instance}" or "{instance} | anything" or "{instance}\n..."
+	if rest == instanceName {
+		return true
+	}
+	for _, sep := range []string{" ", "|", "\t", "\n"} {
+		if strings.HasPrefix(rest, instanceName+sep) {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/opnsense/ownership_test.go
+++ b/providers/opnsense/ownership_test.go
@@ -1,0 +1,49 @@
+package opnsense
+
+import "testing"
+
+func TestOwnershipDescription(t *testing.T) {
+	got := ownershipDescription("opns-fw")
+	want := "dnsweaver:opns-fw"
+	if got != want {
+		t.Errorf("ownershipDescription = %q, want %q", got, want)
+	}
+}
+
+func TestIsOwnedBy(t *testing.T) {
+	cases := map[string]bool{
+		"dnsweaver:foo":              true,
+		"  dnsweaver:foo":            true,
+		"dnsweaver:foo | edited":     true,
+		"manual entry":               false,
+		"":                           false,
+		"legacy dnsweaver placement": false,
+	}
+	for input, want := range cases {
+		if got := isOwnedBy(input); got != want {
+			t.Errorf("isOwnedBy(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestOwnedByInstance(t *testing.T) {
+	cases := []struct {
+		desc     string
+		instance string
+		want     bool
+	}{
+		{"dnsweaver:opns", "opns", true},
+		{"dnsweaver:opns | manual note", "opns", true},
+		{"dnsweaver:opns\ncomment", "opns", true},
+		{"dnsweaver:opns\tcomment", "opns", true},
+		{"dnsweaver:opns-other", "opns", false},
+		{"dnsweaver:other", "opns", false},
+		{"manual", "opns", false},
+		{"", "opns", false},
+	}
+	for _, tc := range cases {
+		if got := ownedByInstance(tc.desc, tc.instance); got != tc.want {
+			t.Errorf("ownedByInstance(%q, %q) = %v, want %v", tc.desc, tc.instance, got, tc.want)
+		}
+	}
+}

--- a/providers/opnsense/provider.go
+++ b/providers/opnsense/provider.go
@@ -1,0 +1,419 @@
+package opnsense
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// Provider implements provider.Provider for OPNsense host overrides.
+//
+// One provider instance covers exactly one OPNsense resolver engine on one
+// firewall. Deploy multiple instances (with the same URL, different names)
+// if you want to write the same record set to both engines on one firewall.
+type Provider struct {
+	name   string
+	url    string // recorded for Identity reporting
+	zone   string
+	ttl    int
+	engine engine
+	mode   ReconfigureMode
+	client *Client
+	logger *slog.Logger
+}
+
+// Compile-time interface check.
+var _ provider.Provider = (*Provider)(nil)
+
+// ProviderOption configures a Provider at construction time.
+type ProviderOption func(*Provider)
+
+// WithProviderLogger sets a structured logger for the provider.
+func WithProviderLogger(logger *slog.Logger) ProviderOption {
+	return func(p *Provider) {
+		if logger != nil {
+			p.logger = logger
+		}
+	}
+}
+
+// WithProviderHTTPClient replaces the client's HTTP transport. Used by the
+// factory to inject the framework's TLS-configured HTTP client, and by tests
+// to point at an httptest.Server.
+func WithProviderHTTPClient(h *http.Client) ProviderOption {
+	return func(p *Provider) {
+		if h != nil && p.client != nil {
+			p.client.httpClient = h
+		}
+	}
+}
+
+// WithClient replaces the API client (test-only helper).
+func WithClient(c *Client) ProviderOption {
+	return func(p *Provider) { p.client = c }
+}
+
+// New constructs an OPNsense Provider. cfg must be validated by the caller
+// (or via LoadConfig/LoadConfigFromMap, which validate on load).
+func New(name string, cfg *Config, opts ...ProviderOption) (*Provider, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	p := &Provider{
+		name:   name,
+		url:    cfg.URL,
+		zone:   cfg.Zone,
+		ttl:    cfg.TTL,
+		engine: newEngine(cfg.Engine),
+		mode:   cfg.ReconfigureMode,
+		logger: slog.Default(),
+		client: NewClient(cfg.URL, cfg.APIKey, cfg.APISecret),
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p, nil
+}
+
+// Name returns the provider instance name.
+func (p *Provider) Name() string { return p.name }
+
+// Type returns "opnsense".
+func (p *Provider) Type() string { return "opnsense" }
+
+// Identity uniquely identifies the backend this provider writes to. Two
+// opnsense instances share an identity when they target the same URL, engine,
+// and zone. Instances that share an identity also share a record set on
+// OPNsense, so the reconciler treats them as first-match-wins to avoid
+// competing writes (see pkg/provider docs).
+func (p *Provider) Identity() provider.ProviderIdentity {
+	return provider.ProviderIdentity{
+		Type:     "opnsense/" + string(p.engine.Name()),
+		Endpoint: p.url,
+		Zone:     p.zone,
+	}
+}
+
+// Capabilities describes what the OPNsense provider can do. Host overrides
+// do not carry TXT records, so ownership TXT tracking is unavailable — the
+// reconciler falls back to target-matching for orphan detection. Native
+// update is unsupported in v1; the reconciler will use delete+create.
+func (p *Provider) Capabilities() provider.Capabilities {
+	return provider.Capabilities{
+		SupportsOwnershipTXT: false,
+		SupportsNativeUpdate: false,
+		SupportedRecordTypes: []provider.RecordType{
+			provider.RecordTypeA,
+			provider.RecordTypeAAAA,
+		},
+	}
+}
+
+// Ping checks connectivity to OPNsense by issuing a lightweight search
+// against the configured engine. A successful search proves the API is
+// reachable, credentials work, and the target engine is enabled — three
+// failure modes that all matter for downstream operations.
+func (p *Provider) Ping(ctx context.Context) error {
+	body, status, err := p.client.do(ctx, p.engine.SearchPath(), newSearchRequest())
+	if err != nil {
+		return fmt.Errorf("%w: %w", provider.ErrProviderUnavailable, err)
+	}
+	if statusErr := mapStatusError(status, body); statusErr != nil {
+		return statusErr
+	}
+	// Even a decode failure at this stage is a real signal: OPNsense is
+	// reachable but returning something the engine can't parse, which
+	// usually means the engine module is disabled or a version mismatch.
+	if _, err := p.engine.DecodeSearchResponse(body); err != nil {
+		return fmt.Errorf("opnsense reachable but %s search response is unparseable (is the %s module enabled?): %w",
+			p.engine.Name(), p.engine.Name(), err)
+	}
+	return nil
+}
+
+// List returns all dnsweaver-managed host overrides in the configured zone.
+// Records without the dnsweaver ownership marker in their description are
+// intentionally omitted, so operator-managed host overrides cannot be
+// accidentally deleted by orphan cleanup.
+func (p *Provider) List(ctx context.Context) ([]provider.Record, error) {
+	body, status, err := p.client.do(ctx, p.engine.SearchPath(), newSearchRequest())
+	if err != nil {
+		return nil, fmt.Errorf("listing records: %w", err)
+	}
+	if statusErr := mapStatusError(status, body); statusErr != nil {
+		return nil, statusErr
+	}
+	rows, err := p.engine.DecodeSearchResponse(body)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]provider.Record, 0, len(rows))
+	for _, r := range rows {
+		// Skip records dnsweaver didn't create. This is the load-bearing
+		// safety check: without it, orphan cleanup would happily delete
+		// every operator-managed host override in the zone.
+		if !isOwnedBy(r.Description) {
+			continue
+		}
+
+		fqdn := joinFQDN(r.Hostname, r.Domain)
+		if p.zone != "" && !inZone(fqdn, p.zone) {
+			continue
+		}
+
+		rt, ok := recordTypeFromString(r.Type)
+		if !ok {
+			p.logger.Debug("skipping record with unsupported type",
+				slog.String("provider", p.name),
+				slog.String("fqdn", fqdn),
+				slog.String("type", r.Type),
+			)
+			continue
+		}
+
+		records = append(records, provider.Record{
+			Hostname:   fqdn,
+			Type:       rt,
+			Target:     r.Target,
+			TTL:        p.ttl,
+			ProviderID: r.UUID,
+		})
+	}
+
+	p.logger.Debug("listed records",
+		slog.String("provider", p.name),
+		slog.String("engine", string(p.engine.Name())),
+		slog.Int("total_rows", len(rows)),
+		slog.Int("matched", len(records)),
+	)
+	return records, nil
+}
+
+// Create adds a new host override. TXT records are silently skipped
+// (OPNsense host overrides do not support TXT). Other unsupported types
+// return an error so misconfiguration surfaces loudly.
+func (p *Provider) Create(ctx context.Context, record provider.Record) error {
+	switch record.Type {
+	case provider.RecordTypeA, provider.RecordTypeAAAA:
+		// supported
+	case provider.RecordTypeTXT:
+		p.logger.Debug("skipping TXT record (opnsense host overrides do not support TXT)",
+			slog.String("provider", p.name),
+			slog.String("hostname", record.Hostname))
+		return nil
+	default:
+		return fmt.Errorf("%s records are not supported by the opnsense provider (v1: A/AAAA only)", record.Type)
+	}
+
+	if net.ParseIP(record.Target) == nil {
+		return fmt.Errorf("opnsense provider requires an IP target for %s, got %q", record.Type, record.Target)
+	}
+
+	hostname, domain, ok := splitFQDN(record.Hostname)
+	if !ok {
+		return fmt.Errorf("hostname %q must be a fully qualified name with at least one dot", record.Hostname)
+	}
+
+	rec := hostRecord{
+		Hostname:    hostname,
+		Domain:      domain,
+		Type:        string(record.Type),
+		Target:      record.Target,
+		Description: ownershipDescription(p.name),
+		Enabled:     true,
+	}
+
+	payload, err := p.engine.EncodeAddPayload(rec)
+	if err != nil {
+		return fmt.Errorf("encoding add payload: %w", err)
+	}
+
+	body, status, err := p.client.do(ctx, p.engine.AddPath(), payload)
+	if err != nil {
+		return fmt.Errorf("creating record %s: %w", record.Hostname, err)
+	}
+	if statusErr := mapStatusError(status, body); statusErr != nil {
+		return statusErr
+	}
+	if err := parseMutationResponse(body); err != nil {
+		return fmt.Errorf("creating record %s: %w", record.Hostname, err)
+	}
+
+	if err := p.maybeReconfigure(ctx); err != nil {
+		return fmt.Errorf("record %s created but reconfigure failed: %w", record.Hostname, err)
+	}
+
+	p.logger.Info("created DNS record",
+		slog.String("provider", p.name),
+		slog.String("engine", string(p.engine.Name())),
+		slog.String("hostname", record.Hostname),
+		slog.String("type", string(record.Type)),
+		slog.String("target", record.Target),
+	)
+	return nil
+}
+
+// Delete removes a host override. The record's ProviderID (the OPNsense
+// UUID) is preferred; if empty we fall back to a lookup by (hostname, type,
+// target) so callers who construct records by hand still work.
+func (p *Provider) Delete(ctx context.Context, record provider.Record) error {
+	switch record.Type {
+	case provider.RecordTypeA, provider.RecordTypeAAAA:
+		// supported
+	case provider.RecordTypeTXT:
+		return nil
+	default:
+		return fmt.Errorf("%s records are not supported by the opnsense provider", record.Type)
+	}
+
+	uuid := record.ProviderID
+	if uuid == "" {
+		found, err := p.findUUID(ctx, record)
+		if err != nil {
+			return err
+		}
+		uuid = found
+	}
+	if uuid == "" {
+		return provider.ErrNotFound
+	}
+
+	body, status, err := p.client.do(ctx, p.engine.DelPath(uuid), nil)
+	if err != nil {
+		return fmt.Errorf("deleting record %s: %w", record.Hostname, err)
+	}
+	if statusErr := mapStatusError(status, body); statusErr != nil {
+		return statusErr
+	}
+	if err := parseMutationResponse(body); err != nil {
+		return fmt.Errorf("deleting record %s: %w", record.Hostname, err)
+	}
+
+	if err := p.maybeReconfigure(ctx); err != nil {
+		return fmt.Errorf("record %s deleted but reconfigure failed: %w", record.Hostname, err)
+	}
+
+	p.logger.Info("deleted DNS record",
+		slog.String("provider", p.name),
+		slog.String("engine", string(p.engine.Name())),
+		slog.String("hostname", record.Hostname),
+		slog.String("type", string(record.Type)),
+	)
+	return nil
+}
+
+// findUUID looks up a record by (hostname, type, target). Only searches
+// dnsweaver-owned rows so we can never accidentally delete an operator's
+// host override that happens to share hostname/target.
+func (p *Provider) findUUID(ctx context.Context, record provider.Record) (string, error) {
+	body, status, err := p.client.do(ctx, p.engine.SearchPath(), newSearchRequest())
+	if err != nil {
+		return "", fmt.Errorf("searching for %s: %w", record.Hostname, err)
+	}
+	if statusErr := mapStatusError(status, body); statusErr != nil {
+		return "", statusErr
+	}
+	rows, err := p.engine.DecodeSearchResponse(body)
+	if err != nil {
+		return "", err
+	}
+
+	targetFQDN := strings.TrimSuffix(strings.ToLower(record.Hostname), ".")
+	for _, r := range rows {
+		if !ownedByInstance(r.Description, p.name) {
+			continue
+		}
+		if !strings.EqualFold(joinFQDN(r.Hostname, r.Domain), targetFQDN) {
+			continue
+		}
+		if !strings.EqualFold(r.Type, string(record.Type)) {
+			continue
+		}
+		if record.Target != "" && !strings.EqualFold(r.Target, record.Target) {
+			continue
+		}
+		return r.UUID, nil
+	}
+	return "", nil
+}
+
+// maybeReconfigure triggers a resolver reload when the configured mode calls
+// for it. Errors are propagated so callers can decide whether to retry the
+// underlying mutation.
+func (p *Provider) maybeReconfigure(ctx context.Context) error {
+	if p.mode != ReconfigureModePerWrite {
+		return nil
+	}
+	body, status, err := p.client.do(ctx, p.engine.ReconfigurePath(), nil)
+	if err != nil {
+		return fmt.Errorf("reconfigure: %w", err)
+	}
+	if statusErr := mapStatusError(status, body); statusErr != nil {
+		return fmt.Errorf("reconfigure: %w", statusErr)
+	}
+	// Reconfigure responses use a "status" field ("ok") rather than the
+	// standard result envelope. Anything non-2xx has already been rejected
+	// by mapStatusError, so we don't need to parse the body strictly here.
+	return nil
+}
+
+// joinFQDN glues a hostname and domain into a fully qualified name, trimming
+// trailing dots and lowercasing so comparisons are stable.
+func joinFQDN(hostname, domain string) string {
+	hostname = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(hostname)), ".")
+	domain = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(domain)), ".")
+	switch {
+	case hostname == "" && domain == "":
+		return ""
+	case hostname == "":
+		return domain
+	case domain == "":
+		return hostname
+	default:
+		return hostname + "." + domain
+	}
+}
+
+// splitFQDN cleaves a FQDN into (hostname, domain). Returns ok=false if
+// there is no dot to split on — OPNsense host overrides always require
+// both a hostname and a domain.
+func splitFQDN(fqdn string) (hostname, domain string, ok bool) {
+	fqdn = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(fqdn)), ".")
+	idx := strings.Index(fqdn, ".")
+	if idx <= 0 || idx == len(fqdn)-1 {
+		return "", "", false
+	}
+	return fqdn[:idx], fqdn[idx+1:], true
+}
+
+// inZone returns true if fqdn is equal to or a subdomain of zone.
+func inZone(fqdn, zone string) bool {
+	fqdn = strings.TrimSuffix(strings.ToLower(fqdn), ".")
+	zone = strings.TrimSuffix(strings.ToLower(zone), ".")
+	if fqdn == zone {
+		return true
+	}
+	return strings.HasSuffix(fqdn, "."+zone)
+}
+
+// recordTypeFromString maps OPNsense's RR strings to framework record types.
+func recordTypeFromString(s string) (provider.RecordType, bool) {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "A":
+		return provider.RecordTypeA, true
+	case "AAAA":
+		return provider.RecordTypeAAAA, true
+	default:
+		return "", false
+	}
+}

--- a/providers/opnsense/provider_test.go
+++ b/providers/opnsense/provider_test.go
@@ -1,0 +1,559 @@
+package opnsense
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// fakeOPNsense simulates the OPNsense host-override endpoints for a given
+// engine. It supports search / add / delete / reconfigure and records every
+// request so tests can assert on wire behavior. Auth is validated against
+// the fixed key/secret pair below.
+type fakeOPNsense struct {
+	t         *testing.T
+	engine    Engine
+	apiKey    string
+	apiSecret string
+
+	mu           sync.Mutex
+	rows         []map[string]string // simulated database rows
+	nextUUID     int
+	reloadCount  int
+	requestPaths []string
+	requestBody  map[string][]byte
+	// override lets a test inject a canned response for a specific path.
+	override map[string]func(w http.ResponseWriter, r *http.Request)
+}
+
+func newFakeOPNsense(t *testing.T, engine Engine) *fakeOPNsense {
+	t.Helper()
+	return &fakeOPNsense{
+		t:           t,
+		engine:      engine,
+		apiKey:      "test-key",
+		apiSecret:   "test-secret",
+		rows:        []map[string]string{},
+		requestBody: map[string][]byte{},
+		override:    map[string]func(w http.ResponseWriter, r *http.Request){},
+	}
+}
+
+func (f *fakeOPNsense) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != f.apiKey || pass != f.apiSecret {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+
+		f.mu.Lock()
+		f.requestPaths = append(f.requestPaths, r.URL.Path)
+		f.requestBody[r.URL.Path] = body
+		override := f.override[r.URL.Path]
+		f.mu.Unlock()
+
+		if override != nil {
+			// Re-attach body since override may want to inspect it.
+			r.Body = io.NopCloser(strings.NewReader(string(body)))
+			override(w, r)
+			return
+		}
+
+		switch {
+		case f.isSearchPath(r.URL.Path):
+			f.handleSearch(w)
+		case f.isAddPath(r.URL.Path):
+			f.handleAdd(w, body)
+		case f.isDelPathPrefix(r.URL.Path):
+			uuid := strings.TrimPrefix(r.URL.Path, f.delPathPrefix())
+			f.handleDel(w, uuid)
+		case r.URL.Path == f.reconfigurePath():
+			f.mu.Lock()
+			f.reloadCount++
+			f.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	})
+}
+
+func (f *fakeOPNsense) isSearchPath(path string) bool {
+	switch f.engine {
+	case EngineUnbound:
+		return path == "/api/unbound/settings/searchHostOverride"
+	default:
+		return path == "/api/dnsmasq/settings/searchHost"
+	}
+}
+func (f *fakeOPNsense) isAddPath(path string) bool {
+	switch f.engine {
+	case EngineUnbound:
+		return path == "/api/unbound/settings/addHostOverride"
+	default:
+		return path == "/api/dnsmasq/settings/addHost"
+	}
+}
+func (f *fakeOPNsense) delPathPrefix() string {
+	switch f.engine {
+	case EngineUnbound:
+		return "/api/unbound/settings/delHostOverride/"
+	default:
+		return "/api/dnsmasq/settings/delHost/"
+	}
+}
+func (f *fakeOPNsense) isDelPathPrefix(path string) bool {
+	return strings.HasPrefix(path, f.delPathPrefix())
+}
+func (f *fakeOPNsense) reconfigurePath() string {
+	switch f.engine {
+	case EngineUnbound:
+		return "/api/unbound/service/reconfigure"
+	default:
+		return "/api/dnsmasq/service/reconfigure"
+	}
+}
+
+func (f *fakeOPNsense) handleSearch(w http.ResponseWriter) {
+	f.mu.Lock()
+	rowsCopy := make([]map[string]string, len(f.rows))
+	copy(rowsCopy, f.rows)
+	f.mu.Unlock()
+
+	resp := map[string]interface{}{
+		"rows":     rowsCopy,
+		"rowCount": len(rowsCopy),
+		"total":    len(rowsCopy),
+		"current":  1,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (f *fakeOPNsense) handleAdd(w http.ResponseWriter, body []byte) {
+	var wrapper map[string]map[string]string
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	host := wrapper["host"]
+	if host == nil {
+		http.Error(w, "missing host", http.StatusBadRequest)
+		return
+	}
+
+	f.mu.Lock()
+	f.nextUUID++
+	uuid := fmt.Sprintf("uuid-%d", f.nextUUID)
+	row := map[string]string{"uuid": uuid}
+	for k, v := range host {
+		row[k] = v
+	}
+	f.rows = append(f.rows, row)
+	f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"result": "saved", "uuid": uuid})
+}
+
+func (f *fakeOPNsense) handleDel(w http.ResponseWriter, uuid string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i, r := range f.rows {
+		if r["uuid"] == uuid {
+			f.rows = append(f.rows[:i], f.rows[i+1:]...)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"result":"deleted"}`))
+			return
+		}
+	}
+	http.Error(w, "not found", http.StatusNotFound)
+}
+
+// seedUnbound inserts a row using Unbound field names.
+func (f *fakeOPNsense) seedUnbound(uuid, hostname, domain, rr, server, description string, enabled bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = append(f.rows, map[string]string{
+		"uuid": uuid, "hostname": hostname, "domain": domain,
+		"rr": rr, "server": server, "description": description,
+		"enabled": boolStr(enabled),
+	})
+}
+
+// seedDnsmasq inserts a row using Dnsmasq field names.
+func (f *fakeOPNsense) seedDnsmasq(uuid, host, domain, ip, descr string, enabled bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = append(f.rows, map[string]string{
+		"uuid": uuid, "host": host, "domain": domain,
+		"ip": ip, "descr": descr, "enabled": boolStr(enabled),
+	})
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+// newTestProvider spins up the fake OPNsense, wires up a real Provider
+// pointed at it, and returns both plus a cleanup function.
+func newTestProvider(t *testing.T, engine Engine, mode ReconfigureMode) (*Provider, *fakeOPNsense, func()) {
+	t.Helper()
+	f := newFakeOPNsense(t, engine)
+	srv := httptest.NewServer(f.handler())
+
+	cfg := &Config{
+		URL:             srv.URL,
+		APIKey:          f.apiKey,
+		APISecret:       f.apiSecret,
+		Engine:          engine,
+		ReconfigureMode: mode,
+	}
+	p, err := New("opns-test", cfg)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("New: %v", err)
+	}
+	// The default httputil.DefaultClient() already talks http; nothing else needed.
+	return p, f, srv.Close
+}
+
+func TestProvider_Type(t *testing.T) {
+	p, _, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	if p.Type() != "opnsense" {
+		t.Errorf("Type() = %q, want opnsense", p.Type())
+	}
+	id := p.Identity()
+	if !strings.HasPrefix(id.Type, "opnsense/") {
+		t.Errorf("Identity.Type = %q, want prefix opnsense/", id.Type)
+	}
+
+	caps := p.Capabilities()
+	if caps.SupportsOwnershipTXT {
+		t.Error("SupportsOwnershipTXT should be false (host overrides do not support TXT)")
+	}
+	if caps.SupportsNativeUpdate {
+		t.Error("SupportsNativeUpdate should be false (v1)")
+	}
+}
+
+func TestProvider_Ping_OK(t *testing.T) {
+	p, _, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	if err := p.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+}
+
+func TestProvider_Ping_Unauthorized(t *testing.T) {
+	f := newFakeOPNsense(t, EngineUnbound)
+	srv := httptest.NewServer(f.handler())
+	defer srv.Close()
+
+	p, err := New("opns", &Config{
+		URL:             srv.URL,
+		APIKey:          "wrong",
+		APISecret:       "wrong",
+		Engine:          EngineUnbound,
+		ReconfigureMode: ReconfigureModePerWrite,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	err = p.Ping(context.Background())
+	if !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestProvider_List_FiltersToDnsweaverOwned_Unbound(t *testing.T) {
+	p, fake, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	// Two dnsweaver rows in-zone + one operator row in-zone + one dnsweaver row out-of-zone.
+	fake.seedUnbound("u1", "web", "example.com", "A", "10.0.0.1", "dnsweaver:opns-test", true)
+	fake.seedUnbound("u2", "api", "example.com", "AAAA", "2001:db8::1", "dnsweaver:opns-test | notes", true)
+	fake.seedUnbound("u3", "manual", "example.com", "A", "10.0.0.99", "operator note", true)
+	fake.seedUnbound("u4", "elsewhere", "other.tld", "A", "10.0.0.2", "dnsweaver:opns-test", true)
+
+	// Zone filter should keep only the two dnsweaver-owned in example.com.
+	p.zone = "example.com"
+
+	recs, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2: %+v", len(recs), recs)
+	}
+	hosts := map[string]bool{}
+	for _, r := range recs {
+		hosts[r.Hostname] = true
+	}
+	if !hosts["web.example.com"] || !hosts["api.example.com"] {
+		t.Errorf("missing expected hosts: %+v", hosts)
+	}
+}
+
+func TestProvider_List_FiltersToDnsweaverOwned_Dnsmasq(t *testing.T) {
+	p, fake, cleanup := newTestProvider(t, EngineDnsmasq, ReconfigureModePerWrite)
+	defer cleanup()
+
+	fake.seedDnsmasq("u1", "web", "example.com", "10.0.0.1", "dnsweaver:opns-test", true)
+	fake.seedDnsmasq("u2", "manual", "example.com", "10.0.0.99", "operator", true)
+
+	recs, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(recs) != 1 || recs[0].Hostname != "web.example.com" {
+		t.Fatalf("unexpected records: %+v", recs)
+	}
+	if recs[0].Type != provider.RecordTypeA {
+		t.Errorf("type = %q, want A", recs[0].Type)
+	}
+}
+
+func TestProvider_Create_Delete_Roundtrip_Unbound(t *testing.T) {
+	p, fake, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	rec := provider.Record{
+		Hostname: "web.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.5",
+	}
+	if err := p.Create(context.Background(), rec); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Verify wire: dnsweaver marker was written on the description.
+	payload := fake.requestBody["/api/unbound/settings/addHostOverride"]
+	if !strings.Contains(string(payload), "dnsweaver:opns-test") {
+		t.Errorf("add payload missing ownership marker: %s", payload)
+	}
+	// Reconfigure was called after create (per_write mode).
+	if fake.reloadCount != 1 {
+		t.Errorf("reloadCount = %d, want 1", fake.reloadCount)
+	}
+
+	// List sees the row.
+	listed, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("List after Create: got %d, want 1: %+v", len(listed), listed)
+	}
+	uuid := listed[0].ProviderID
+	if uuid == "" {
+		t.Fatal("ProviderID (UUID) missing from listed record")
+	}
+
+	// Delete using the UUID from List.
+	if err := p.Delete(context.Background(), listed[0]); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if fake.reloadCount != 2 {
+		t.Errorf("reloadCount after delete = %d, want 2", fake.reloadCount)
+	}
+
+	// Row is gone.
+	listed, err = p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List after Delete: %v", err)
+	}
+	if len(listed) != 0 {
+		t.Errorf("expected empty list after delete, got %+v", listed)
+	}
+}
+
+func TestProvider_Delete_LookupByFields_WhenUUIDMissing(t *testing.T) {
+	p, fake, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	fake.seedUnbound("u-known", "web", "example.com", "A", "10.0.0.5", "dnsweaver:opns-test", true)
+
+	err := p.Delete(context.Background(), provider.Record{
+		Hostname: "web.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.5",
+		// No ProviderID.
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(fake.rows) != 0 {
+		t.Errorf("row not deleted: %+v", fake.rows)
+	}
+}
+
+func TestProvider_Delete_DoesNotTouchOperatorRecords(t *testing.T) {
+	p, fake, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	// Same hostname/target as what we'll try to delete, but no ownership marker.
+	fake.seedUnbound("u-operator", "web", "example.com", "A", "10.0.0.5", "operator", true)
+
+	err := p.Delete(context.Background(), provider.Record{
+		Hostname: "web.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.5",
+	})
+	if !errors.Is(err, provider.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound (operator row must be untouchable), got %v", err)
+	}
+	if len(fake.rows) != 1 {
+		t.Errorf("operator row was deleted (BUG): %+v", fake.rows)
+	}
+}
+
+func TestProvider_Create_SkipsTXT(t *testing.T) {
+	p, fake, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	err := p.Create(context.Background(), provider.Record{
+		Hostname: "_ownership.web.example.com",
+		Type:     provider.RecordTypeTXT,
+		Target:   "heritage=dnsweaver",
+	})
+	if err != nil {
+		t.Fatalf("Create(TXT) should silently skip, got %v", err)
+	}
+	if len(fake.rows) != 0 {
+		t.Errorf("TXT should not have created a row: %+v", fake.rows)
+	}
+}
+
+func TestProvider_Create_RejectsInvalidHostname(t *testing.T) {
+	p, _, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	err := p.Create(context.Background(), provider.Record{
+		Hostname: "no-dot",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "fully qualified") {
+		t.Errorf("expected FQDN error, got %v", err)
+	}
+}
+
+func TestProvider_Create_RejectsNonIPTarget(t *testing.T) {
+	p, _, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	err := p.Create(context.Background(), provider.Record{
+		Hostname: "web.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "not-an-ip",
+	})
+	if err == nil || !strings.Contains(err.Error(), "IP target") {
+		t.Errorf("expected IP-target error, got %v", err)
+	}
+}
+
+func TestProvider_ReconfigureMode_Never(t *testing.T) {
+	p, fake, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModeNever)
+	defer cleanup()
+
+	if err := p.Create(context.Background(), provider.Record{
+		Hostname: "web.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.5",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if fake.reloadCount != 0 {
+		t.Errorf("reloadCount = %d, want 0 in never mode", fake.reloadCount)
+	}
+}
+
+func TestProvider_Create_FailedResponseSurfaces(t *testing.T) {
+	p, fake, cleanup := newTestProvider(t, EngineUnbound, ReconfigureModePerWrite)
+	defer cleanup()
+
+	fake.mu.Lock()
+	fake.override["/api/unbound/settings/addHostOverride"] = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":"failed","validations":{"host.hostname":"invalid"}}`))
+	}
+	fake.mu.Unlock()
+
+	err := p.Create(context.Background(), provider.Record{
+		Hostname: "web.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.5",
+	})
+	if err == nil {
+		t.Fatal("expected error on validation failure")
+	}
+	if !strings.Contains(err.Error(), "host.hostname") {
+		t.Errorf("expected validation detail in error, got %v", err)
+	}
+	if fake.reloadCount != 0 {
+		t.Errorf("reload should not have run after a failed create, got %d", fake.reloadCount)
+	}
+}
+
+func TestJoinFQDN(t *testing.T) {
+	cases := []struct {
+		host, dom, want string
+	}{
+		{"web", "example.com", "web.example.com"},
+		{"web", "example.com.", "web.example.com"},
+		{"WEB", "Example.COM", "web.example.com"},
+		{"", "example.com", "example.com"},
+		{"web", "", "web"},
+	}
+	for _, tc := range cases {
+		if got := joinFQDN(tc.host, tc.dom); got != tc.want {
+			t.Errorf("joinFQDN(%q,%q) = %q, want %q", tc.host, tc.dom, got, tc.want)
+		}
+	}
+}
+
+func TestSplitFQDN(t *testing.T) {
+	if h, d, ok := splitFQDN("web.example.com"); !ok || h != "web" || d != "example.com" {
+		t.Errorf("normal split failed: %q %q %v", h, d, ok)
+	}
+	if _, _, ok := splitFQDN("host"); ok {
+		t.Error("hostname without dot should fail")
+	}
+	if _, _, ok := splitFQDN("web.example.com."); !ok {
+		t.Error("trailing dot should be ok")
+	}
+}
+
+func TestInZone(t *testing.T) {
+	if !inZone("web.example.com", "example.com") {
+		t.Error("subdomain should match zone")
+	}
+	if !inZone("example.com", "example.com") {
+		t.Error("apex should match zone")
+	}
+	if inZone("web.other.com", "example.com") {
+		t.Error("unrelated FQDN must not match")
+	}
+	if inZone("badexample.com", "example.com") {
+		t.Error("suffix without dot boundary must not match")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `opnsense` DNS provider that manages **host overrides** on OPNsense 24.7+ via its REST API. A single provider covers both DNS engines OPNsense ships with (**Unbound** and **Dnsmasq**) behind a small pluggable `engine` interface — pick with `DNSWEAVER_{NAME}_ENGINE=unbound|dnsmasq` (default `unbound`).

Closes GH #114, GL #188.

## Design

- **One provider, two engines.** OPNsense treats Unbound and Dnsmasq host overrides as separate subsystems with different endpoints and payload shapes but identical *conceptual* record model. The `engine` interface localises the per-engine REST specifics; everything else — auth, ownership, reconcile flow, tests — is shared.
- **Ownership via description prefix, not TXT.** Neither engine's host overrides support TXT records, so ownership is tagged on the `description` field as `dnsweaver:{instance-name}`. dnsweaver only lists / mutates rows carrying that prefix, so operator-managed host overrides in the OPNsense GUI are always safe from orphan cleanup.
- **Reconfigure control.** Post-write behavior is `DNSWEAVER_{NAME}_RECONFIGURE_MODE=per_write` (default; each mutation triggers an Unbound/Dnsmasq reload) or `never` (defer to an operator-managed reload schedule). Debounced/batched reconfigure is a documented v1.1 follow-up.
- **v1 scope.** A / AAAA only. CNAME support requires the Unbound alias-table endpoint and is deferred.

## Config

Required (per instance, `_FILE` suffix supported for secrets):

- `DNSWEAVER_{NAME}_URL` — OPNsense base URL (e.g. `https://opnsense.example.com`)
- `DNSWEAVER_{NAME}_API_KEY` / `DNSWEAVER_{NAME}_API_SECRET` — API credentials
- `DNSWEAVER_{NAME}_ENGINE` — `unbound` (default) or `dnsmasq`
- `DNSWEAVER_{NAME}_RECONFIGURE_MODE` — `per_write` (default) or `never`

Plus the standard TLS / logging surface.

## Testing

- Unit tests: config validation, ownership parse/format round-trip, per-engine payload shape (Unbound + Dnsmasq).
- Integration-shape test: an `httptest` fake OPNsense (`fakeOPNsense`) exercises the full Ping / List / Create / Delete / Reconfigure cycle for both engines through the real `client.go` transport.
- `go test ./providers/opnsense/... -count=1` and `go test ./... -count=1` both green.
- `golangci-lint run ./providers/opnsense/...` clean.

## Docs

- New provider page: `docs/providers/opnsense.md` (setup, config reference, engine trade-offs, orphan-safety guarantee, v1.1 deferred items).
- README supported-providers table row added.
- `docs/providers/index.md` + `mkdocs.yml` nav entries.
- `docs/contributing/adding-provider.md` updated with the engine-backend pattern as a case study.

## CHANGELOG

Under `## [Unreleased]` → `### Added`.