### PR TITLE
docs: enrich diagrams (architecture, lifecycle, domain matching)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,29 @@ secrets:
 
 ```mermaid
 flowchart LR
-    A["Docker / Swarm"] --> B["dnsweaver"]
-    D["Kubernetes"] --> B
-    P["Proxmox VE"] --> B
-    I["Incus"] --> B
-    B --> C["DNS Providers<br/>(create / update / delete)"]
+    subgraph sources["Sources"]
+        direction TB
+        A["Docker / Swarm<br/>Traefik · Caddy · nginx labels"]
+        D["Kubernetes<br/>Ingress · HTTPRoute · Service"]
+        P["Proxmox VE · Incus<br/>VMs · LXC"]
+    end
+
+    subgraph engine["dnsweaver"]
+        direction TB
+        W["Watch<br/>events"] --> M["Match hostname<br/>to domain patterns"] --> R["Reconcile<br/>desired vs. live"]
+    end
+
+    subgraph providers["DNS providers · split-horizon"]
+        direction TB
+        INT["Internal<br/>Technitium · Pi-hole · AdGuard"]
+        EXT["External<br/>Cloudflare · OVH · RFC 2136"]
+    end
+
+    A --> W
+    D --> W
+    P --> W
+    R -->|create / update / delete| INT
+    R -->|create / update / delete| EXT
 ```
 
 1. A container starts with a Traefik label (or a Kubernetes Ingress/HTTPRoute is created):

--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -2,6 +2,21 @@
 
 dnsweaver supports flexible domain matching with glob patterns, regex, and exclusions.
 
+Each provider instance is evaluated **independently**: a hostname is first tested
+against the instance's `DOMAINS` patterns, then filtered by its
+`EXCLUDE_DOMAINS`. Because instances are independent, the same hostname can land
+in several providers at once — this is what makes split-horizon DNS work.
+
+```mermaid
+flowchart TD
+    H["Hostname from source<br/>e.g. app.example.com"] --> L{"Matches instance's<br/>DOMAINS pattern?"}
+    L -->|no| SKIP["Skip for this instance"]
+    L -->|yes| X{"Matches instance's<br/>EXCLUDE_DOMAINS?"}
+    X -->|yes| SKIP
+    X -->|no| CREATE["Create / update record<br/>in this provider"]
+    CREATE --> MULTI["Repeat for every instance<br/>(split-horizon)"]
+```
+
 ## Glob Patterns
 
 The default and simplest way to match domains:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -232,6 +232,27 @@ For production deployments, avoid passing credentials as plain environment varia
 
 See [Secrets Management](configuration/secrets.md) for more details.
 
+## How It Works
+
+Once dnsweaver is running, DNS records track the lifecycle of your workloads
+automatically:
+
+```mermaid
+sequenceDiagram
+    participant C as Container / Resource
+    participant D as dnsweaver
+    participant P as DNS provider
+    C->>D: starts with a hostname label / annotation
+    D->>D: extract hostname, match domain patterns
+    D->>P: create record (A / CNAME / ...)
+    Note over D,P: record stays in sync while the workload runs
+    C->>D: stops or is deleted
+    D->>P: delete record (ownership-tracked)
+```
+
+Records that dnsweaver created are tracked so it only ever modifies or removes
+its own entries — DNS you manage by hand is never touched.
+
 ## Verify It's Working
 
 === "Docker"

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,11 +69,29 @@ dnsweaver watches Docker events, Kubernetes resources, and Proxmox VE clusters t
 
 ```mermaid
 flowchart LR
-    A["Docker / Swarm"] --> B["dnsweaver"]
-    D["Kubernetes"] --> B
-    P["Proxmox VE"] --> B
-    I["Incus"] --> B
-    B --> C["DNS Providers<br/>(create / update / delete)"]
+    subgraph sources["Sources"]
+        direction TB
+        A["Docker / Swarm<br/>Traefik · Caddy · nginx labels"]
+        D["Kubernetes<br/>Ingress · HTTPRoute · Service"]
+        P["Proxmox VE · Incus<br/>VMs · LXC"]
+    end
+
+    subgraph engine["dnsweaver"]
+        direction TB
+        W["Watch<br/>events"] --> M["Match hostname<br/>to domain patterns"] --> R["Reconcile<br/>desired vs. live"]
+    end
+
+    subgraph providers["DNS providers · split-horizon"]
+        direction TB
+        INT["Internal<br/>Technitium · Pi-hole · AdGuard"]
+        EXT["External<br/>Cloudflare · OVH · RFC 2136"]
+    end
+
+    A --> W
+    D --> W
+    P --> W
+    R -->|create / update / delete| INT
+    R -->|create / update / delete| EXT
 ```
 
 === "Docker / Swarm"


### PR DESCRIPTION
Improves the Mermaid diagrams for clarity and adds two where they add real value.

## Changes
- **Architecture diagram (README + docs/index.md)** — replaced the flat `sources -> dnsweaver -> providers` flowchart with a three-stage **watch -> match -> reconcile** pipeline that also shows the **split-horizon** internal/external provider split. Names the label sources so newcomers see what's parsed.
- **Record lifecycle (getting-started.md)** — new `sequenceDiagram` showing the temporal flow: create on start, keep in sync while running, delete on stop, all ownership-tracked. Distinct from the README flowchart.
- **Domain matching (configuration/domains.md)** — new decision flowchart clarifying that each instance is evaluated independently (`DOMAINS` then `EXCLUDE_DOMAINS`), and that a hostname can land in multiple providers (split-horizon). This is a common source of confusion.

Skipped faq/observability/docker where a diagram wouldn't add value (Q&A and reference tables).

## Validation
- `mkdocs build` succeeds; all three diagrams emit as mermaid blocks in the generated HTML.
- Sequence diagram validated with `mermaid.parse`. Flowcharts use only standard constructs already rendering elsewhere in these docs (`subgraph`, `direction`, `<br/>`, decision nodes, labeled edges).