### PR TITLE
docs: document Cloudflare proxied label + refresh stale v2.0 deprecation notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Deprecation notices for the legacy TLS aliases (`INSECURE_SKIP_VERIFY`,
+  `DNSWEAVER_PROXMOX_VERIFY_TLS`) no longer claim removal "in v2.0" — the
+  project is already past v2.0 and the aliases still ship. The operator-facing
+  log warnings now say "a future major release."
+
+### Documentation
+- Documented the Cloudflare per-host **`proxied` override** in the native Label
+  Reference (`dnsweaver.proxied` and `dnsweaver.records.<name>.proxied`, plus
+  `dnsweaver.records.<name>.meta.<key>`), with a worked example on the native
+  labels and Cloudflare provider pages. Previously the override was usable but
+  undocumented. ([discussion #113](https://github.com/maxfield-allison/dnsweaver/discussions/113))
+- Added the `incus` source to the `DNSWEAVER_SOURCES` enumeration and refreshed
+  stale "will be removed in v2.0" deprecation notes across the provider,
+  environment, FAQ, and Proxmox source pages.
+
 ## [2.3.0] - 2026-07-04
 
 Minor release adding the OPNsense DNS provider and a standalone platform mode for

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -282,9 +282,9 @@ func run() error {
 			BaseURL:     cfg.ProxmoxURL(),
 			TokenID:     cfg.ProxmoxTokenID(),
 			TokenSecret: cfg.ProxmoxTokenSecret(),
-			// Intentional use of deprecated accessor: until v2.0 we pass both
-			// the legacy bool and the unified TLS config so operators on the
-			// old env var still work. The proxmox client prefers TLS when set.
+			// Intentional use of deprecated accessor: we pass both the legacy
+			// bool and the unified TLS config so operators on the old env var
+			// still work. The proxmox client prefers TLS when set.
 			VerifyTLS: cfg.ProxmoxVerifyTLS(), //nolint:staticcheck // SA1019: see comment above
 			TLS:       cfg.ProxmoxTLS(),
 			Logger:    logger,

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -144,7 +144,7 @@ Replace `{NAME}` with your instance name. For example, instance `internal-dns` u
 | `DNSWEAVER_{NAME}_TLS_SERVER_NAME` | No | SNI / verification hostname override. Use when the server's certificate CN/SAN does not match the URL host. |
 | `DNSWEAVER_{NAME}_TLS_MIN_VERSION` | No | Minimum TLS protocol version: `1.2` (default) or `1.3`. |
 | `DNSWEAVER_{NAME}_TLS_SKIP_VERIFY` | No | Skip TLS certificate verification (`true`/`false`, default: `false`). **Warning:** disables MITM protection — prefer `TLS_CA_FILE`. |
-| `DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY` | No | **Deprecated** — alias of `TLS_SKIP_VERIFY`. Will be removed in v2.0. |
+| `DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY` | No | **Deprecated** — alias of `TLS_SKIP_VERIFY`. Will be removed in a future major release. |
 
 ### TLS Certificate File Permissions
 
@@ -218,10 +218,10 @@ world-readable inside the container, a real downgrade):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DNSWEAVER_SOURCES` | `traefik` | Comma-separated list: `traefik`, `caddy`, `nginx-proxy`, `dnsweaver`, `kubernetes`, `proxmox` |
+| `DNSWEAVER_SOURCES` | `traefik` | Comma-separated list: `traefik`, `caddy`, `nginx-proxy`, `dnsweaver`, `kubernetes`, `proxmox`, `incus` |
 
 !!! warning "Deprecated Variable"
-    `DNSWEAVER_SOURCE` (singular) is deprecated and will be removed in v2.0. Use `DNSWEAVER_SOURCES` (plural) instead.
+    `DNSWEAVER_SOURCE` (singular) is deprecated and will be removed in a future major release. Use `DNSWEAVER_SOURCES` (plural) instead.
     When both are set, `DNSWEAVER_SOURCES` takes precedence.
 
 ### Traefik File Source Settings
@@ -252,7 +252,7 @@ full setup including the required PVE role privileges.
 | `DNSWEAVER_PROXMOX_TLS_SERVER_NAME` | No | — | SNI/verification hostname override. |
 | `DNSWEAVER_PROXMOX_TLS_MIN_VERSION` | No | `1.2` | Minimum TLS protocol version (`1.2` or `1.3`). |
 | `DNSWEAVER_PROXMOX_TLS_SKIP_VERIFY` | No | `false` | Skip PVE TLS certificate verification. Prefer `TLS_CA_FILE`. |
-| `DNSWEAVER_PROXMOX_VERIFY_TLS` | No | `true` | **Deprecated** — inverted-polarity alias of `TLS_SKIP_VERIFY`. Will be removed in v2.0. |
+| `DNSWEAVER_PROXMOX_VERIFY_TLS` | No | `true` | **Deprecated** — inverted-polarity alias of `TLS_SKIP_VERIFY`. Will be removed in a future major release. |
 | `DNSWEAVER_PROXMOX_NODE_FILTER` | No | *(all)* | Restrict discovery to a single PVE node name |
 | `DNSWEAVER_PROXMOX_TAG_FILTER` | No | *(all)* | Only include resources with this tag (prefix match) |
 | `DNSWEAVER_PROXMOX_STATE_FILTER` | No | `running` | Resource status filter (`running`, `stopped`, etc.) |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -268,7 +268,7 @@ and is **not recommended for production**:
 ```
 
 The legacy `INSECURE_SKIP_VERIFY` variable still works but emits a deprecation
-warning and will be removed in v2.0.
+warning and will be removed in a future major release.
 
 ### Records created but not resolving
 

--- a/docs/providers/adguard.md
+++ b/docs/providers/adguard.md
@@ -192,7 +192,7 @@ AdGuard Home is often fronted by a reverse proxy with a private CA or self-signe
 | `DNSWEAVER_ADGUARD_TLS_SKIP_VERIFY` | Disable verification (development only) |
 | `DNSWEAVER_ADGUARD_TLS_MIN_VERSION` | `1.2` (default) or `1.3` |
 
-The legacy `DNSWEAVER_ADGUARD_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in v2.0. See the [environment reference](../configuration/environment.md) for complete recipes.
+The legacy `DNSWEAVER_ADGUARD_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in a future major release. See the [environment reference](../configuration/environment.md) for complete recipes.
 
 !!! warning "Mounted certs must be readable by uid/gid 1000"
     The container drops privileges to the unprivileged `dnsweaver` user, so a

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -91,6 +91,24 @@ When proxied:
 - Origin IP is hidden
 - Additional features available (caching, WAF, etc.)
 
+### Per-Host Proxy Override (Labels)
+
+`PROXIED` sets the default for **every** record this instance creates. To make
+individual hostnames DNS-only (grey-cloud) while the rest stay proxied, use the
+[native `proxied` label](../sources/native-labels.md#cloudflare-proxy-override-per-host)
+on the workload:
+
+```yaml
+labels:
+  # This host bypasses the Cloudflare proxy even though PROXIED=true
+  - "dnsweaver.hostname=ssh.example.com"
+  - "dnsweaver.proxied=false"
+```
+
+For several records on one service, use the named-record form
+(`dnsweaver.records.<name>.proxied`). Records that omit `proxied` fall back to
+the instance's `PROXIED` default.
+
 ## Split-Horizon with Cloudflare
 
 Common pattern: Cloudflare for external, Technitium for internal:
@@ -130,7 +148,7 @@ Cloudflare's public API uses publicly-trusted certificates so the defaults work 
 | `DNSWEAVER_CLOUDFLARE_TLS_SKIP_VERIFY` | Disable verification (development only — **never** in production) |
 | `DNSWEAVER_CLOUDFLARE_TLS_MIN_VERSION` | `1.2` (default) or `1.3` |
 
-The legacy `DNSWEAVER_CLOUDFLARE_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in v2.0.
+The legacy `DNSWEAVER_CLOUDFLARE_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in a future major release.
 
 !!! warning "Mounted certs must be readable by uid/gid 1000"
     The container drops privileges to the unprivileged `dnsweaver` user, so a

--- a/docs/providers/pihole.md
+++ b/docs/providers/pihole.md
@@ -170,7 +170,7 @@ When using API mode against a Pi-hole instance served over HTTPS — typically t
 | `DNSWEAVER_PIHOLE_TLS_SKIP_VERIFY` | Disable verification (development only) |
 | `DNSWEAVER_PIHOLE_TLS_MIN_VERSION` | `1.2` (default) or `1.3` |
 
-The legacy `DNSWEAVER_PIHOLE_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in v2.0. File mode does not perform HTTP requests so these keys have no effect there.
+The legacy `DNSWEAVER_PIHOLE_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in a future major release. File mode does not perform HTTP requests so these keys have no effect there.
 
 !!! warning "Mounted certs must be readable by uid/gid 1000"
     The container drops privileges to the unprivileged `dnsweaver` user, so a

--- a/docs/providers/technitium.md
+++ b/docs/providers/technitium.md
@@ -47,7 +47,7 @@ environment:
 | `TLS_SERVER_NAME` | No | — | SNI / verification hostname override |
 | `TLS_MIN_VERSION` | No | `1.2` | Minimum TLS protocol version (`1.2` or `1.3`) |
 | `TLS_SKIP_VERIFY` | No | `false` | Skip TLS certificate verification. Prefer `TLS_CA_FILE`. |
-| `INSECURE_SKIP_VERIFY` | No | `false` | **Deprecated** alias of `TLS_SKIP_VERIFY` (removed in v2.0) |
+| `INSECURE_SKIP_VERIFY` | No | `false` | **Deprecated** alias of `TLS_SKIP_VERIFY` (will be removed in a future major release) |
 | `AUTO_HTTPS_RECORDS` | No | `true` | Auto-create companion HTTPS records (see below) |
 | `AUTO_HTTPS_ALPN` | No | `h2` | ALPN protocol for companion HTTPS records |
 
@@ -186,7 +186,7 @@ you can disable verification entirely — this removes MITM protection and is
 ```
 
 The legacy `DNSWEAVER_TECHNITIUM_INSECURE_SKIP_VERIFY` variable still works
-but emits a deprecation warning and will be removed in v2.0.
+but emits a deprecation warning and will be removed in a future major release.
 
 ## Companion HTTPS Records
 

--- a/docs/providers/webhook.md
+++ b/docs/providers/webhook.md
@@ -183,7 +183,7 @@ Webhook endpoints frequently live on internal services with private CAs or mTLS 
 | `DNSWEAVER_WEBHOOK_TLS_SKIP_VERIFY` | Disable verification (development only) |
 | `DNSWEAVER_WEBHOOK_TLS_MIN_VERSION` | `1.2` (default) or `1.3` |
 
-The legacy `DNSWEAVER_WEBHOOK_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in v2.0.
+The legacy `DNSWEAVER_WEBHOOK_INSECURE_SKIP_VERIFY` variable still works but emits a deprecation warning and will be removed in a future major release.
 
 !!! warning "Mounted certs must be readable by uid/gid 1000"
     The container drops privileges to the unprivileged `dnsweaver` user, so a

--- a/docs/sources/native-labels.md
+++ b/docs/sources/native-labels.md
@@ -81,6 +81,7 @@ labels:
 | `dnsweaver.hostnames` | - | Comma-separated list of hostnames |
 | `dnsweaver.enabled` | `true` | Enable/disable processing |
 | `dnsweaver.ttl` | - | Override TTL for this container |
+| `dnsweaver.proxied` | provider default | Cloudflare proxy (orange-cloud) override — `true` or `false`. Applies to every hostname on the container. Ignored by non-Cloudflare providers. |
 
 ### Named Record Labels
 
@@ -97,6 +98,8 @@ For advanced use cases, use the named record format: `dnsweaver.records.<name>.<
 | `dnsweaver.records.<name>.priority` | - | Priority (for SRV records) |
 | `dnsweaver.records.<name>.weight` | - | Weight (for SRV records) |
 | `dnsweaver.records.<name>.enabled` | `true` | Enable/disable this record |
+| `dnsweaver.records.<name>.proxied` | provider default | Cloudflare proxy (orange-cloud) override for this record — `true` or `false`. Ignored by non-Cloudflare providers. |
+| `dnsweaver.records.<name>.meta.<key>` | - | Arbitrary provider metadata passed through to the target provider (advanced). |
 
 ## Examples
 
@@ -140,6 +143,39 @@ services:
       - "dnsweaver.records.mc.priority=10"
       - "dnsweaver.records.mc.weight=100"
 ```
+
+### Cloudflare Proxy Override (Per-Host)
+
+When a hostname is served by a [Cloudflare provider](../providers/cloudflare.md),
+the `proxied` label overrides that provider's `PROXIED` default on a per-host
+basis. This is the typical "most services proxied, a few DNS-only" pattern —
+keep the provider default proxied and flip individual hosts off.
+
+Simple hostname form (applies to every hostname on the container):
+
+```yaml
+labels:
+  - "dnsweaver.hostname=ssh.example.com"
+  - "dnsweaver.proxied=false"  # DNS-only, bypass Cloudflare's proxy
+```
+
+Named-record form (mix proxied and DNS-only on one service):
+
+```yaml
+labels:
+  - "dnsweaver.records.app.hostname=app.example.com"
+  - "dnsweaver.records.app.proxied=true"   # orange-cloud
+
+  - "dnsweaver.records.ssh.hostname=ssh.example.com"
+  - "dnsweaver.records.ssh.proxied=false"  # DNS-only
+
+  - "dnsweaver.records.vpn.hostname=vpn.example.com"
+  - "dnsweaver.records.vpn.proxied=false"  # DNS-only
+```
+
+When a record does not set `proxied`, the Cloudflare instance's
+`DNSWEAVER_{NAME}_PROXIED` value (default `true`) is used as the fallback. The
+label is ignored by providers that have no concept of proxying.
 
 ### Combine with Traefik Labels
 

--- a/docs/sources/proxmox.md
+++ b/docs/sources/proxmox.md
@@ -40,7 +40,7 @@ flowchart LR
 | `DNSWEAVER_PROXMOX_TLS_SERVER_NAME` | No | — | SNI / verification hostname override. |
 | `DNSWEAVER_PROXMOX_TLS_MIN_VERSION` | No | `1.2` | Minimum TLS protocol version (`1.2` or `1.3`). |
 | `DNSWEAVER_PROXMOX_TLS_SKIP_VERIFY` | No | `false` | Skip PVE TLS certificate verification. Prefer `TLS_CA_FILE`. |
-| `DNSWEAVER_PROXMOX_VERIFY_TLS` | No | `true` | **Deprecated** inverted-polarity alias of `TLS_SKIP_VERIFY` (removed in v2.0). |
+| `DNSWEAVER_PROXMOX_VERIFY_TLS` | No | `true` | **Deprecated** inverted-polarity alias of `TLS_SKIP_VERIFY` (will be removed in a future major release). |
 | `DNSWEAVER_PROXMOX_NODE_FILTER` | No | _(all nodes)_ | Restrict discovery to a single PVE node name |
 | `DNSWEAVER_PROXMOX_TAG_FILTER` | No | _(all tags)_ | Only include resources with this tag (prefix match) |
 | `DNSWEAVER_PROXMOX_STATE_FILTER` | No | `running` | PVE resource status filter (`running`, `stopped`, etc.) |
@@ -310,7 +310,7 @@ DNSWEAVER_PROXMOX_TLS_SKIP_VERIFY=true
 ```
 
 The legacy `DNSWEAVER_PROXMOX_VERIFY_TLS` variable (note inverted polarity)
-still works but emits a deprecation warning and will be removed in v2.0.
+still works but emits a deprecation warning and will be removed in a future major release.
 
 ### No records created
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -347,7 +347,7 @@ func (c *Config) ProxmoxTargetMode() string {
 //
 // Deprecated: prefer ProxmoxTLS().InsecureSkip (inverted polarity). Retained
 // so the legacy env var DNSWEAVER_PROXMOX_VERIFY_TLS continues to flow through
-// the same Config accessor for one release; will be removed in v2.0.
+// the same Config accessor; will be removed in a future major release.
 func (c *Config) ProxmoxVerifyTLS() bool {
 	return c.Global.ProxmoxVerifyTLS
 }

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -412,7 +412,8 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	// Unified PVE TLS env vars (v1.5+). The legacy DNSWEAVER_PROXMOX_VERIFY_TLS
 	// is honored as a back-compat alias (inverted polarity) with a deprecation
 	// warning. When both are set, the new TLS_SKIP_VERIFY wins and a conflict
-	// warning is emitted. Legacy alias is scheduled for removal in v2.0.
+	// warning is emitted. Legacy alias is scheduled for removal in a future
+	// major release.
 	cfg.ProxmoxTLSCAFile = getEnv("DNSWEAVER_PROXMOX_TLS_CA_FILE")
 	cfg.ProxmoxTLSCertFile = getEnv("DNSWEAVER_PROXMOX_TLS_CERT_FILE")
 	cfg.ProxmoxTLSKeyFile = getEnv("DNSWEAVER_PROXMOX_TLS_KEY_FILE")
@@ -423,12 +424,12 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	_, hasLegacy := os.LookupEnv("DNSWEAVER_PROXMOX_VERIFY_TLS")
 	switch {
 	case hasNew && hasLegacy:
-		slog.Warn("both DNSWEAVER_PROXMOX_VERIFY_TLS (deprecated) and DNSWEAVER_PROXMOX_TLS_SKIP_VERIFY are set; the new TLS_SKIP_VERIFY value wins. Remove VERIFY_TLS — it will be removed in v2.0.")
+		slog.Warn("both DNSWEAVER_PROXMOX_VERIFY_TLS (deprecated) and DNSWEAVER_PROXMOX_TLS_SKIP_VERIFY are set; the new TLS_SKIP_VERIFY value wins. Remove VERIFY_TLS — it will be removed in a future major release.")
 		cfg.ProxmoxTLSSkipVerify = parseBool(skipNew, false)
 	case hasNew:
 		cfg.ProxmoxTLSSkipVerify = parseBool(skipNew, false)
 	case hasLegacy:
-		slog.Warn("DNSWEAVER_PROXMOX_VERIFY_TLS is deprecated; use DNSWEAVER_PROXMOX_TLS_SKIP_VERIFY instead (legacy alias will be removed in v2.0)")
+		slog.Warn("DNSWEAVER_PROXMOX_VERIFY_TLS is deprecated; use DNSWEAVER_PROXMOX_TLS_SKIP_VERIFY instead (legacy alias will be removed in a future major release)")
 		// Invert polarity: VERIFY_TLS=true → TLS_SKIP_VERIFY=false
 		cfg.ProxmoxTLSSkipVerify = !cfg.ProxmoxVerifyTLS
 	}

--- a/internal/config/instance.go
+++ b/internal/config/instance.go
@@ -220,7 +220,8 @@ func loadInstanceConfig(instanceName string, defaultTTL int) (*ProviderInstanceC
 
 // resolveLegacyTLSSkipVerify migrates DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY
 // into TLS_SKIP_VERIFY in the per-instance ProviderConfig map and emits a
-// deprecation warning when the legacy key is in use. Removed: v2.0.
+// deprecation warning when the legacy key is in use. Scheduled for removal in
+// a future major release.
 func resolveLegacyTLSSkipVerify(cfgMap map[string]string, instanceName string) {
 	const (
 		legacy    = "INSECURE_SKIP_VERIFY"
@@ -230,12 +231,12 @@ func resolveLegacyTLSSkipVerify(cfgMap map[string]string, instanceName string) {
 	_, hasCanonical := cfgMap[canonical]
 	switch {
 	case hasLegacy && hasCanonical:
-		slog.Warn("both DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY (deprecated) and DNSWEAVER_{NAME}_TLS_SKIP_VERIFY are set; the new TLS_SKIP_VERIFY value wins. Remove INSECURE_SKIP_VERIFY — it will be removed in v2.0.",
+		slog.Warn("both DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY (deprecated) and DNSWEAVER_{NAME}_TLS_SKIP_VERIFY are set; the new TLS_SKIP_VERIFY value wins. Remove INSECURE_SKIP_VERIFY — it will be removed in a future major release.",
 			slog.String("instance", instanceName),
 		)
 		delete(cfgMap, legacy)
 	case hasLegacy:
-		slog.Warn("DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY is deprecated; use DNSWEAVER_{NAME}_TLS_SKIP_VERIFY instead (the legacy name will be removed in v2.0)",
+		slog.Warn("DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY is deprecated; use DNSWEAVER_{NAME}_TLS_SKIP_VERIFY instead (the legacy name will be removed in a future major release)",
 			slog.String("instance", instanceName),
 		)
 		cfgMap[canonical] = legacyVal
@@ -272,7 +273,7 @@ var providerConfigFields = []struct {
 	{"API_SECRET", true},            // OPNsense specific: paired with API_KEY for basic auth
 	{"ENGINE", false},               // OPNsense specific: unbound|dnsmasq resolver selection
 	{"RECONFIGURE_MODE", false},     // OPNsense specific: per_write|never
-	{"INSECURE_SKIP_VERIFY", false}, // DEPRECATED: alias for TLS_SKIP_VERIFY, kept one release
+	{"INSECURE_SKIP_VERIFY", false}, // DEPRECATED: alias for TLS_SKIP_VERIFY
 	// Unified TLS fields — consumed by pkg/provider/extractTLSConfig and
 	// passed to every HTTP-based provider via FactoryConfig.HTTP.TLS.
 	{"TLS_CA_FILE", false},        // PEM CA bundle path (appended to system roots)

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -54,8 +54,8 @@ type ClientConfig struct {
 	//
 	// Deprecated: use TLS for full control (CA bundle, mTLS, SNI, min version,
 	// skip-verify). When TLS is non-nil, VerifyTLS is ignored. Retained so the
-	// legacy DNSWEAVER_PROXMOX_VERIFY_TLS env var path still works for one
-	// release; will be removed in v2.0.
+	// legacy DNSWEAVER_PROXMOX_VERIFY_TLS env var path still works; will be
+	// removed in a future major release.
 	VerifyTLS bool
 
 	// TLS is the unified TLS configuration. When non-nil, it fully describes


### PR DESCRIPTION
## Summary

Documentation cohesion pass triggered by [discussion #113](https://github.com/maxfield-allison/dnsweaver/discussions/113) (per-host Cloudflare proxy control), plus cleanup of stale deprecation notices now that the project is past v2.0.

### Docs
- Document the Cloudflare per-host proxy override in the native Label Reference: `dnsweaver.proxied` (simple form) and `dnsweaver.records.<name>.proxied` (named-record form), plus the previously-undocumented `dnsweaver.records.<name>.meta.<key>`. Verified against `sources/dnsweaver/parser.go` — both map to `Metadata["proxied"]` with the instance `PROXIED` default as fallback.
- New worked examples on the native-labels page (**Cloudflare Proxy Override (Per-Host)**) and a cross-linked **Per-Host Proxy Override (Labels)** section on the Cloudflare provider page.
- Add the `incus` source to the `DNSWEAVER_SOURCES` enumeration.
- Replace stale "will be removed in v2.0" notes (project ships v2.3.0 with the aliases still present) with "a future major release" across environment, FAQ, Proxmox source, and the cloudflare/adguard/technitium/pihole/webhook provider pages.

### Code
- Same stale "v2.0" text corrected in the actual Go source, including two operator-facing `slog.Warn` strings (`internal/config/instance.go`, `internal/config/global.go`) plus deprecated-field comments. No behavior change — log text and comments only.

### Validation
- `go vet`, `go build`, and `internal/config` + `internal/proxmox` tests pass.
- `mkdocs build` adds no new content/link warnings.

Closes the documentation gap raised in #113.