### PR TITLE
docs: sync provider counts for OPNsense (now 10 providers)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ dnsweaver watches Docker events, Kubernetes resources, and Proxmox VE clusters t
 
     ---
 
-    Route different domains to different DNS providers. Nine providers: Technitium, Cloudflare, OVHcloud, AdGuard Home, RFC 2136, PowerDNS, Pi-hole, dnsmasq, and webhook.
+    Route different domains to different DNS providers. Ten providers: Technitium, Cloudflare, OVHcloud, AdGuard Home, RFC 2136, PowerDNS, OPNsense, Pi-hole, dnsmasq, and webhook.
 
     [:octicons-arrow-right-24: Providers](providers/index.md)
 

--- a/docs/testing/TEST-CASES.md
+++ b/docs/testing/TEST-CASES.md
@@ -8,7 +8,7 @@ For test templates and patterns, see the [templates/](templates/) directory.
 
 | Category | Test Cases | Description |
 |----------|-----------|-------------|
-| [Provider Tests](#provider-tests) | 9 providers × record types | CRUD operations, orphan cleanup |
+| [Provider Tests](#provider-tests) | 10 providers × record types | CRUD operations, orphan cleanup |
 | [Source Tests](#source-tests) | 3 sources × modes | Service discovery, watch/poll |
 | [Scenario Tests](#scenario-tests) | 9 scenarios | End-to-end behavior, recovery |
 | [Reconciler Tests](#reconciler-tests) | Edge cases | Multi-provider, conflict resolution |
@@ -31,6 +31,7 @@ Each provider must pass the full test matrix for every record type it supports.
 | Pi-hole v5 | ✅ | ✅ | ✅ | ❌ | ❌ | Custom list |
 | Pi-hole v6 | ✅ | ✅ | ✅ | ❌ | ❌ | Custom list |
 | AdGuard Home | ✅ | ✅ | ✅ | ❌ | ❌ | DNS rewrite |
+| OPNsense | ✅ | ✅ | ❌ | ❌ | ❌ | Description prefix |
 | dnsmasq | ✅ | ✅ | ✅ | ❌ | ❌ | Config file |
 | Webhook | ✅ | ✅ | ✅ | ✅ | ✅ | Callback |
 


### PR DESCRIPTION
Post-v2.3.0 documentation sync. The OPNsense provider made dnsweaver a ten-provider tool, but two docs still said nine:

- **`docs/index.md`** — landing-page "Multi-Provider Support" card said "Nine providers" and omitted OPNsense from the list. Now "Ten providers" with OPNsense included.
- **`docs/testing/TEST-CASES.md`** — the summary table said "9 providers" and the record-type support matrix had no OPNsense row. Bumped to "10 providers" and added the OPNsense row (A/AAAA only; ownership via description prefix, matching the `dnsweaver:{instance}` scheme).

Already current from earlier PRs (verified, no changes needed here):
- `docs/providers/index.md` cards + comparison table, `mkdocs.yml` nav, `README.md` — updated in #118.
- Standalone mode (`DNSWEAVER_PLATFORM=none`) in `docs/configuration/environment.md` + `docs/faq.md` — updated in #119.

`mkdocs build --strict` passes (with imaging deps for the social plugin).