### PR TITLE
fix(docker): bounded startup connection retry (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Bounded Docker startup connection retry** (`DNSWEAVER_DOCKER_CONNECT_TIMEOUT`,
+  default `30s`). dnsweaver now retries the initial Docker connection with capped
+  backoff before failing hard, instead of exiting on the first error. This fixes
+  a startup race with label-driven socket proxies (e.g. `wollomatic/socket-proxy`)
+  that only authorize dnsweaver's container a few seconds after it starts — the
+  first `Info`/`ping` call would hit `403`/`405` and the process would exit. It
+  logs `waiting for docker endpoint to become available` at INFO until connected.
+  Set `DNSWEAVER_DOCKER_CONNECT_TIMEOUT=0` for strict fail-fast. Deterministic
+  misconfiguration (Swarm forced but node is not a manager) still fails
+  immediately. ([GitHub #125](https://github.com/maxfield-allison/dnsweaver/issues/125))
+
 ### Security
 - Bumped the Go toolchain to **1.26.5** to pick up the `crypto/tls` fix for
   [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -173,6 +173,7 @@ func run() error {
 			docker.WithMode(parseDockerMode(cfg.DockerMode())),
 			docker.WithLogger(logger),
 			docker.WithCleanupOnStop(cfg.CleanupOnStop()),
+			docker.WithConnectTimeout(cfg.DockerConnectTimeout()),
 		)
 		if err != nil {
 			return fmt.Errorf("creating docker client: %w", err)

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -53,6 +53,7 @@ dnsweaver --config /etc/dnsweaver/config.yml
 | `DNSWEAVER_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker host (socket path or TCP URL) |
 | `DNSWEAVER_DOCKER_MODE` | `auto` | Docker mode: `auto`, `swarm`, `standalone` |
 | `DNSWEAVER_DOCKER_GID` | _(unset)_ | Explicitly add the unprivileged `dnsweaver` user to this group GID so it can read a socket whose GID can't be auto-detected (e.g. a root-owned socket on Synology: set `0`). The process still drops privileges; a [socket proxy](../sources/docker.md#socket-proxy-recommended-for-security) is stronger. |
+| `DNSWEAVER_DOCKER_CONNECT_TIMEOUT` | `30s` | How long to retry the initial Docker connection before failing hard (Go duration). Set `0` for strict fail-fast (exit on the first error). Useful with a label-driven [socket proxy](../sources/docker.md#socket-proxy-recommended-for-security) that authorizes dnsweaver a few seconds after startup. |
 
 ### Socket Proxy Support
 

--- a/docs/sources/docker.md
+++ b/docs/sources/docker.md
@@ -161,6 +161,22 @@ intentionally skipped. Two supported ways forward:
    unprivileged dnsweaver user read the root-owned socket. Simpler, but grants
    the container's user root-group membership, so prefer the proxy where you can.
 
+#### Startup timing with label-driven proxies
+
+Some proxies (e.g. [`wollomatic/socket-proxy`](https://github.com/wollomatic/socket-proxy))
+build their allow-list *per container* from Docker labels and only authorize
+dnsweaver a few seconds **after** its container starts. During that brief window
+every request is blocked (`403`/`405`), so dnsweaver's first Docker call can
+fail.
+
+dnsweaver handles this by retrying the initial Docker connection for up to
+`DNSWEAVER_DOCKER_CONNECT_TIMEOUT` (default `30s`) before failing hard. You'll
+see `waiting for docker endpoint to become available` at INFO level until the
+proxy authorizes it. Set `DNSWEAVER_DOCKER_CONNECT_TIMEOUT=0` for strict
+fail-fast (exit on the first error) if you prefer to rely on the container
+restart policy instead.
+
+
 ## Event Processing
 
 When a container/service starts:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,13 @@ func (c *Config) DockerHost() string {
 	return c.Global.DockerHost
 }
 
+// DockerConnectTimeout returns the maximum time to keep retrying the initial
+// Docker connection before failing hard. Zero means fail immediately on the
+// first connection error.
+func (c *Config) DockerConnectTimeout() time.Duration {
+	return c.Global.DockerConnectTimeout
+}
+
 // DockerMode returns the Docker mode (auto/swarm/standalone).
 func (c *Config) DockerMode() string {
 	return c.Global.DockerMode

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -74,8 +74,9 @@ type FileReconcilerConfig struct {
 
 // FileDockerConfig holds Docker connection settings.
 type FileDockerConfig struct {
-	Host string `yaml:"host,omitempty"` // unix:///var/run/docker.sock or tcp://...
-	Mode string `yaml:"mode,omitempty"` // auto, swarm, standalone
+	Host           string `yaml:"host,omitempty"`            // unix:///var/run/docker.sock or tcp://...
+	Mode           string `yaml:"mode,omitempty"`            // auto, swarm, standalone
+	ConnectTimeout string `yaml:"connect_timeout,omitempty"` // Max time to retry the initial connect before failing hard (e.g. 30s); "0" fails immediately
 }
 
 // FileKubernetesConfig holds Kubernetes watcher settings.
@@ -259,6 +260,7 @@ func (c *FileConfig) ToGlobalConfig() *GlobalConfig {
 		Platform:             DefaultPlatform,
 		DockerHost:           DefaultDockerHost,
 		DockerMode:           DefaultDockerMode,
+		DockerConnectTimeout: DefaultDockerConnectTimeout,
 		K8sWatchIngress:      true,
 		K8sWatchIngressRoute: true,
 		K8sWatchHTTPRoute:    true,
@@ -335,6 +337,11 @@ func (c *FileConfig) ToGlobalConfig() *GlobalConfig {
 		}
 		if c.Docker.Mode != "" {
 			cfg.DockerMode = strings.ToLower(c.Docker.Mode)
+		}
+		if c.Docker.ConnectTimeout != "" {
+			if timeout, err := time.ParseDuration(c.Docker.ConnectTimeout); err == nil && timeout >= 0 {
+				cfg.DockerConnectTimeout = timeout
+			}
 		}
 	}
 

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -12,26 +12,27 @@ import (
 
 // Global configuration defaults.
 const (
-	DefaultLogLevel          = "info"
-	DefaultLogFormat         = "json"
-	DefaultLogMaxSize        = 100  // megabytes
-	DefaultLogMaxBackups     = 5    // number of old log files to keep
-	DefaultLogMaxAge         = 30   // days to retain old logs
-	DefaultLogCompress       = true // compress rotated log files
-	DefaultDryRun            = false
-	DefaultCleanupOrphans    = true
-	DefaultCleanupOnStop     = true
-	DefaultOwnershipTracking = true
-	DefaultAdoptExisting     = false
-	DefaultTTL               = 300
-	DefaultReconcileInterval = 60 * time.Second
-	DefaultShutdownTimeout   = 30 * time.Second
-	DefaultHealthPort        = 8080
-	DefaultDockerHost        = "unix:///var/run/docker.sock"
-	DefaultDockerMode        = "auto"
-	DefaultSource            = "traefik"
-	DefaultInstanceID        = ""
-	DefaultPlatform          = "docker"
+	DefaultLogLevel             = "info"
+	DefaultLogFormat            = "json"
+	DefaultLogMaxSize           = 100  // megabytes
+	DefaultLogMaxBackups        = 5    // number of old log files to keep
+	DefaultLogMaxAge            = 30   // days to retain old logs
+	DefaultLogCompress          = true // compress rotated log files
+	DefaultDryRun               = false
+	DefaultCleanupOrphans       = true
+	DefaultCleanupOnStop        = true
+	DefaultOwnershipTracking    = true
+	DefaultAdoptExisting        = false
+	DefaultTTL                  = 300
+	DefaultReconcileInterval    = 60 * time.Second
+	DefaultShutdownTimeout      = 30 * time.Second
+	DefaultHealthPort           = 8080
+	DefaultDockerHost           = "unix:///var/run/docker.sock"
+	DefaultDockerMode           = "auto"
+	DefaultDockerConnectTimeout = 30 * time.Second
+	DefaultSource               = "traefik"
+	DefaultInstanceID           = ""
+	DefaultPlatform             = "docker"
 )
 
 // InstanceID validation constraints.
@@ -66,8 +67,9 @@ type GlobalConfig struct {
 	Platform string // docker, kubernetes, both
 
 	// Docker connection
-	DockerHost string // Docker socket path or TCP URL
-	DockerMode string // auto, swarm, standalone
+	DockerHost           string        // Docker socket path or TCP URL
+	DockerMode           string        // auto, swarm, standalone
+	DockerConnectTimeout time.Duration // Max time to keep retrying the initial Docker connect before failing hard; 0 = fail immediately
 
 	// Kubernetes settings
 	K8sKubeconfig        string // Path to kubeconfig file; empty = in-cluster
@@ -330,6 +332,25 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 		}
 	} else {
 		cfg.ShutdownTimeout = DefaultShutdownTimeout
+	}
+
+	// Parse DOCKER_CONNECT_TIMEOUT (supports Go duration format: 30s, 1m, etc.)
+	// This bounds how long dnsweaver retries the initial Docker connection before
+	// failing hard. A value of 0 disables retrying (fail immediately on the first
+	// error) for operators who want strict fail-fast behavior. It exists so a
+	// label-driven socket proxy (which only authorizes dnsweaver a few seconds
+	// after its container starts) doesn't lose a startup race (#125).
+	if timeoutStr := getEnv("DNSWEAVER_DOCKER_CONNECT_TIMEOUT"); timeoutStr != "" {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			errs = append(errs, configErrFull("DNSWEAVER_DOCKER_CONNECT_TIMEOUT", fmt.Sprintf("invalid duration %q", timeoutStr), "Use Go duration format: 30s, 1m; 0 to fail immediately", "DNSWEAVER_DOCKER_CONNECT_TIMEOUT=30s"))
+		} else if timeout < 0 {
+			errs = append(errs, configErrFull("DNSWEAVER_DOCKER_CONNECT_TIMEOUT", "must not be negative", "Use 0 to fail immediately, or a positive duration to retry", "DNSWEAVER_DOCKER_CONNECT_TIMEOUT=30s"))
+		} else {
+			cfg.DockerConnectTimeout = timeout
+		}
+	} else {
+		cfg.DockerConnectTimeout = DefaultDockerConnectTimeout
 	}
 
 	// Parse HEALTH_PORT

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -27,6 +27,7 @@ func clearGlobalEnv(t *testing.T) {
 		"DNSWEAVER_HEALTH_PORT",
 		"DNSWEAVER_DOCKER_HOST",
 		"DNSWEAVER_DOCKER_MODE",
+		"DNSWEAVER_DOCKER_CONNECT_TIMEOUT",
 		"DNSWEAVER_SOURCES",
 		"DNSWEAVER_SOURCE",
 		"DNSWEAVER_INSTANCE_ID",
@@ -98,6 +99,9 @@ func TestLoadGlobalConfig_Defaults(t *testing.T) {
 	if cfg.DockerMode != DefaultDockerMode {
 		t.Errorf("DockerMode = %q, want %q", cfg.DockerMode, DefaultDockerMode)
 	}
+	if cfg.DockerConnectTimeout != DefaultDockerConnectTimeout {
+		t.Errorf("DockerConnectTimeout = %v, want %v", cfg.DockerConnectTimeout, DefaultDockerConnectTimeout)
+	}
 	if cfg.Source != DefaultSource {
 		t.Errorf("Source = %q, want %q", cfg.Source, DefaultSource)
 	}
@@ -123,6 +127,7 @@ func TestLoadGlobalConfig_CustomValues(t *testing.T) {
 	os.Setenv("DNSWEAVER_HEALTH_PORT", "9090")
 	os.Setenv("DNSWEAVER_DOCKER_HOST", "tcp://localhost:2375")
 	os.Setenv("DNSWEAVER_DOCKER_MODE", "swarm")
+	os.Setenv("DNSWEAVER_DOCKER_CONNECT_TIMEOUT", "45s")
 	os.Setenv("DNSWEAVER_LOG_FILE", "/var/log/dnsweaver.log")
 	os.Setenv("DNSWEAVER_LOG_MAX_SIZE", "50")
 	os.Setenv("DNSWEAVER_LOG_MAX_BACKUPS", "3")
@@ -179,6 +184,9 @@ func TestLoadGlobalConfig_CustomValues(t *testing.T) {
 	}
 	if cfg.DockerMode != "swarm" {
 		t.Errorf("DockerMode = %q, want %q", cfg.DockerMode, "swarm")
+	}
+	if cfg.DockerConnectTimeout != 45*time.Second {
+		t.Errorf("DockerConnectTimeout = %v, want %v", cfg.DockerConnectTimeout, 45*time.Second)
 	}
 	if cfg.Source != DefaultSource {
 		t.Errorf("Source = %q, want %q (deprecated DNSWEAVER_SOURCE should not set GlobalConfig.Source)", cfg.Source, DefaultSource)

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -69,12 +70,13 @@ var (
 // standalone mode and provides appropriate methods for each. Use ListWorkloads()
 // for mode-agnostic workload listing.
 type Client struct {
-	docker        *client.Client
-	mode          Mode
-	detectedMode  Mode
-	logger        *slog.Logger
-	host          string
-	cleanupOnStop bool // If true, only list running containers; if false, include stopped
+	docker         *client.Client
+	mode           Mode
+	detectedMode   Mode
+	logger         *slog.Logger
+	host           string
+	cleanupOnStop  bool          // If true, only list running containers; if false, include stopped
+	connectTimeout time.Duration // Max time to retry the initial connect before failing hard; 0 = fail immediately
 }
 
 // NewClient creates a new Docker client with the given options.
@@ -119,8 +121,12 @@ func NewClient(ctx context.Context, opts ...Option) (*Client, error) {
 	}
 	c.docker = dockerClient
 
-	// Detect or verify mode
-	if err := c.initializeMode(ctx); err != nil {
+	// Detect or verify mode, retrying the initial connection for up to
+	// connectTimeout. This tolerates a dependency that isn't ready the instant
+	// dnsweaver starts (e.g. a label-driven socket proxy that authorizes this
+	// container a few seconds after it comes up, #125) while still failing hard
+	// if the endpoint never becomes usable.
+	if err := c.connectWithRetry(ctx); err != nil {
 		dockerClient.Close()
 		return nil, err
 	}
@@ -131,6 +137,71 @@ func NewClient(ctx context.Context, opts ...Option) (*Client, error) {
 	)
 
 	return c, nil
+}
+
+// connectWithRetry runs initializeMode, retrying with capped exponential
+// backoff until it succeeds or connectTimeout elapses. A connectTimeout of 0
+// means fail immediately on the first error (strict fail-fast). Configuration
+// errors that can't be fixed by waiting (e.g. Swarm mode forced but this node
+// is not a manager) fail immediately regardless of the timeout.
+func (c *Client) connectWithRetry(ctx context.Context) error {
+	err := c.initializeMode(ctx)
+	if err == nil {
+		return nil
+	}
+	// Never retry deterministic misconfiguration — waiting won't fix it.
+	if c.connectTimeout <= 0 || isTerminalModeErr(err) {
+		return err
+	}
+
+	deadline := time.Now().Add(c.connectTimeout)
+	backoff := 500 * time.Millisecond
+	const maxBackoff = 5 * time.Second
+
+	for {
+		wait := backoff
+		if remaining := time.Until(deadline); remaining < wait {
+			wait = remaining
+		}
+		if wait <= 0 {
+			return fmt.Errorf("connecting to docker after %s: %w", c.connectTimeout, err)
+		}
+
+		c.logger.Info("waiting for docker endpoint to become available",
+			slog.String("host", c.host),
+			slog.String("error", err.Error()),
+			slog.Duration("retry_in", wait),
+		)
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("connecting to docker: %w", ctx.Err())
+		case <-timer.C:
+		}
+
+		err = c.initializeMode(ctx)
+		if err == nil {
+			return nil
+		}
+		if isTerminalModeErr(err) {
+			return err
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}
+
+// isTerminalModeErr reports whether an initializeMode error is a deterministic
+// misconfiguration that retrying cannot resolve, so we should fail immediately
+// instead of waiting out the connect timeout.
+func isTerminalModeErr(err error) bool {
+	return errors.Is(err, ErrNotManager) || errors.Is(err, ErrSwarmNotActive)
 }
 
 // initializeMode detects or verifies the Docker mode based on configuration.

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/docker/docker/client"
 )
 
 // TestModeConstants verifies mode constants are correctly defined.
@@ -176,6 +179,109 @@ func TestWithHost(t *testing.T) {
 
 	if c.host != host {
 		t.Errorf("WithHost did not set host correctly: expected %s, got %s", host, c.host)
+	}
+}
+
+// TestWithConnectTimeout verifies the connect timeout option and that
+// non-positive values leave the default (zero) in place.
+func TestWithConnectTimeout(t *testing.T) {
+	c := &Client{}
+	WithConnectTimeout(30 * time.Second)(c)
+	if c.connectTimeout != 30*time.Second {
+		t.Errorf("WithConnectTimeout = %v, want %v", c.connectTimeout, 30*time.Second)
+	}
+
+	// Zero and negative values must not overwrite an existing value.
+	c.connectTimeout = 10 * time.Second
+	WithConnectTimeout(0)(c)
+	WithConnectTimeout(-5 * time.Second)(c)
+	if c.connectTimeout != 10*time.Second {
+		t.Errorf("WithConnectTimeout with non-positive value changed timeout to %v", c.connectTimeout)
+	}
+}
+
+// TestIsTerminalModeErr verifies which mode errors are treated as
+// non-retryable misconfiguration.
+func TestIsTerminalModeErr(t *testing.T) {
+	if !isTerminalModeErr(ErrNotManager) {
+		t.Error("ErrNotManager should be terminal")
+	}
+	if !isTerminalModeErr(ErrSwarmNotActive) {
+		t.Error("ErrSwarmNotActive should be terminal")
+	}
+	if isTerminalModeErr(errors.New("connection refused")) {
+		t.Error("a generic connectivity error should not be terminal")
+	}
+}
+
+// newDeadClient returns a Client whose Docker API points at a closed local
+// port, so initializeMode fails fast with a connection error (not a terminal
+// mode error). Used to exercise connectWithRetry deterministically.
+func newDeadClient(t *testing.T, connectTimeout time.Duration) *Client {
+	t.Helper()
+	dc, err := client.NewClientWithOpts(client.WithHost("tcp://127.0.0.1:1"))
+	if err != nil {
+		t.Fatalf("building docker client: %v", err)
+	}
+	t.Cleanup(func() { _ = dc.Close() })
+	return &Client{
+		docker:         dc,
+		mode:           ModeAuto,
+		logger:         slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		connectTimeout: connectTimeout,
+	}
+}
+
+// TestConnectWithRetry_FailFast verifies that a zero timeout fails immediately.
+func TestConnectWithRetry_FailFast(t *testing.T) {
+	c := newDeadClient(t, 0)
+	start := time.Now()
+	err := c.connectWithRetry(context.Background())
+	if err == nil {
+		t.Fatal("expected error connecting to a dead endpoint")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("fail-fast took %v, expected near-immediate", elapsed)
+	}
+}
+
+// TestConnectWithRetry_DeadlineExceeded verifies that a bounded timeout retries
+// and then fails hard once the deadline elapses.
+func TestConnectWithRetry_DeadlineExceeded(t *testing.T) {
+	c := newDeadClient(t, 700*time.Millisecond)
+	start := time.Now()
+	err := c.connectWithRetry(context.Background())
+	if err == nil {
+		t.Fatal("expected error after deadline")
+	}
+	elapsed := time.Since(start)
+	if elapsed < 500*time.Millisecond {
+		t.Errorf("returned too early (%v); should have retried until the deadline", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("took too long (%v); deadline was not honored", elapsed)
+	}
+}
+
+// TestConnectWithRetry_ContextCancel verifies that cancelling the context
+// aborts the retry loop promptly.
+func TestConnectWithRetry_ContextCancel(t *testing.T) {
+	c := newDeadClient(t, 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	err := c.connectWithRetry(ctx)
+	if err == nil {
+		t.Fatal("expected error when context is cancelled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("cancellation not honored promptly, took %v", elapsed)
 	}
 }
 

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -263,7 +263,7 @@ func TestConnectWithRetry_DeadlineExceeded(t *testing.T) {
 	}
 }
 
-// TestConnectWithRetry_ContextCancel verifies that cancelling the context
+// TestConnectWithRetry_ContextCancel verifies that canceling the context
 // aborts the retry loop promptly.
 func TestConnectWithRetry_ContextCancel(t *testing.T) {
 	c := newDeadClient(t, 30*time.Second)
@@ -275,7 +275,7 @@ func TestConnectWithRetry_ContextCancel(t *testing.T) {
 	start := time.Now()
 	err := c.connectWithRetry(ctx)
 	if err == nil {
-		t.Fatal("expected error when context is cancelled")
+		t.Fatal("expected error when context is canceled")
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)

--- a/internal/docker/options.go
+++ b/internal/docker/options.go
@@ -1,6 +1,9 @@
 package docker
 
-import "log/slog"
+import (
+	"log/slog"
+	"time"
+)
 
 // Option is a functional option for configuring the Client.
 type Option func(*Client)
@@ -55,5 +58,21 @@ func WithLogger(logger *slog.Logger) Option {
 func WithCleanupOnStop(cleanup bool) Option {
 	return func(c *Client) {
 		c.cleanupOnStop = cleanup
+	}
+}
+
+// WithConnectTimeout sets how long NewClient retries the initial Docker
+// connection before failing hard. Zero (the default when this option is
+// omitted) means fail immediately on the first connection error.
+//
+// This exists so a label-driven socket proxy — which only authorizes
+// dnsweaver's container a few seconds after it starts — doesn't lose a startup
+// race (#125). Deterministic misconfiguration (e.g. Swarm forced but the node
+// is not a manager) still fails immediately regardless of this value.
+func WithConnectTimeout(timeout time.Duration) Option {
+	return func(c *Client) {
+		if timeout > 0 {
+			c.connectTimeout = timeout
+		}
 	}
 }


### PR DESCRIPTION
Closes #125.

## Problem
Running dnsweaver behind a **label-driven** socket proxy (e.g. [`wollomatic/socket-proxy`](https://github.com/wollomatic/socket-proxy)) crashes at startup. The proxy builds its allow-list *per requesting container* and only authorizes dnsweaver a few seconds **after** its container starts. During that window every request is blocked (`403`/`405`), so dnsweaver's first Docker call (`Info` + version-negotiation `ping`) fails and the process exits:

```
fatal error: creating docker client: getting docker info: Error response from daemon: Method Not Allowed
```

With `restart: unless-stopped` it only recovers by winning a non-deterministic restart race — the proxy *removes* its allow-list when the container exits, so every crash-restart cycle resets proxy state (recovery took ~68s in the report).

## Approach — bounded fail-fast, not open-ended resilience
- **`DNSWEAVER_DOCKER_CONNECT_TIMEOUT`** (default **30s**) caps how long `docker.NewClient` retries the initial connect with capped exponential backoff (500ms → 5s), then **fails hard** with the last error.
- **`0`** = strict fail-fast (exit on the first error) for anyone who prefers to rely on the restart policy.
- Deterministic misconfiguration that waiting can't fix (`ErrNotManager`, `ErrSwarmNotActive`) **fails immediately** regardless of the timeout.
- Retries log `waiting for docker endpoint to become available` at INFO instead of a scary `ERROR fatal error`.
- Scope is the **initial connect only** — steady-state Docker errors are unchanged.

This matches the reporter's own ask ("retry with backoff **and a limit**") and the existing pattern where providers retry in the background rather than crashing at startup. Docker was the only startup dependency with zero tolerance.

## Changes
- `internal/docker/client.go` — `connectWithRetry` + `isTerminalModeErr`.
- `internal/docker/options.go` — `WithConnectTimeout`.
- `internal/config/{global,config,file}.go` — `DNSWEAVER_DOCKER_CONNECT_TIMEOUT` env + `docker.connect_timeout` YAML.
- `cmd/dnsweaver/main.go` — wire the option.
- Tests: option handling, fail-fast (0), deadline-exceeded, context-cancel, terminal-error classification.
- Docs: `docs/configuration/environment.md`, `docs/sources/docker.md` (startup timing section).

## Verification (local, Go 1.26.5)
- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — all pass (incl. new retry tests)
- `govulncheck` — only the 5 allowlisted docker/docker SDK vulns