### PR TITLE
feat(config): standalone platform mode (DNSWEAVER_PLATFORM=none)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Standalone platform mode** (`DNSWEAVER_PLATFORM=none`, alias `standalone`).
+  dnsweaver can now run as a bare binary on a host, VM, or LXC with no Docker or
+  Kubernetes runtime — previously it always created a Docker (or Kubernetes)
+  client at startup and exited fatally with `Cannot connect to the Docker
+  daemon` even when only non-container sources were configured. With `none`, no
+  container-runtime client is created; configure at least one non-container
+  source instead — a Proxmox VE source (`DNSWEAVER_PROXMOX_URL`), an Incus
+  source (`DNSWEAVER_INCUS_URL`/`DNSWEAVER_INCUS_SOCKET_PATH`), or a
+  file-discovery source (e.g. `DNSWEAVER_SOURCE_TRAEFIK_FILE_PATHS`). Startup
+  fails with an actionable error if `none` is set without any such source.
+  ([GitHub #116](https://github.com/maxfield-allison/dnsweaver/issues/116))
 - **OPNsense provider** with pluggable engine backend for **Unbound** and
   **Dnsmasq** (OPNsense 24.7+), driven by the OPNsense REST API
   ([GitHub #114](https://github.com/maxfield-allison/dnsweaver/issues/114),

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -327,8 +327,14 @@ func run() error {
 		)
 	}
 
+	if len(listers) == 0 && len(sourceRegistry.DiscoverableSources()) == 0 {
+		return fmt.Errorf("no workload listers or discovery sources configured: set DNSWEAVER_PLATFORM to docker, kubernetes, or both; set DNSWEAVER_PROXMOX_URL for Proxmox VE; set DNSWEAVER_INCUS_URL/DNSWEAVER_INCUS_SOCKET_PATH for Incus; or, when running standalone (DNSWEAVER_PLATFORM=none), configure a file-discovery source such as DNSWEAVER_SOURCE_TRAEFIK_FILE_PATHS")
+	}
+
 	if len(listers) == 0 {
-		return fmt.Errorf("no platform watchers configured: set DNSWEAVER_PLATFORM to docker, kubernetes, or both, set DNSWEAVER_PROXMOX_URL for Proxmox VE, or set DNSWEAVER_INCUS_URL/DNSWEAVER_INCUS_SOCKET_PATH for Incus")
+		logger.Info("running in standalone mode with file discovery only (no workload listers)",
+			slog.String("platform", cfg.Platform()),
+		)
 	}
 
 	rec := reconciler.New(listers, sourceRegistry, providerRegistry,

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -68,7 +68,7 @@ The socket proxy only needs read-only access to containers, services, and events
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DNSWEAVER_PLATFORM` | `docker` | Platform mode: `docker`, `kubernetes`, or `both` |
+| `DNSWEAVER_PLATFORM` | `docker` | Platform mode: `docker`, `kubernetes`, `both`, or `none` |
 | `DNSWEAVER_INSTANCE_ID` | *(empty)* | Unique instance identifier for multi-instance coordination |
 
 Set `DNSWEAVER_PLATFORM` to control which workload sources are active:
@@ -76,6 +76,27 @@ Set `DNSWEAVER_PLATFORM` to control which workload sources are active:
 - **`docker`** — Watch Docker containers/services only (default, backward-compatible)
 - **`kubernetes`** — Watch Kubernetes Ingress/IngressRoute/HTTPRoute/Service resources only
 - **`both`** — Watch both Docker and Kubernetes workloads simultaneously
+- **`none`** (alias: `standalone`) — Create no container-runtime client. Use this to run dnsweaver as a bare binary on a host, VM, or LXC where there is no Docker or Kubernetes. You must configure at least one non-container source: a Proxmox VE source (`DNSWEAVER_PROXMOX_URL`), an Incus source (`DNSWEAVER_INCUS_URL` / `DNSWEAVER_INCUS_SOCKET_PATH`), or a file-discovery source (e.g. `DNSWEAVER_SOURCE_TRAEFIK_FILE_PATHS`). Startup will fail if `none` is set and no such source is configured.
+
+### Standalone (no Docker or Kubernetes)
+
+To run dnsweaver directly on a host alongside, for example, Technitium DNS, using only the Proxmox VE source:
+
+```bash
+DNSWEAVER_PLATFORM=none
+DNSWEAVER_SOURCES=proxmox
+DNSWEAVER_PROXMOX_URL=https://pve.example.com:8006/
+DNSWEAVER_PROXMOX_TOKEN_ID=user@pve!dnsweaver
+DNSWEAVER_PROXMOX_TOKEN_SECRET_FILE=/etc/dnsweaver/pve-token
+
+DNSWEAVER_INSTANCES=technitium
+DNSWEAVER_TECHNITIUM_TYPE=technitium
+DNSWEAVER_TECHNITIUM_URL=http://127.0.0.1:5380
+DNSWEAVER_TECHNITIUM_TOKEN_FILE=/etc/dnsweaver/technitium-token
+DNSWEAVER_TECHNITIUM_ZONE=example.com
+```
+
+With `DNSWEAVER_PLATFORM=none` no Docker or Kubernetes client is created, so dnsweaver no longer fails with `Cannot connect to the Docker daemon` on hosts without a container runtime.
 
 ## Kubernetes Settings
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,6 +29,10 @@ dnsweaver watches Kubernetes resources (Ingress, IngressRoute, HTTPRoute, Servic
 
 Yes! Set `DNSWEAVER_PLATFORM=both` to watch Docker events and Kubernetes resources simultaneously. This is useful for mixed environments or gradual migrations between platforms.
 
+### Can I run dnsweaver without Docker or Kubernetes?
+
+Yes. Set `DNSWEAVER_PLATFORM=none` (alias `standalone`) to run dnsweaver as a bare binary on a host, VM, or LXC with no container runtime. No Docker or Kubernetes client is created, so it won't fail with `Cannot connect to the Docker daemon`. You must configure at least one non-container source — a Proxmox VE source (`DNSWEAVER_PROXMOX_URL`), an Incus source (`DNSWEAVER_INCUS_URL`/`DNSWEAVER_INCUS_SOCKET_PATH`), or a file-discovery source (e.g. `DNSWEAVER_SOURCE_TRAEFIK_FILE_PATHS`). See [Standalone](configuration/environment.md#standalone-no-docker-or-kubernetes) for a full example.
+
 ### Can dnsweaver manage existing DNS records?
 
 By default, dnsweaver only manages records it creates (tracked via ownership TXT records). To adopt existing records:
@@ -124,7 +128,7 @@ In addition to the standard provider configuration, Kubernetes-specific options 
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DNSWEAVER_PLATFORM` | Platform to watch: `docker`, `kubernetes`, or `both` | `docker` |
+| `DNSWEAVER_PLATFORM` | Platform to watch: `docker`, `kubernetes`, `both`, or `none` | `docker` |
 | `DNSWEAVER_KUBE_NAMESPACES` | Comma-separated list of namespaces to watch | All namespaces |
 | `DNSWEAVER_KUBE_LABEL_SELECTOR` | Label selector to filter watched resources | None |
 
@@ -211,7 +215,7 @@ docker exec dnsweaver ls -la /var/run/docker.sock
 ```
 
 !!! tip
-    If running on Kubernetes only, set `DNSWEAVER_PLATFORM=kubernetes` to skip the Docker connection entirely.
+    If running on Kubernetes only, set `DNSWEAVER_PLATFORM=kubernetes` to skip the Docker connection entirely. If running with no container runtime at all (e.g. a bare host or LXC using only the Proxmox or a file-discovery source), set `DNSWEAVER_PLATFORM=none`.
 
 ### "Failed to create Kubernetes watcher"
 

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -124,6 +124,20 @@ type GlobalConfig struct {
 	InstanceID string // Unique identifier for this dnsweaver instance (for shared zone management)
 }
 
+// normalizePlatform lowercases the platform value and maps recognized aliases
+// to their canonical form. "standalone" is an alias for "none" — both mean
+// "create no container-runtime client" so dnsweaver can run as a bare binary
+// on a host, VM, or LXC using only non-container sources (Proxmox, file
+// discovery). Unknown values are returned lowercased for the caller to reject.
+func normalizePlatform(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "standalone":
+		return "none"
+	default:
+		return strings.ToLower(strings.TrimSpace(v))
+	}
+}
+
 // loadGlobalConfig loads global configuration from environment variables.
 // Returns a list of validation errors (may be empty).
 func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
@@ -160,12 +174,12 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	if cfg.Platform == "" {
 		cfg.Platform = DefaultPlatform
 	}
-	cfg.Platform = strings.ToLower(cfg.Platform)
+	cfg.Platform = normalizePlatform(cfg.Platform)
 	switch cfg.Platform {
-	case "docker", "kubernetes", "both":
+	case "docker", "kubernetes", "both", "none":
 		// Valid
 	default:
-		errs = append(errs, configErrFull("DNSWEAVER_PLATFORM", fmt.Sprintf("invalid value %q", cfg.Platform), "Must be one of: docker, kubernetes, both", "DNSWEAVER_PLATFORM=docker"))
+		errs = append(errs, configErrFull("DNSWEAVER_PLATFORM", fmt.Sprintf("invalid value %q", cfg.Platform), "Must be one of: docker, kubernetes, both, none", "DNSWEAVER_PLATFORM=docker"))
 	}
 
 	// Validate log level

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -30,6 +30,7 @@ func clearGlobalEnv(t *testing.T) {
 		"DNSWEAVER_SOURCES",
 		"DNSWEAVER_SOURCE",
 		"DNSWEAVER_INSTANCE_ID",
+		"DNSWEAVER_PLATFORM",
 	}
 	for _, v := range envVars {
 		os.Unsetenv(v)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -274,12 +274,12 @@ func mergeGlobalConfig(base *GlobalConfig) (*GlobalConfig, []*ConfigError) {
 
 	// Override platform if set in env
 	if v := getEnv("DNSWEAVER_PLATFORM"); v != "" {
-		cfg.Platform = strings.ToLower(v)
+		cfg.Platform = normalizePlatform(v)
 		switch cfg.Platform {
-		case "docker", "kubernetes", "both":
+		case "docker", "kubernetes", "both", "none":
 			// Valid
 		default:
-			errs = append(errs, configErrFull("DNSWEAVER_PLATFORM", fmt.Sprintf("invalid value %q", v), "Must be one of: docker, kubernetes, both", "DNSWEAVER_PLATFORM=docker"))
+			errs = append(errs, configErrFull("DNSWEAVER_PLATFORM", fmt.Sprintf("invalid value %q", v), "Must be one of: docker, kubernetes, both, none", "DNSWEAVER_PLATFORM=docker"))
 		}
 	}
 

--- a/internal/config/platform_test.go
+++ b/internal/config/platform_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNormalizePlatform(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"docker lowercase", "docker", "docker"},
+		{"docker mixed case", "Docker", "docker"},
+		{"kubernetes", "kubernetes", "kubernetes"},
+		{"both", "both", "both"},
+		{"none", "none", "none"},
+		{"none uppercase", "NONE", "none"},
+		{"standalone alias", "standalone", "none"},
+		{"standalone mixed case", "Standalone", "none"},
+		{"standalone with whitespace", "  standalone  ", "none"},
+		{"unknown passthrough lowercased", "K8S", "k8s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizePlatform(tt.in); got != tt.want {
+				t.Errorf("normalizePlatform(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadGlobalConfig_PlatformNone(t *testing.T) {
+	clearGlobalEnv(t)
+	os.Setenv("DNSWEAVER_PLATFORM", "none")
+	defer os.Unsetenv("DNSWEAVER_PLATFORM")
+
+	cfg, errs := loadGlobalConfig()
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if cfg.Platform != "none" {
+		t.Errorf("Platform = %q, want %q", cfg.Platform, "none")
+	}
+}
+
+func TestLoadGlobalConfig_PlatformStandaloneAlias(t *testing.T) {
+	clearGlobalEnv(t)
+	os.Setenv("DNSWEAVER_PLATFORM", "standalone")
+	defer os.Unsetenv("DNSWEAVER_PLATFORM")
+
+	cfg, errs := loadGlobalConfig()
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if cfg.Platform != "none" {
+		t.Errorf("Platform = %q, want %q (standalone should normalize to none)", cfg.Platform, "none")
+	}
+}
+
+func TestLoadGlobalConfig_PlatformInvalid(t *testing.T) {
+	clearGlobalEnv(t)
+	os.Setenv("DNSWEAVER_PLATFORM", "vmware")
+	defer os.Unsetenv("DNSWEAVER_PLATFORM")
+
+	_, errs := loadGlobalConfig()
+	if len(errs) == 0 {
+		t.Fatal("expected a validation error for invalid platform, got none")
+	}
+}
+
+// TestConfig_UsePlatformClients_None verifies that the "none" platform creates
+// neither a Docker nor a Kubernetes client, which is what lets dnsweaver run as
+// a standalone binary (issue #116).
+func TestConfig_UsePlatformClients_None(t *testing.T) {
+	cfg := &Config{Global: &GlobalConfig{Platform: "none"}}
+	if cfg.UseDocker() {
+		t.Error("UseDocker() = true for platform none, want false")
+	}
+	if cfg.UseKubernetes() {
+		t.Error("UseKubernetes() = true for platform none, want false")
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -55,7 +55,7 @@ func validateConfig(cfg *Config) []*ConfigError {
 
 	// Validate platform value
 	switch cfg.Global.Platform {
-	case "docker", "kubernetes", "both":
+	case "docker", "kubernetes", "both", "none":
 		// Valid
 	case "":
 		// Will use default
@@ -63,7 +63,7 @@ func validateConfig(cfg *Config) []*ConfigError {
 		errs = append(errs, configErrFull(
 			"platform",
 			fmt.Sprintf("invalid value %q", cfg.Global.Platform),
-			"Must be one of: docker, kubernetes, both",
+			"Must be one of: docker, kubernetes, both, none",
 			"DNSWEAVER_PLATFORM=docker",
 		))
 	}


### PR DESCRIPTION
## Summary

Resolves #116 — dnsweaver could not run as a standalone binary without Docker or Kubernetes.

`DNSWEAVER_PLATFORM` defaults to `docker` and always creates a Docker client at startup. On a host with no container runtime (bare metal, VM, LXC) running only a non-container source like Proxmox, startup failed fatally with `Cannot connect to the Docker daemon`, even though no Docker-backed source was configured.

## Change

Add `none` (alias `standalone`) as a valid `DNSWEAVER_PLATFORM` value:

- `normalizePlatform()` lowercases and maps the `standalone` alias to `none`. All three platform-validation sites (`global.go`, `loader.go`, `validate.go`) accept `none` and mention it in their error messages.
- `UseDocker()` / `UseKubernetes()` already return false for anything that is not `docker`/`kubernetes`/`both`, so `none` creates **no** container-runtime client with no further change.
- The final startup guard is relaxed: it now fails only when there are **neither** workload listers **nor** discovery-capable sources. This lets a Proxmox-only **or** a file-discovery-only standalone deployment boot. The error message points at the standalone path, and a file-discovery-only run logs an informational "standalone mode" line.

Fully backward-compatible: `docker` / `kubernetes` / `both` behavior is unchanged.

## Example (the issue reporters use case)

```bash
DNSWEAVER_PLATFORM=none
DNSWEAVER_SOURCES=proxmox
DNSWEAVER_PROXMOX_URL=https://pve.example.com:8006/
DNSWEAVER_PROXMOX_TOKEN_ID=user@pve!dnsweaver
DNSWEAVER_PROXMOX_TOKEN_SECRET_FILE=/etc/dnsweaver/pve-token

DNSWEAVER_INSTANCES=technitium
DNSWEAVER_TECHNITIUM_TYPE=technitium
DNSWEAVER_TECHNITIUM_URL=http://127.0.0.1:5380
DNSWEAVER_TECHNITIUM_TOKEN_FILE=/etc/dnsweaver/technitium-token
DNSWEAVER_TECHNITIUM_ZONE=example.com
```

## Tests

- `TestNormalizePlatform` — table incl. `standalone` alias, case/whitespace, unknown passthrough.
- `TestLoadGlobalConfig_PlatformNone` / `_PlatformStandaloneAlias` / `_PlatformInvalid`.
- `TestConfig_UsePlatformClients_None` — asserts `UseDocker()`/`UseKubernetes()` are both false for `none`.
- `go test ./... -count=1` green; `gofmt`/`go vet` clean. (Local golangci-lint is built against Go 1.25 vs the repos 1.26.4 pin, so lint is deferred to CI.)

## Docs

- `docs/configuration/environment.md`: `none` row + a **Standalone (no Docker or Kubernetes)** section with a full example.
- `docs/faq.md`: new "Can I run dnsweaver without Docker or Kubernetes?" entry, platform var table updated, Docker-connection troubleshooting tip updated.
- CHANGELOG under `## [Unreleased]`.