### PR TITLE
fix(docker): support root-owned sockets via DNSWEAVER_DOCKER_GID + socket proxy (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   privacy leak). `go.mod`, the Dockerfile `GO_VERSION`, and the GitLab CI base
   image are bumped in lock-step.
 
+### Added
+- **`DNSWEAVER_DOCKER_GID` escape hatch** for reading a Docker socket whose group
+  can't be auto-detected. The container entrypoint auto-detects a bind-mounted
+  socket's GID and adds the unprivileged `dnsweaver` user to it, but deliberately
+  skips GID 0 (root-owned sockets) rather than silently granting root-group
+  access. Platforms that force a root-owned socket and won't let you change it
+  (e.g. Synology Container Manager) can now set `DNSWEAVER_DOCKER_GID=0` to opt
+  in explicitly — the process still drops to `uid 1000` via `su-exec`, only a
+  supplementary group is added, so the application never runs as root. A loud
+  startup warning is emitted for the GID-0 case.
+  ([GitHub #79](https://github.com/maxfield-allison/dnsweaver/issues/79))
+
 ### Changed
 - Deprecation notices for the legacy TLS aliases (`INSECURE_SKIP_VERIFY`,
   `DNSWEAVER_PROXMOX_VERIFY_TLS`) no longer claim removal "in v2.0" — the
   project is already past v2.0 and the aliases still ship. The operator-facing
   log warnings now say "a future major release."
+
+### Documentation
+- Made the **Docker socket proxy** the recommended standalone deployment path,
+  with a full runnable example
+  ([`docs/examples/docker-compose.socket-proxy.example.yml`](docs/examples/docker-compose.socket-proxy.example.yml))
+  and a Synology-specific section covering the root-owned socket case. Documented
+  socket permissions, the non-root privilege drop, and `DNSWEAVER_DOCKER_GID`.
+  ([GitHub #79](https://github.com/maxfield-allison/dnsweaver/issues/79))
 
 ### Documentation
 - Documented the Cloudflare per-host **`proxied` override** in the native Label

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,38 +11,80 @@
 # Behavior:
 #   - If /var/run/docker.sock is mounted, read its GID and add the dnsweaver
 #     user to a group with that GID (creating the group if needed).
+#   - GID 0 (root-owned socket) is NOT granted automatically — that would give
+#     the dnsweaver user root-group access without the operator asking for it.
+#     Platforms that force a root-owned socket (e.g. Synology Container Manager)
+#     should use a socket proxy (recommended) or opt in with DNSWEAVER_DOCKER_GID.
 #   - If no socket is mounted (k8s-only mode, socket proxy, etc.), skip the
 #     logic entirely and just drop privileges.
 #   - Always exec the binary as the unprivileged dnsweaver user via su-exec.
 #
-# Manual escape hatch: users can still set `group_add` in compose for unusual
-# cases (rootless Docker with no group on the socket, etc.).
+# Escape hatch (DNSWEAVER_DOCKER_GID): explicitly grant the dnsweaver user
+# membership in a specific GID. Intended for platforms with a root-owned socket
+# that can't be chgrp'd (set DNSWEAVER_DOCKER_GID=0). The process still drops to
+# the unprivileged dnsweaver user via su-exec — only a supplementary group is
+# added, the application never runs as root.
 # =============================================================================
 
 set -e
 
 DOCKER_SOCK="${DOCKER_SOCK:-/var/run/docker.sock}"
 
+# add_to_gid GID
+# Ensure the dnsweaver user is a member (in /etc/group) of a group with the
+# given GID, creating the group if one doesn't already exist. Writing to
+# /etc/group is what makes the membership survive the su-exec privilege drop:
+# su-exec calls initgroups(), which rebuilds supplementary groups from
+# /etc/group rather than inheriting the container's initial (root) groups.
+add_to_gid() {
+    _gid="$1"
+    [ -z "$_gid" ] && return 0
+
+    # Already a member? Nothing to do.
+    if id -G dnsweaver | tr ' ' '\n' | grep -qx "$_gid"; then
+        return 0
+    fi
+
+    _group_name=$(getent group "$_gid" | cut -d: -f1)
+    if [ -z "$_group_name" ]; then
+        _group_name="docker-host-$_gid"
+        addgroup -g "$_gid" "$_group_name" 2>/dev/null || true
+    fi
+    # Add dnsweaver to the group (idempotent; ignore failure).
+    addgroup dnsweaver "$_group_name" 2>/dev/null || true
+}
+
+# 1. Auto-detect the mounted socket's GID (standard low-friction path).
 if [ -S "$DOCKER_SOCK" ]; then
     SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK")
 
-    # Skip if dnsweaver already has access (socket world-readable, GID matches
-    # dnsweaver's primary group, or running on a system where socket has no
-    # restrictive group).
-    if [ "$SOCK_GID" != "0" ] && ! id -G dnsweaver | tr ' ' '\n' | grep -qx "$SOCK_GID"; then
-        # Find or create a group with the socket's GID
-        GROUP_NAME=$(getent group "$SOCK_GID" | cut -d: -f1)
-        if [ -z "$GROUP_NAME" ]; then
-            GROUP_NAME="docker-host"
-            addgroup -g "$SOCK_GID" "$GROUP_NAME" 2>/dev/null || true
-        fi
-        # Add dnsweaver to the group (idempotent; ignore failure)
-        addgroup dnsweaver "$GROUP_NAME" 2>/dev/null || true
+    if [ "$SOCK_GID" != "0" ]; then
+        add_to_gid "$SOCK_GID"
+    elif [ -z "$DNSWEAVER_DOCKER_GID" ]; then
+        # Root-owned socket and no explicit opt-in: warn instead of silently
+        # granting root-group access.
+        echo "dnsweaver: docker socket $DOCKER_SOCK is owned by GID 0 (root)." >&2
+        echo "dnsweaver: not granting root-group access automatically." >&2
+        echo "dnsweaver: on platforms that force a root-owned socket (e.g. Synology)," >&2
+        echo "dnsweaver: use a socket proxy (recommended) or set DNSWEAVER_DOCKER_GID=0" >&2
+        echo "dnsweaver: to opt in. See docs/sources/docker.md." >&2
     fi
+fi
+
+# 2. Explicit GID opt-in (escape hatch for root-owned or otherwise
+#    undetectable sockets). The process still drops privileges below.
+if [ -n "$DNSWEAVER_DOCKER_GID" ]; then
+    if [ "$DNSWEAVER_DOCKER_GID" = "0" ]; then
+        echo "dnsweaver: WARNING DNSWEAVER_DOCKER_GID=0 — granting the dnsweaver user" >&2
+        echo "dnsweaver: membership in the root group so it can read a root-owned docker" >&2
+        echo "dnsweaver: socket. The process still runs unprivileged (uid 1000), but a" >&2
+        echo "dnsweaver: socket proxy gives stronger isolation. See docs/sources/docker.md." >&2
+    fi
+    add_to_gid "$DNSWEAVER_DOCKER_GID"
 fi
 
 # Note: use `dnsweaver` (not `dnsweaver:dnsweaver`) so su-exec picks up
 # supplementary groups from /etc/group. Specifying an explicit group resets
-# supplementary groups to the empty set, which would undo the docker-host
+# supplementary groups to the empty set, which would undo the group
 # membership we just added.
 exec su-exec dnsweaver /usr/local/bin/dnsweaver "$@"

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -52,6 +52,7 @@ dnsweaver --config /etc/dnsweaver/config.yml
 |----------|---------|-------------|
 | `DNSWEAVER_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker host (socket path or TCP URL) |
 | `DNSWEAVER_DOCKER_MODE` | `auto` | Docker mode: `auto`, `swarm`, `standalone` |
+| `DNSWEAVER_DOCKER_GID` | _(unset)_ | Explicitly add the unprivileged `dnsweaver` user to this group GID so it can read a socket whose GID can't be auto-detected (e.g. a root-owned socket on Synology: set `0`). The process still drops privileges; a [socket proxy](../sources/docker.md#socket-proxy-recommended-for-security) is stronger. |
 
 ### Socket Proxy Support
 

--- a/docs/examples/docker-compose.socket-proxy.example.yml
+++ b/docs/examples/docker-compose.socket-proxy.example.yml
@@ -1,0 +1,80 @@
+# Docker Compose Example — Socket Proxy (recommended for security)
+#
+# This is the recommended standalone Docker deployment. Instead of bind-mounting
+# /var/run/docker.sock directly into dnsweaver, a small read-only socket proxy
+# sits in front of the Docker API and exposes ONLY the endpoints dnsweaver needs.
+#
+# Why this is the secure path:
+#   - Direct socket access is equivalent to root on the host (anyone who can talk
+#     to docker.sock can start a privileged container that mounts the host FS).
+#   - dnsweaver only needs to READ containers, events, info, and (in Swarm)
+#     services/tasks/networks. The proxy blocks everything else (create, exec,
+#     volumes, secrets, ...), so a compromise of dnsweaver cannot drive the
+#     Docker API to escape the container.
+#   - dnsweaver never touches the socket, so it keeps running as its unprivileged
+#     uid 1000 user with no GID juggling.
+#
+# This is also the cleanest fix for platforms that force a root-owned socket and
+# won't let you change its ownership (e.g. Synology Container Manager): the proxy
+# runs as root (which those platforms require anyway) and dnsweaver does not.
+#
+# Deploy:
+#   docker compose -f docker-compose.socket-proxy.example.yml up -d
+
+services:
+  # -------------------------------------------------------------------------
+  # Docker socket proxy — the ONLY container that touches the real socket.
+  # -------------------------------------------------------------------------
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    restart: unless-stopped
+    environment:
+      # Grant only what dnsweaver needs (read-only). Everything else stays 0.
+      CONTAINERS: 1   # list/inspect containers (standalone Docker)
+      EVENTS: 1       # stream start/stop events (default on, listed for clarity)
+      INFO: 1         # dnsweaver queries /info at startup
+      PING: 1         # health/connectivity check
+      # Swarm-only endpoints — enable if dnsweaver runs against a Swarm manager:
+      # SERVICES: 1
+      # TASKS: 1
+      # NETWORKS: 1
+    volumes:
+      # Read-only bind of the real socket. On Synology this is root-owned; the
+      # proxy runs as root so it can read it. dnsweaver never sees this mount.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - dnsweaver-internal
+    # The proxy is the trust boundary — never publish port 2375 to the host.
+
+  # -------------------------------------------------------------------------
+  # dnsweaver — talks to the proxy over TCP, runs unprivileged (uid 1000).
+  # -------------------------------------------------------------------------
+  dnsweaver:
+    image: ghcr.io/maxfield-allison/dnsweaver:latest
+    restart: unless-stopped
+    depends_on:
+      - socket-proxy
+    environment:
+      # Point dnsweaver at the proxy instead of a local socket. Because no
+      # unix socket is mounted, the entrypoint's GID auto-detection is a no-op.
+      DNSWEAVER_DOCKER_HOST: "tcp://socket-proxy:2375"
+
+      DNSWEAVER_LOG_LEVEL: "info"
+
+      # --- Example provider config (replace with your own) ---------------
+      DNSWEAVER_INSTANCES: "internal"
+      DNSWEAVER_INTERNAL_TYPE: "technitium"
+      DNSWEAVER_INTERNAL_URL: "http://dns.example.com:5380"
+      DNSWEAVER_INTERNAL_TOKEN: "replace-me"
+      DNSWEAVER_INTERNAL_ZONE: "home.example.com"
+      DNSWEAVER_INTERNAL_RECORD_TYPE: "A"
+      DNSWEAVER_INTERNAL_TARGET: "192.0.2.10"
+      DNSWEAVER_INTERNAL_DOMAINS: "*.home.example.com"
+    networks:
+      - dnsweaver-internal
+    ports:
+      - "8080:8080"   # health endpoint (optional)
+
+networks:
+  dnsweaver-internal:
+    driver: bridge

--- a/docs/sources/docker.md
+++ b/docs/sources/docker.md
@@ -79,7 +79,11 @@ environment:
 
 ### Socket Proxy (Recommended for Security)
 
-Use a socket proxy for improved security:
+A socket proxy is the **recommended** way to give dnsweaver Docker access. It
+sits in front of the Docker API and exposes only the read-only endpoints
+dnsweaver needs, so a compromise of dnsweaver can't drive the full Docker API to
+escape the container. dnsweaver connects over TCP and never touches the socket,
+so it also keeps running as its unprivileged `uid 1000` user.
 
 ```yaml
 services:
@@ -87,14 +91,18 @@ services:
     image: tecnativa/docker-socket-proxy
     environment:
       - CONTAINERS=1
-      - SERVICES=1
-      - TASKS=1
-      - NETWORKS=1
+      - EVENTS=1
+      - INFO=1
+      - PING=1
+      # Swarm only:
+      # - SERVICES=1
+      # - TASKS=1
+      # - NETWORKS=1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   dnsweaver:
-    image: maxamill/dnsweaver:latest
+    image: ghcr.io/maxfield-allison/dnsweaver:latest
     environment:
       - DNSWEAVER_DOCKER_HOST=tcp://socket-proxy:2375
     depends_on:
@@ -103,9 +111,55 @@ services:
 
 Required socket proxy permissions:
 - `CONTAINERS=1` - Read container info
-- `SERVICES=1` - Read service info (Swarm)
-- `TASKS=1` - Read task info (Swarm)
-- `NETWORKS=1` - Read network info
+- `EVENTS=1` - Stream container start/stop events
+- `INFO=1` - dnsweaver queries `/info` at startup
+- `PING=1` - Connectivity/health check
+- `SERVICES=1` - Read service info (Swarm only)
+- `TASKS=1` - Read task info (Swarm only)
+- `NETWORKS=1` - Read network info (Swarm only)
+
+A full runnable example lives at
+[`docs/examples/docker-compose.socket-proxy.example.yml`](https://github.com/maxfield-allison/dnsweaver/blob/main/docs/examples/docker-compose.socket-proxy.example.yml).
+
+## Socket Permissions & the Non-Root User
+
+dnsweaver runs as an unprivileged user (`uid 1000`) inside the container. When
+you bind-mount the socket directly, the container starts as root just long
+enough for its entrypoint to detect the socket's group (GID) and add the
+`dnsweaver` user to it, then drops privileges via `su-exec`. The standard
+compose example works out of the box — no `group_add` needed.
+
+The entrypoint deliberately **does not** grant access when the socket is owned
+by GID 0 (root), because that would silently hand the `dnsweaver` user
+root-group membership. If that happens you'll see a startup log explaining the
+options below.
+
+### `DNSWEAVER_DOCKER_GID` (explicit opt-in)
+
+Set this to force the `dnsweaver` user into a specific group GID. It's an escape
+hatch for platforms whose socket ownership can't be detected or changed:
+
+```yaml
+environment:
+  - DNSWEAVER_DOCKER_GID=0   # read a root-owned socket
+```
+
+The process still drops to `uid 1000` — only a supplementary group is added, so
+the application never runs as root. A socket proxy is still the stronger option.
+
+### Synology (Container Manager)
+
+Synology's Container Manager mounts `/var/run/docker.sock` as `root:root` and
+reverts ownership changes on reboot, and it won't let you create host users with
+arbitrary UIDs/GIDs. Because the socket is GID 0, direct-mount auto-detection is
+intentionally skipped. Two supported ways forward:
+
+1. **Socket proxy (recommended).** The proxy runs as root (which Synology
+   requires anyway) and dnsweaver connects over TCP as `uid 1000`. See the
+   example above.
+2. **`DNSWEAVER_DOCKER_GID=0`.** Quick single-line opt-in that lets the
+   unprivileged dnsweaver user read the root-owned socket. Simpler, but grants
+   the container's user root-group membership, so prefer the proxy where you can.
 
 ## Event Processing
 


### PR DESCRIPTION
Follow-up to #79.

## Problem
Synology Container Manager mounts \`/var/run/docker.sock\` as \`root:root\` (GID 0) and reverts ownership changes on reboot, and won't let you create host users with arbitrary UID/GID. The v1.1.4 entrypoint auto-detects the socket GID but **intentionally skips GID 0** (to avoid silently granting root-group access), so the unprivileged \`dnsweaver\` user (uid 1000) can't read a root-owned socket. There was no supported way forward.

## Approach
Keep the non-root privilege drop — the application never runs as root — and add two supported paths:

1. **Socket proxy (recommended).** Now the recommended standalone deployment. A read-only [tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) exposes only the endpoints dnsweaver needs; dnsweaver connects over TCP as uid 1000 and never touches the socket. The proxy runs as root — which Synology requires anyway — so dnsweaver doesn't have to. New runnable example at \`docs/examples/docker-compose.socket-proxy.example.yml\`.
2. **\`DNSWEAVER_DOCKER_GID\` (explicit opt-in).** Set \`DNSWEAVER_DOCKER_GID=0\` to add the \`dnsweaver\` user to the root group so it can read a root-owned socket. The process **still drops to uid 1000 via su-exec** — only a supplementary group is added. A loud startup warning is emitted for the GID-0 case.

A run-as-root mode was deliberately **not** added: direct socket access is already host-root-equivalent, so running the app as root is strictly weaker than the two options above and unnecessary given the socket proxy.

## Changes
- \`docker/entrypoint.sh\` — \`add_to_gid\` helper; GID-0 guidance; \`DNSWEAVER_DOCKER_GID\` opt-in that preserves the privilege drop.
- \`docs/examples/docker-compose.socket-proxy.example.yml\` — new runnable example.
- \`docs/sources/docker.md\` — socket proxy elevated to recommended; new "Socket Permissions & the Non-Root User" + Synology sections.
- \`docs/configuration/environment.md\` — \`DNSWEAVER_DOCKER_GID\` reference.
- \`CHANGELOG.md\` — Unreleased entry.

## Testing
Entrypoint passes \`dash -n\`; the GID-0 flow uses the same \`su-exec\` + \`/etc/group\` mechanism already proven for non-zero GIDs. Seeking confirmation from a Synology user on #79.

Refs #79