### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-07-04
+
+Minor release adding the OPNsense DNS provider and a standalone platform mode for
+running dnsweaver without Docker or Kubernetes.
+
 ### Added
 - **Standalone platform mode** (`DNSWEAVER_PLATFORM=none`, alias `standalone`).
   dnsweaver can now run as a bare binary on a host, VM, or LXC with no Docker or


### PR DESCRIPTION
## v2.3.0 — OPNsense provider + standalone platform mode

Minor release batching two feature PRs already merged to `main`:

### Added
- **OPNsense provider** (#118, closes #114) — single `opnsense` provider covering both Unbound and Dnsmasq resolvers via a pluggable engine backend, driven by the OPNsense REST API. Ownership via `dnsweaver:{instance}` description prefix (host overrides do not support TXT); `RECONFIGURE_MODE=per_write|never`; A/AAAA in v1.
- **Standalone platform mode** (#119, closes #116) — `DNSWEAVER_PLATFORM=none` (alias `standalone`) runs dnsweaver as a bare binary on a host/VM/LXC with no Docker or Kubernetes, using only non-container sources (Proxmox, Incus, or file discovery).

This PR only promotes the `## [Unreleased]` CHANGELOG section to `## [2.3.0]`; all code already landed via #118 and #119.

After merge: tag `v2.3.0` (signed) → GitLab tag pipeline builds Docker images (ghcr.io + docker.io), creates the GitHub Release, and deploys docs.