### PR TITLE
feat(providers): add pfSense provider (pfSense-pkg-RESTAPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-07-09
+
+### Added
+- **pfSense provider** (`DNSWEAVER_{NAME}_TYPE=pfsense`) managing host overrides on
+  pfSense's DNS Resolver (Unbound, default) or DNS Forwarder (Dnsmasq), selected with
+  `ENGINE`. pfSense ships no REST API in its base system and Netgate offers no official
+  one, so the provider targets the community
+  [pfSense-pkg-RESTAPI](https://pfrest.org) v2 package (the de facto standard, CE and
+  Plus). Ownership is tracked via a `dnsweaver:{instance}` marker in the host override
+  description (host overrides carry no TXT), so operator-managed rows are never touched.
+  A/AAAA in v1; dual-stack names merge into a single Unbound override (the DNS
+  Forwarder's one-IP-per-override limit is surfaced as a clear error). REST-only
+  transport keeps `config.xml`, HA (CARP/XMLRPC) sync, and backups consistent.
+  ([GitHub #114](https://github.com/maxfield-allison/dnsweaver/issues/114))
+
 ## [2.4.0] - 2026-07-08
 
 Minor release focused on Docker connectivity robustness: an opt-in for reading

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you manage a homelab with Traefik, Proxmox, and a self-hosted resolver and yo
 | [Pi-hole](https://maxfield-allison.github.io/dnsweaver/providers/pihole/) | A, CNAME | API or file mode |
 | [AdGuard Home](https://maxfield-allison.github.io/dnsweaver/providers/adguard/) | A, AAAA, CNAME | DNS rewrite management |
 | [OPNsense](https://maxfield-allison.github.io/dnsweaver/providers/opnsense/) | A, AAAA | Unbound or Dnsmasq host overrides via REST API |
+| [pfSense](https://maxfield-allison.github.io/dnsweaver/providers/pfsense/) | A, AAAA | Unbound or Dnsmasq host overrides via REST API (community pfSense-pkg-RESTAPI) |
 | [dnsmasq](https://maxfield-allison.github.io/dnsweaver/providers/dnsmasq/) | A, CNAME | File-based configuration |
 | [Webhook](https://maxfield-allison.github.io/dnsweaver/providers/webhook/) | Any | Custom integrations |
 

--- a/cmd/dnsweaver/setup.go
+++ b/cmd/dnsweaver/setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/maxfield-allison/dnsweaver/providers/dnsmasq"
 	"github.com/maxfield-allison/dnsweaver/providers/opnsense"
 	"github.com/maxfield-allison/dnsweaver/providers/ovh"
+	"github.com/maxfield-allison/dnsweaver/providers/pfsense"
 	"github.com/maxfield-allison/dnsweaver/providers/pihole"
 	"github.com/maxfield-allison/dnsweaver/providers/powerdns"
 	"github.com/maxfield-allison/dnsweaver/providers/rfc2136"
@@ -317,6 +318,9 @@ func registerProviderFactories(registry *provider.Registry) {
 
 	// Register OPNsense provider factory (Unbound/Dnsmasq host overrides via REST API)
 	registry.RegisterFactory("opnsense", opnsense.Factory())
+
+	// Register pfSense provider factory (Unbound/Dnsmasq host overrides via REST API)
+	registry.RegisterFactory("pfsense", pfsense.Factory())
 }
 
 // initializeProviders initializes all configured providers using the manager.

--- a/docs/contributing/adding-provider.md
+++ b/docs/contributing/adding-provider.md
@@ -361,7 +361,7 @@ DNSWEAVER_{NAME}_ZONE_ID=...     # Or ZONE for name lookup
 DNSWEAVER_{NAME}_TTL=300
 ```
 
-### Private DNS Providers (Technitium, Pi-hole, dnsmasq, unbound, OPNsense)
+### Private DNS Providers (Technitium, Pi-hole, dnsmasq, unbound, OPNsense, pfSense)
 
 Characteristics:
 - Local network access

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ dnsweaver watches Docker events, Kubernetes resources, and Proxmox VE clusters t
 
     ---
 
-    Route different domains to different DNS providers. Ten providers: Technitium, Cloudflare, OVHcloud, AdGuard Home, RFC 2136, PowerDNS, OPNsense, Pi-hole, dnsmasq, and webhook.
+    Route different domains to different DNS providers. Eleven providers: Technitium, Cloudflare, OVHcloud, AdGuard Home, RFC 2136, PowerDNS, OPNsense, pfSense, Pi-hole, dnsmasq, and webhook.
 
     [:octicons-arrow-right-24: Providers](providers/index.md)
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -92,6 +92,14 @@ dnsweaver supports multiple DNS providers, each with different capabilities and 
 
     [:octicons-arrow-right-24: Configuration](opnsense.md)
 
+-   :material-firewall:{ .lg .middle } **pfSense**
+
+    ---
+
+    Manage Unbound or Dnsmasq host overrides on pfSense. REST API.
+
+    [:octicons-arrow-right-24: Configuration](pfsense.md)
+
 </div>
 
 ## Provider Comparison
@@ -106,6 +114,7 @@ dnsweaver supports multiple DNS providers, each with different capabilities and 
 | [Pi-hole](pihole.md) | REST API or File | A, CNAME | Existing Pi-hole setups |
 | [AdGuard Home](adguard.md) | REST API | A, AAAA, CNAME | Existing AdGuard Home setups |
 | [OPNsense](opnsense.md) | REST API | A, AAAA | Unbound or Dnsmasq host overrides on OPNsense |
+| [pfSense](pfsense.md) | REST API | A, AAAA | Unbound or Dnsmasq host overrides on pfSense |
 | [dnsmasq](dnsmasq.md) | File | A, CNAME | Simple file-based DNS |
 | [Webhook](webhook.md) | HTTP Callback | Any | Custom integrations |
 

--- a/docs/providers/pfsense.md
+++ b/docs/providers/pfsense.md
@@ -1,0 +1,136 @@
+# pfSense
+
+[pfSense](https://www.pfsense.org/) is an open-source firewall and routing platform. dnsweaver manages **host override** records on pfSense's DNS resolvers via a REST API.
+
+pfSense exposes two DNS resolvers: the **DNS Resolver** (Unbound, default) and the **DNS Forwarder** (Dnsmasq). A single dnsweaver `pfsense` provider covers both — pick the resolver with the `ENGINE` setting.
+
+## Requirements
+
+pfSense does **not** ship a REST API in its base system, and Netgate offers no official one. You must install the community [pfSense-pkg-RESTAPI](https://pfrest.org) package (REST API v2) on the firewall first — it is the de facto standard and works on both pfSense CE and pfSense Plus:
+
+- Install it from **System → Package Manager**, then create a key under **System → REST API → Keys**.
+- Enable the target resolver (**Services → DNS Resolver**, or **Services → DNS Forwarder**).
+- The API key needs permission to manage the target resolver.
+- dnsweaver needs network reachability to the pfSense web/GUI port.
+
+## Why REST, not SSH?
+
+pfSense manages state through `config.xml` and its own internal state machine, including HA sync over CARP/XMLRPC. Writing to the underlying resolver's config files over SSH would work briefly, then break the moment HA sync, an upgrade, or a backup/restore rewrites `config.xml`. The REST API is the only supported way to make changes.
+
+If you have a standalone Linux dnsmasq host (not fronted by pfSense), use the [dnsmasq](dnsmasq.md) provider instead.
+
+## Configuration
+
+```yaml
+environment:
+  - DNSWEAVER_INSTANCES=pf
+
+  - DNSWEAVER_PF_TYPE=pfsense
+  - DNSWEAVER_PF_URL=https://pfsense.internal
+  - DNSWEAVER_PF_API_KEY_FILE=/run/secrets/pfsense_key
+  - DNSWEAVER_PF_ENGINE=unbound            # or dnsmasq
+  - DNSWEAVER_PF_ZONE=home.example.com
+  - DNSWEAVER_PF_RECORD_TYPE=A
+  - DNSWEAVER_PF_TARGET=192.0.2.10
+  - DNSWEAVER_PF_DOMAINS=*.home.example.com
+```
+
+## Configuration Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TYPE` | Yes | – | Must be `pfsense` |
+| `URL` | Yes | – | pfSense base URL (`https://pfsense.internal`) |
+| `API_KEY` | Yes | – | REST API key (sent as the `X-API-Key` header) |
+| `API_KEY_FILE` | Alt | – | File-based alternative for Docker/K8s secrets |
+| `ENGINE` | No | `unbound` | Target resolver: `unbound` (DNS Resolver) or `dnsmasq` (DNS Forwarder) |
+| `ZONE` | No | – | DNS zone for record filtering |
+| `TTL` | No | `300` | Informational only — host overrides have no per-record TTL |
+| `RECONFIGURE_MODE` | No | `per_write` | `per_write` (apply after every change) or `never` |
+| `TLS_CA_FILE` | No | – | Path to a PEM CA bundle (for a private CA on pfSense) |
+| `TLS_SKIP_VERIFY` | No | `false` | Bypass certificate verification (**insecure**) |
+| `RECORD_TYPE` | Yes | – | `A` or `AAAA` |
+| `TARGET` | Yes | – | IP address |
+| `DOMAINS` | Yes | – | Glob patterns to match |
+| `EXCLUDE_DOMAINS` | No | – | Patterns to exclude |
+
+## Record Types (v1)
+
+Both engines support **A** and **AAAA** host overrides. CNAME and other record types are not implemented in the first release.
+
+## Resolver Differences
+
+The two pfSense resolvers store host overrides differently, and it matters for dual-stack names:
+
+| | DNS Resolver (`unbound`) | DNS Forwarder (`dnsmasq`) |
+|---|---|---|
+| IPs per host override | Multiple | Exactly one |
+| Dual-stack (A + AAAA) for one name | Supported — both IPs live on one override | **Not supported** — each `(host, domain)` must be unique with a single IP |
+
+If you point the `dnsmasq` engine at a name that already has an IP and try to add a second (e.g. an AAAA alongside an existing A), dnsweaver returns a clear error and recommends the `unbound` engine for dual-stack.
+
+## Ownership Marking
+
+pfSense host overrides expose no TXT records, so dnsweaver cannot write its usual `_dnsweaver.*` ownership record.
+
+Instead, every record dnsweaver creates carries a marker in the pfSense **description** field:
+
+```
+dnsweaver:{instance-name}
+```
+
+Two consequences:
+
+1. **Operator-managed host overrides are always safe.** dnsweaver's `List()` filters to rows that carry its marker, so orphan cleanup can never touch a host override you created by hand in the pfSense GUI. dnsweaver also refuses to modify an existing `(host, domain)` override it doesn't own.
+2. **Editing a dnsweaver-managed record's description in the GUI unbinds it from dnsweaver.** If you want to add a note, keep the `dnsweaver:{instance}` prefix and separate your note with ` | ` — the parser tolerates that form.
+
+## Reconfigure Semantics
+
+pfSense requires an explicit "apply" call to reload the resolver after a change.
+
+| Mode | Behavior | When to use |
+|------|----------|-------------|
+| `per_write` (default) | Apply after every Create/Delete | Small deployments; correctness over throughput |
+| `never` | Never auto-apply | Large deployments; you apply externally (cron, orchestration) |
+
+## TLS
+
+pfSense typically presents a self-signed certificate. Prefer one of these approaches (in order of preference):
+
+1. **Trust the pfSense CA properly** — export it from pfSense (System → Cert. Manager → CAs) and point `TLS_CA_FILE` at it.
+2. **Bypass verification** — set `TLS_SKIP_VERIFY=true`. dnsweaver will log a WARN at startup. Only acceptable on trusted management networks.
+
+## API Endpoints Used
+
+For reference, dnsweaver uses these pfSense-pkg-RESTAPI v2 endpoints:
+
+**DNS Resolver (Unbound):**
+- `GET /api/v2/services/dns_resolver/host_overrides` — list rows
+- `POST /api/v2/services/dns_resolver/host_override` — create
+- `PATCH /api/v2/services/dns_resolver/host_override` — update (merge/remove an IP)
+- `DELETE /api/v2/services/dns_resolver/host_override?id={id}` — delete
+- `POST /api/v2/services/dns_resolver/apply` — apply changes
+
+**DNS Forwarder (Dnsmasq):**
+- `GET /api/v2/services/dns_forwarder/host_overrides`
+- `POST /api/v2/services/dns_forwarder/host_override`
+- `PATCH /api/v2/services/dns_forwarder/host_override`
+- `DELETE /api/v2/services/dns_forwarder/host_override?id={id}`
+- `POST /api/v2/services/dns_forwarder/apply`
+
+## Troubleshooting
+
+**`unauthorized`**
+: The API key is wrong, disabled, or lacks permission for the target resolver. Verify under System → REST API → Keys.
+
+**`pfsense reachable but the {engine} host-override endpoint was not found (is the REST API package installed and the {engine} resolver enabled?)`**
+: pfSense answered but the resolver's endpoints are missing. Most often this means the REST API package isn't installed, or the target resolver (DNS Resolver / DNS Forwarder) is disabled.
+
+**`the dnsmasq engine (DNS Forwarder) stores one IP per host override … Use the unbound engine for dual-stack`**
+: You tried to give one name both an A and an AAAA record on the DNS Forwarder, which pfSense doesn't allow. Switch that instance to `ENGINE=unbound`.
+
+**`refusing to modify host override … it exists on pfsense but is not managed by dnsweaver`**
+: A host override for that `(host, domain)` already exists and lacks the `dnsweaver:{instance}` marker. dnsweaver won't overwrite operator-managed rows. Remove or rename the conflicting override, or let dnsweaver own it.
+
+**`pfsense provider requires an IP target`**
+: The A/AAAA record's `TARGET` is not a parseable IP. Host overrides on both engines resolve names to IPs, so the target must be `10.1.2.3` or `2001:db8::1`, not another hostname.

--- a/docs/testing/TEST-CASES.md
+++ b/docs/testing/TEST-CASES.md
@@ -8,7 +8,7 @@ For test templates and patterns, see the [templates/](templates/) directory.
 
 | Category | Test Cases | Description |
 |----------|-----------|-------------|
-| [Provider Tests](#provider-tests) | 10 providers × record types | CRUD operations, orphan cleanup |
+| [Provider Tests](#provider-tests) | 11 providers × record types | CRUD operations, orphan cleanup |
 | [Source Tests](#source-tests) | 3 sources × modes | Service discovery, watch/poll |
 | [Scenario Tests](#scenario-tests) | 9 scenarios | End-to-end behavior, recovery |
 | [Reconciler Tests](#reconciler-tests) | Edge cases | Multi-provider, conflict resolution |

--- a/internal/config/instance.go
+++ b/internal/config/instance.go
@@ -271,8 +271,8 @@ var providerConfigFields = []struct {
 	{"USERNAME", false},             // AdGuard Home specific
 	{"PASSWORD", true},              // Pi-hole and AdGuard Home specific
 	{"API_SECRET", true},            // OPNsense specific: paired with API_KEY for basic auth
-	{"ENGINE", false},               // OPNsense specific: unbound|dnsmasq resolver selection
-	{"RECONFIGURE_MODE", false},     // OPNsense specific: per_write|never
+	{"ENGINE", false},               // OPNsense/pfSense: unbound|dnsmasq resolver selection
+	{"RECONFIGURE_MODE", false},     // OPNsense/pfSense: per_write|never
 	{"INSECURE_SKIP_VERIFY", false}, // DEPRECATED: alias for TLS_SKIP_VERIFY
 	// Unified TLS fields — consumed by pkg/provider/extractTLSConfig and
 	// passed to every HTTP-based provider via FactoryConfig.HTTP.TLS.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
       - Pi-hole: providers/pihole.md
       - AdGuard Home: providers/adguard.md
       - OPNsense: providers/opnsense.md
+      - pfSense: providers/pfsense.md
       - dnsmasq: providers/dnsmasq.md
       - Webhook: providers/webhook.md
   - Sources:

--- a/providers/pfsense/client.go
+++ b/providers/pfsense/client.go
@@ -1,0 +1,297 @@
+package pfsense
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// client is a low-level HTTP client for the pfSense REST API, as provided by
+// the community pfSense-pkg-RESTAPI package (https://pfrest.org), REST API v2.
+// It knows about authentication, transport, and the pfrest response envelope,
+// but not about DNS concepts — those live on the Provider, which composes this
+// client with a resolver.
+//
+// Auth is a single API key sent in the X-API-Key header. Mutations use the
+// resource-appropriate HTTP verb (POST create, PATCH update, DELETE remove),
+// and every response is wrapped in pfrest's {code,status,response_id,message,
+// data} envelope.
+type client struct {
+	baseURL    string
+	apiKey     string
+	res        resolver
+	httpClient *http.Client
+	logger     *slog.Logger
+}
+
+// clientOption configures a client at construction time.
+type clientOption func(*client)
+
+// withHTTPClient overrides the HTTP client (primarily for tests and to inject
+// the framework-configured transport with unified TLS settings).
+func withHTTPClient(h *http.Client) clientOption {
+	return func(c *client) {
+		if h != nil {
+			c.httpClient = h
+		}
+	}
+}
+
+// withLogger sets a structured logger.
+func withLogger(logger *slog.Logger) clientOption {
+	return func(c *client) {
+		if logger != nil {
+			c.logger = logger
+		}
+	}
+}
+
+// newClient constructs a client for the given resolver. baseURL must be an
+// absolute URL with scheme (http:// or https://); trailing slashes are trimmed
+// so path concatenation is unambiguous.
+func newClient(baseURL, apiKey string, res resolver, opts ...clientOption) *client {
+	c := &client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiKey:     apiKey,
+		res:        res,
+		httpClient: httputil.DefaultClient(),
+		logger:     slog.Default(),
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// envelope is the common pfrest v2 response wrapper. The HTTP status code
+// mirrors Code, so transport-level status handling stays authoritative and the
+// envelope is used mainly for surfacing Message on errors and reading Data on
+// success.
+type envelope struct {
+	Code       int             `json:"code"`
+	Status     string          `json:"status"`
+	ResponseID string          `json:"response_id"`
+	Message    string          `json:"message"`
+	Data       json.RawMessage `json:"data"`
+}
+
+// wireOverride is the pfrest wire shape of a DNS host override. The ip field is
+// an array on the DNS Resolver (Unbound) and a scalar on the DNS Forwarder
+// (Dnsmasq), so it is decoded via RawMessage and normalized per resolver.
+type wireOverride struct {
+	ID     json.Number     `json:"id,omitempty"`
+	Host   string          `json:"host"`
+	Domain string          `json:"domain"`
+	IP     json.RawMessage `json:"ip"`
+	Descr  string          `json:"descr"`
+}
+
+// do issues a request against the pfrest API and returns the decoded envelope
+// Data on success. Non-2xx responses are mapped to the framework's provider
+// sentinels so callers can use errors.Is.
+func (c *client) do(ctx context.Context, method, path, rawQuery string, body any) (json.RawMessage, error) {
+	reqURL := c.baseURL + path
+	if rawQuery != "" {
+		reqURL += "?" + rawQuery
+	}
+
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("encoding request body: %w", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, reader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	c.logger.Debug("pfsense request",
+		slog.String("method", method),
+		slog.String("path", path),
+	)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", provider.ErrProviderUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := httputil.ReadBody(resp, 0)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	var env envelope
+	// A decode failure is tolerated for error statuses (pfSense can return a
+	// bare HTML error page); it is only fatal when the status says success.
+	decodeErr := json.Unmarshal(respBody, &env)
+
+	if statusErr := mapStatusError(resp.StatusCode, env.Message, respBody); statusErr != nil {
+		return nil, statusErr
+	}
+	if decodeErr != nil {
+		return nil, fmt.Errorf("decoding pfsense response: %w (body: %s)", decodeErr, truncate(string(respBody)))
+	}
+	return env.Data, nil
+}
+
+// list returns every host override for the configured resolver, including
+// operator-managed ones (the provider filters by ownership).
+func (c *client) list(ctx context.Context) ([]hostOverride, error) {
+	data, err := c.do(ctx, http.MethodGet, c.res.plural, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	var rows []wireOverride
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &rows); err != nil {
+			return nil, fmt.Errorf("decoding pfsense host override list: %w", err)
+		}
+	}
+	out := make([]hostOverride, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, hostOverride{
+			ID:     strings.TrimSpace(row.ID.String()),
+			Host:   row.Host,
+			Domain: row.Domain,
+			IPs:    decodeIPs(row.IP),
+			Descr:  row.Descr,
+		})
+	}
+	return out, nil
+}
+
+// create adds a new host override.
+func (c *client) create(ctx context.Context, ho hostOverride) error {
+	payload, err := c.encodePayload(ho, false)
+	if err != nil {
+		return err
+	}
+	_, err = c.do(ctx, http.MethodPost, c.res.single, "", payload)
+	return err
+}
+
+// update replaces an existing host override identified by ho.ID.
+func (c *client) update(ctx context.Context, ho hostOverride) error {
+	if ho.ID == "" {
+		return fmt.Errorf("update requires a host override id")
+	}
+	payload, err := c.encodePayload(ho, true)
+	if err != nil {
+		return err
+	}
+	_, err = c.do(ctx, http.MethodPatch, c.res.single, "", payload)
+	return err
+}
+
+// remove deletes a host override by its pfSense object id.
+func (c *client) remove(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("remove requires a host override id")
+	}
+	q := url.Values{}
+	q.Set("id", id)
+	_, err := c.do(ctx, http.MethodDelete, c.res.single, q.Encode(), nil)
+	return err
+}
+
+// apply reloads the resolver so pending changes take effect.
+func (c *client) apply(ctx context.Context) error {
+	_, err := c.do(ctx, http.MethodPost, c.res.apply, "", map[string]any{})
+	return err
+}
+
+// encodePayload builds the pfrest request body for a host override. The ip
+// field is serialized as an array for multi-IP resolvers (Unbound) and as a
+// scalar otherwise (Dnsmasq). When withID is set, the object id is included so
+// PATCH targets the right row.
+func (c *client) encodePayload(ho hostOverride, withID bool) (map[string]any, error) {
+	if len(ho.IPs) == 0 {
+		return nil, fmt.Errorf("host override %s.%s has no IP targets", ho.Host, ho.Domain)
+	}
+	payload := map[string]any{
+		"host":   ho.Host,
+		"domain": ho.Domain,
+		"descr":  ho.Descr,
+	}
+	if c.res.multiIP {
+		payload["ip"] = ho.IPs
+	} else {
+		if len(ho.IPs) > 1 {
+			return nil, fmt.Errorf("the %s engine (DNS Forwarder) stores one IP per host override, got %d for %s.%s; use the unbound engine for dual-stack",
+				c.res.name, len(ho.IPs), ho.Host, ho.Domain)
+		}
+		payload["ip"] = ho.IPs[0]
+	}
+	if withID {
+		payload["id"] = ho.ID
+	}
+	return payload, nil
+}
+
+// decodeIPs normalizes the pfrest ip field, which is an array on the DNS
+// Resolver and a scalar string on the DNS Forwarder.
+func decodeIPs(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var list []string
+	if err := json.Unmarshal(raw, &list); err == nil {
+		return list
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil && single != "" {
+		return []string{single}
+	}
+	return nil
+}
+
+// mapStatusError translates common HTTP status codes into the framework's
+// provider-level sentinel errors. message is the pfrest envelope message when
+// available; body is the raw response for fallback context.
+func mapStatusError(status int, message string, body []byte) error {
+	detail := strings.TrimSpace(message)
+	if detail == "" {
+		detail = truncate(string(body))
+	}
+	switch {
+	case status >= 200 && status < 300:
+		return nil
+	case status == http.StatusUnauthorized, status == http.StatusForbidden:
+		return provider.ErrUnauthorized
+	case status == http.StatusNotFound:
+		return provider.ErrNotFound
+	case status >= 500:
+		return fmt.Errorf("%w: pfsense returned %d: %s", provider.ErrProviderUnavailable, status, detail)
+	default:
+		return fmt.Errorf("pfsense returned %d: %s", status, detail)
+	}
+}
+
+// truncate caps a string for inclusion in error messages so a runaway HTML
+// error page or huge JSON body doesn't drown the logs.
+func truncate(s string) string {
+	const n = 200
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/providers/pfsense/config.go
+++ b/providers/pfsense/config.go
@@ -1,0 +1,226 @@
+package pfsense
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Engine identifies which DNS resolver on pfSense this instance targets.
+type Engine string
+
+const (
+	// EngineUnbound is pfSense's DNS Resolver (Unbound), the default.
+	EngineUnbound Engine = "unbound"
+	// EngineDnsmasq is pfSense's DNS Forwarder (Dnsmasq).
+	EngineDnsmasq Engine = "dnsmasq"
+)
+
+// ReconfigureMode controls when the provider calls the resolver's apply
+// endpoint (which reloads the daemon so new records take effect).
+type ReconfigureMode string
+
+const (
+	// ReconfigureModePerWrite applies after every Create/Delete. Correct but
+	// expensive on large batches; acceptable at typical homelab scale.
+	ReconfigureModePerWrite ReconfigureMode = "per_write"
+	// ReconfigureModeNever disables automatic apply. Operators must apply out
+	// of band (cron, manual, etc).
+	ReconfigureModeNever ReconfigureMode = "never"
+)
+
+// DefaultTTL is informational only — pfSense host overrides have no per-record
+// TTL; the resolver uses its global TTL.
+const DefaultTTL = 300
+
+// Config holds pfSense-specific configuration.
+type Config struct {
+	// URL is the pfSense base URL (e.g. "https://pfsense.internal").
+	URL string
+	// APIKey is the REST API key. It is sent as the X-API-Key header.
+	APIKey string
+	// Engine selects the DNS resolver backend (unbound or dnsmasq).
+	Engine Engine
+	// Zone optionally filters records to a specific DNS zone.
+	Zone string
+	// TTL is informational only.
+	TTL int
+	// ReconfigureMode controls automatic resolver reload after mutations.
+	ReconfigureMode ReconfigureMode
+}
+
+// Validate checks that all required configuration is present and correct.
+func (c *Config) Validate() error {
+	var errs []string
+
+	if c.URL == "" {
+		errs = append(errs, "URL is required")
+	} else {
+		parsed, err := url.Parse(c.URL)
+		switch {
+		case err != nil:
+			errs = append(errs, fmt.Sprintf("invalid URL: %v", err))
+		case parsed.Scheme != "http" && parsed.Scheme != "https":
+			errs = append(errs, "URL must start with http:// or https://")
+		case parsed.User != nil:
+			errs = append(errs, "URL must not contain embedded credentials")
+		}
+	}
+
+	if c.APIKey == "" {
+		errs = append(errs, "API_KEY is required")
+	}
+
+	switch c.Engine {
+	case EngineUnbound, EngineDnsmasq:
+		// ok
+	case "":
+		errs = append(errs, "ENGINE is required (unbound or dnsmasq)")
+	default:
+		errs = append(errs, fmt.Sprintf("ENGINE must be %q or %q, got %q",
+			EngineUnbound, EngineDnsmasq, c.Engine))
+	}
+
+	switch c.ReconfigureMode {
+	case ReconfigureModePerWrite, ReconfigureModeNever:
+		// ok
+	default:
+		errs = append(errs, fmt.Sprintf("RECONFIGURE_MODE must be %q or %q, got %q",
+			ReconfigureModePerWrite, ReconfigureModeNever, c.ReconfigureMode))
+	}
+
+	if c.TTL < 0 {
+		errs = append(errs, "TTL must be non-negative")
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("pfsense config validation failed: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// LoadConfig loads pfSense configuration from environment variables.
+// Environment variable pattern: DNSWEAVER_{INSTANCE_NAME}_{SETTING}
+//
+// Instance names are normalized: lowercase with hyphens becomes uppercase with
+// underscores. Example: "pfsense-fw" looks for DNSWEAVER_PFSENSE_FW_*.
+func LoadConfig(instanceName string) (*Config, error) {
+	prefix := envPrefix(instanceName)
+
+	config := &Config{
+		URL:             getEnv(prefix + "URL"),
+		APIKey:          getEnvOrFile(prefix+"API_KEY", prefix+"API_KEY_FILE"),
+		Engine:          engineFromString(getEnv(prefix + "ENGINE")),
+		Zone:            getEnv(prefix + "ZONE"),
+		TTL:             DefaultTTL,
+		ReconfigureMode: reconfigureModeFromString(getEnv(prefix + "RECONFIGURE_MODE")),
+	}
+
+	if ttlStr := getEnv(prefix + "TTL"); ttlStr != "" {
+		ttl, err := strconv.Atoi(ttlStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TTL value %q: %w", ttlStr, err)
+		}
+		config.TTL = ttl
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("configuration for %s: %w", instanceName, err)
+	}
+	return config, nil
+}
+
+// LoadConfigFromMap creates a Config from a map of key-value pairs, as produced
+// by the framework config loader.
+func LoadConfigFromMap(name string, m map[string]string) (*Config, error) {
+	config := &Config{
+		URL:             getMapValue(m, "URL"),
+		APIKey:          getMapValue(m, "API_KEY"),
+		Engine:          engineFromString(getMapValue(m, "ENGINE")),
+		Zone:            getMapValue(m, "ZONE"),
+		TTL:             DefaultTTL,
+		ReconfigureMode: reconfigureModeFromString(getMapValue(m, "RECONFIGURE_MODE")),
+	}
+
+	if ttlStr := getMapValue(m, "TTL"); ttlStr != "" {
+		ttl, err := strconv.Atoi(ttlStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TTL value %q: %w", ttlStr, err)
+		}
+		config.TTL = ttl
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("configuration for %s: %w", name, err)
+	}
+	return config, nil
+}
+
+// engineFromString parses an engine string, defaulting to unbound when empty
+// so operators who omit the setting get pfSense's default resolver.
+func engineFromString(s string) Engine {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return EngineUnbound
+	case string(EngineUnbound):
+		return EngineUnbound
+	case string(EngineDnsmasq):
+		return EngineDnsmasq
+	default:
+		return Engine(s)
+	}
+}
+
+// reconfigureModeFromString parses a reconfigure mode string, defaulting to
+// per_write when empty.
+func reconfigureModeFromString(s string) ReconfigureMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return ReconfigureModePerWrite
+	case string(ReconfigureModePerWrite):
+		return ReconfigureModePerWrite
+	case string(ReconfigureModeNever):
+		return ReconfigureModeNever
+	default:
+		return ReconfigureMode(s)
+	}
+}
+
+func envPrefix(instanceName string) string {
+	normalized := strings.ToUpper(strings.ReplaceAll(instanceName, "-", "_"))
+	return "DNSWEAVER_" + normalized + "_"
+}
+
+func getEnv(key string) string {
+	return os.Getenv(key)
+}
+
+func getEnvOrFile(envKey, fileKey string) string {
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	if filePath := os.Getenv(fileKey); filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(data))
+	}
+	return ""
+}
+
+// getMapValue looks up a key case-insensitively.
+func getMapValue(m map[string]string, key string) string {
+	if v, ok := m[key]; ok {
+		return v
+	}
+	if v, ok := m[strings.ToUpper(key)]; ok {
+		return v
+	}
+	if v, ok := m[strings.ToLower(key)]; ok {
+		return v
+	}
+	return ""
+}

--- a/providers/pfsense/config_test.go
+++ b/providers/pfsense/config_test.go
@@ -1,0 +1,131 @@
+package pfsense
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string // empty = expect success
+	}{
+		{
+			name: "valid unbound",
+			cfg: Config{
+				URL:             "https://pfsense.test",
+				APIKey:          "k",
+				Engine:          EngineUnbound,
+				ReconfigureMode: ReconfigureModePerWrite,
+			},
+		},
+		{
+			name: "valid dnsmasq never",
+			cfg: Config{
+				URL:             "http://pfsense.test",
+				APIKey:          "k",
+				Engine:          EngineDnsmasq,
+				ReconfigureMode: ReconfigureModeNever,
+			},
+		},
+		{
+			name:    "missing url",
+			cfg:     Config{APIKey: "k", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "URL is required",
+		},
+		{
+			name:    "bad scheme",
+			cfg:     Config{URL: "ftp://pfsense.test", APIKey: "k", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "URL must start with",
+		},
+		{
+			name:    "embedded credentials",
+			cfg:     Config{URL: "https://user:pass@pfsense.test", APIKey: "k", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "must not contain embedded credentials",
+		},
+		{
+			name:    "missing api key",
+			cfg:     Config{URL: "https://pfsense.test", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "API_KEY is required",
+		},
+		{
+			name:    "bad engine",
+			cfg:     Config{URL: "https://pfsense.test", APIKey: "k", Engine: "bind", ReconfigureMode: ReconfigureModePerWrite},
+			wantErr: "ENGINE must be",
+		},
+		{
+			name:    "bad reconfigure mode",
+			cfg:     Config{URL: "https://pfsense.test", APIKey: "k", Engine: EngineUnbound, ReconfigureMode: "sometimes"},
+			wantErr: "RECONFIGURE_MODE must be",
+		},
+		{
+			name:    "negative ttl",
+			cfg:     Config{URL: "https://pfsense.test", APIKey: "k", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite, TTL: -1},
+			wantErr: "TTL must be non-negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected success, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfigFromMapDefaults(t *testing.T) {
+	cfg, err := LoadConfigFromMap("pf", map[string]string{
+		"URL":     "https://pfsense.test",
+		"API_KEY": "secret",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Engine != EngineUnbound {
+		t.Errorf("Engine default = %q, want %q", cfg.Engine, EngineUnbound)
+	}
+	if cfg.ReconfigureMode != ReconfigureModePerWrite {
+		t.Errorf("ReconfigureMode default = %q, want %q", cfg.ReconfigureMode, ReconfigureModePerWrite)
+	}
+	if cfg.TTL != DefaultTTL {
+		t.Errorf("TTL default = %d, want %d", cfg.TTL, DefaultTTL)
+	}
+}
+
+func TestLoadConfigFromMapInvalidTTL(t *testing.T) {
+	_, err := LoadConfigFromMap("pf", map[string]string{
+		"URL":     "https://pfsense.test",
+		"API_KEY": "secret",
+		"TTL":     "not-a-number",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid TTL")
+	}
+}
+
+func TestParsers(t *testing.T) {
+	if got := engineFromString(""); got != EngineUnbound {
+		t.Errorf("engineFromString(empty) = %q, want %q", got, EngineUnbound)
+	}
+	if got := engineFromString("DNSMASQ"); got != EngineDnsmasq {
+		t.Errorf("engineFromString(DNSMASQ) = %q, want %q", got, EngineDnsmasq)
+	}
+	if got := reconfigureModeFromString(""); got != ReconfigureModePerWrite {
+		t.Errorf("reconfigureModeFromString(empty) = %q, want %q", got, ReconfigureModePerWrite)
+	}
+	if got := reconfigureModeFromString("never"); got != ReconfigureModeNever {
+		t.Errorf("reconfigureModeFromString(never) = %q, want %q", got, ReconfigureModeNever)
+	}
+}

--- a/providers/pfsense/doc.go
+++ b/providers/pfsense/doc.go
@@ -1,0 +1,69 @@
+// Package pfsense implements the DNSWeaver provider interface for pfSense
+// firewalls, driven by the pfSense REST API.
+//
+// # REST API package
+//
+// pfSense does not ship a REST API in its base system. This provider talks to
+// the community pfSense-pkg-RESTAPI package (https://pfrest.org), REST API v2 —
+// the de facto standard, which works on both pfSense CE and pfSense Plus.
+// Netgate ships no official REST API, so there is no alternative backend to
+// abstract over. The operator must install and enable the package on the
+// firewall first; the base pfSense install exposes no compatible endpoints.
+//
+// Like the OPNsense provider, pfSense exposes two DNS resolvers — the DNS
+// Resolver (Unbound, default) and the DNS Forwarder (Dnsmasq) — selected with
+// the ENGINE setting. Both manage "host override" records.
+//
+// The provider is strictly REST-based. It never SSH's into pfSense or edits
+// config.xml directly — those approaches fight pfSense's own state machine and
+// break under HA (CARP/XMLRPC) sync, upgrades, and backup/restore.
+//
+// # Configuration
+//
+// Required environment variables (with DNSWEAVER_{INSTANCE}_ prefix):
+//
+//	URL       pfSense base URL (e.g. https://pfsense.internal)
+//	API_KEY   REST API key, sent as the X-API-Key header
+//	          (System > REST API > Keys).
+//
+// Optional:
+//
+//	ENGINE            "unbound" (DNS Resolver, default) or "dnsmasq" (DNS Forwarder)
+//	ZONE              DNS zone for record filtering (e.g. "example.com")
+//	TTL               Informational only — host overrides have no per-record TTL
+//	RECONFIGURE_MODE  "per_write" (default) or "never"
+//	TLS_*             Unified framework TLS knobs (CA file, skip verify, etc.)
+//
+// The API key supports the _FILE suffix for Docker secrets:
+//
+//	API_KEY_FILE=/run/secrets/pfsense_key
+//
+// # Ownership
+//
+// pfSense host overrides expose no TXT records, so ownership TXT tracking is
+// unavailable (Capabilities.SupportsOwnershipTXT is false). The provider tags
+// each record it manages with a `dnsweaver:{instance}` marker in the host
+// override description field, and List returns only records carrying that
+// marker — so operator-managed host overrides are never touched by orphan
+// cleanup.
+//
+// # Resolver differences
+//
+// The DNS Resolver (Unbound) stores multiple IPs per host override, keyed by a
+// unique (host, domain) pair, so a dual-stack name (A + AAAA) is represented as
+// one override with two IPs. The DNS Forwarder (Dnsmasq) stores a single IP per
+// override, so it cannot hold both an A and an AAAA record for the same name —
+// the provider surfaces that as an explicit error and recommends the Unbound
+// engine for dual-stack.
+//
+// # Reconfigure semantics
+//
+// pfSense requires an "apply" call to reload the resolver after mutations:
+//
+//   - per_write (default): apply after every Create/Delete
+//   - never: skip auto-apply entirely (operator applies out of band)
+//
+// # Record types (v1)
+//
+// A and AAAA on both engines. CNAME and other types are deferred.
+package pfsense

--- a/providers/pfsense/engine.go
+++ b/providers/pfsense/engine.go
@@ -1,0 +1,46 @@
+package pfsense
+
+// resolver describes the REST resource layout for one pfSense DNS resolver.
+// It is the small, engine-specific slice of behavior that the otherwise
+// resolver-agnostic backend needs: which endpoints to hit and whether the
+// resolver stores multiple IPs per host override.
+type resolver struct {
+	// name is the engine identifier ("unbound" or "dnsmasq").
+	name Engine
+	// single is the singular host-override endpoint (POST/PATCH/DELETE by id).
+	single string
+	// plural is the plural host-override endpoint (GET all rows).
+	plural string
+	// apply is the endpoint that reloads the resolver after mutations.
+	apply string
+	// multiIP is true when the resolver stores multiple IPs per (host, domain)
+	// override (Unbound). Dnsmasq stores exactly one, so multiIP is false.
+	multiIP bool
+}
+
+// resolverFor returns the resource layout for the given engine.
+//
+// Endpoints follow the community pfSense-pkg-RESTAPI (pfrest) v2 scheme:
+//
+//	Unbound  → /api/v2/services/dns_resolver/host_override(s), .../apply
+//	Dnsmasq  → /api/v2/services/dns_forwarder/host_override(s), .../apply
+func resolverFor(e Engine) resolver {
+	switch e {
+	case EngineDnsmasq:
+		return resolver{
+			name:    EngineDnsmasq,
+			single:  "/api/v2/services/dns_forwarder/host_override",
+			plural:  "/api/v2/services/dns_forwarder/host_overrides",
+			apply:   "/api/v2/services/dns_forwarder/apply",
+			multiIP: false,
+		}
+	default:
+		return resolver{
+			name:    EngineUnbound,
+			single:  "/api/v2/services/dns_resolver/host_override",
+			plural:  "/api/v2/services/dns_resolver/host_overrides",
+			apply:   "/api/v2/services/dns_resolver/apply",
+			multiIP: true,
+		}
+	}
+}

--- a/providers/pfsense/factory.go
+++ b/providers/pfsense/factory.go
@@ -1,0 +1,34 @@
+package pfsense
+
+import (
+	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// Factory returns a provider.Factory for creating pfSense provider instances.
+// The framework calls this once per configured DNSWEAVER_INSTANCES entry of
+// type "pfsense".
+//
+// TLS is configured framework-wide via cfg.HTTP.TLS — this provider does not
+// re-interpret TLS settings. httputil.NewClient itself emits the WARN when
+// verification is disabled, so no duplicate warning here.
+func Factory() provider.Factory {
+	return func(cfg provider.FactoryConfig) (provider.Provider, error) {
+		providerCfg, err := LoadConfigFromMap(cfg.Name, cfg.ProviderConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		httpClient := httputil.NewClient(&httputil.ClientConfig{
+			Timeout:   cfg.HTTP.Timeout,
+			TLS:       cfg.HTTP.TLS,
+			UserAgent: cfg.HTTP.UserAgent,
+			Logger:    cfg.HTTP.Logger,
+		})
+
+		return New(cfg.Name, providerCfg,
+			WithProviderHTTPClient(httpClient),
+			WithProviderLogger(cfg.HTTP.Logger),
+		)
+	}
+}

--- a/providers/pfsense/hostoverride.go
+++ b/providers/pfsense/hostoverride.go
@@ -1,0 +1,103 @@
+package pfsense
+
+import (
+	"net"
+	"strings"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// hostOverride is the engine-agnostic representation of a single pfSense host
+// override. The DNS Resolver (Unbound) stores multiple IPs per override; the
+// DNS Forwarder (Dnsmasq) stores exactly one. The backend maps this struct to
+// and from the wire shape for the selected resolver.
+type hostOverride struct {
+	// ID is pfSense's object identifier for the row (an index into the config
+	// array for the community pfrest backend). Empty on records we are about
+	// to create; populated on records returned by List.
+	ID string
+	// Host is the short hostname (no domain). "web" in "web.example.com".
+	Host string
+	// Domain is the parent domain. "example.com" in "web.example.com".
+	Domain string
+	// IPs are the A/AAAA targets for this override. Unbound may carry several;
+	// Dnsmasq carries exactly one.
+	IPs []string
+	// Descr is the free-form description. dnsweaver stores its ownership marker
+	// here.
+	Descr string
+}
+
+// containsIP reports whether the override already targets the given IP.
+func (h hostOverride) containsIP(ip string) bool {
+	for _, existing := range h.IPs {
+		if strings.EqualFold(strings.TrimSpace(existing), strings.TrimSpace(ip)) {
+			return true
+		}
+	}
+	return false
+}
+
+// withoutIP returns a copy of the override's IPs with the given IP removed.
+func (h hostOverride) withoutIP(ip string) []string {
+	out := make([]string, 0, len(h.IPs))
+	for _, existing := range h.IPs {
+		if strings.EqualFold(strings.TrimSpace(existing), strings.TrimSpace(ip)) {
+			continue
+		}
+		out = append(out, existing)
+	}
+	return out
+}
+
+// recordTypeForIP returns the DNS record type an IP address maps to. Only A and
+// AAAA are supported; a non-IP target returns ok=false.
+func recordTypeForIP(ip string) (provider.RecordType, bool) {
+	parsed := net.ParseIP(strings.TrimSpace(ip))
+	if parsed == nil {
+		return "", false
+	}
+	if parsed.To4() != nil {
+		return provider.RecordTypeA, true
+	}
+	return provider.RecordTypeAAAA, true
+}
+
+// joinFQDN glues a hostname and domain into a fully qualified name, trimming
+// trailing dots and lowercasing so comparisons are stable.
+func joinFQDN(hostname, domain string) string {
+	hostname = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(hostname)), ".")
+	domain = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(domain)), ".")
+	switch {
+	case hostname == "" && domain == "":
+		return ""
+	case hostname == "":
+		return domain
+	case domain == "":
+		return hostname
+	default:
+		return hostname + "." + domain
+	}
+}
+
+// splitFQDN cleaves a FQDN into (hostname, domain). Returns ok=false if there is
+// no dot to split on — pfSense host overrides always require both a hostname
+// and a domain.
+func splitFQDN(fqdn string) (hostname, domain string, ok bool) {
+	fqdn = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(fqdn)), ".")
+	idx := strings.Index(fqdn, ".")
+	if idx <= 0 || idx == len(fqdn)-1 {
+		return "", "", false
+	}
+	return fqdn[:idx], fqdn[idx+1:], true
+}
+
+// inZone returns true if fqdn is equal to or a subdomain of zone.
+func inZone(fqdn, zone string) bool {
+	fqdn = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(fqdn)), ".")
+	zone = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(zone)), ".")
+	if zone == "" {
+		return true
+	}
+	return fqdn == zone || strings.HasSuffix(fqdn, "."+zone)
+}

--- a/providers/pfsense/ownership.go
+++ b/providers/pfsense/ownership.go
@@ -1,0 +1,43 @@
+package pfsense
+
+import "strings"
+
+// ownershipPrefix marks a host override description as dnsweaver-managed.
+// Format: "dnsweaver:{instance}[ | user-supplied text]"
+//
+// pfSense host overrides expose no TXT records, so we piggy-back ownership
+// signaling on the description field. The prefix lets operators see at a glance
+// which pfSense records dnsweaver owns, and lets List() ignore operator-managed
+// host overrides so orphan cleanup can never delete them.
+const ownershipPrefix = "dnsweaver:"
+
+// ownershipDescription returns the description string to write on records this
+// instance manages.
+func ownershipDescription(instanceName string) string {
+	return ownershipPrefix + instanceName
+}
+
+// isOwnedBy returns true if a description was written by any dnsweaver instance.
+// Used by List() to filter to dnsweaver-managed records only.
+func isOwnedBy(description string) bool {
+	return strings.HasPrefix(strings.TrimSpace(description), ownershipPrefix)
+}
+
+// ownedByInstance returns true if a description was written by the given
+// dnsweaver instance specifically.
+func ownedByInstance(description, instanceName string) bool {
+	trimmed := strings.TrimSpace(description)
+	if !strings.HasPrefix(trimmed, ownershipPrefix) {
+		return false
+	}
+	rest := trimmed[len(ownershipPrefix):]
+	if rest == instanceName {
+		return true
+	}
+	for _, sep := range []string{" ", "|", "\t", "\n"} {
+		if strings.HasPrefix(rest, instanceName+sep) {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/pfsense/ownership_test.go
+++ b/providers/pfsense/ownership_test.go
@@ -1,0 +1,98 @@
+package pfsense
+
+import "testing"
+
+func TestOwnershipDescription(t *testing.T) {
+	got := ownershipDescription("edge-fw")
+	want := "dnsweaver:edge-fw"
+	if got != want {
+		t.Fatalf("ownershipDescription = %q, want %q", got, want)
+	}
+}
+
+func TestIsOwnedBy(t *testing.T) {
+	tests := []struct {
+		desc string
+		want bool
+	}{
+		{"dnsweaver:edge-fw", true},
+		{"  dnsweaver:edge-fw  ", true},
+		{"dnsweaver:other | note", true},
+		{"managed by ops", false},
+		{"", false},
+		{"prefix dnsweaver:edge-fw", false},
+	}
+	for _, tt := range tests {
+		if got := isOwnedBy(tt.desc); got != tt.want {
+			t.Errorf("isOwnedBy(%q) = %v, want %v", tt.desc, got, tt.want)
+		}
+	}
+}
+
+func TestOwnedByInstance(t *testing.T) {
+	tests := []struct {
+		desc     string
+		instance string
+		want     bool
+	}{
+		{"dnsweaver:edge-fw", "edge-fw", true},
+		{"dnsweaver:edge-fw | user note", "edge-fw", true},
+		{"dnsweaver:edge-fw\nmore", "edge-fw", true},
+		{"dnsweaver:edge-fw2", "edge-fw", false},
+		{"dnsweaver:other", "edge-fw", false},
+		{"unmanaged", "edge-fw", false},
+	}
+	for _, tt := range tests {
+		if got := ownedByInstance(tt.desc, tt.instance); got != tt.want {
+			t.Errorf("ownedByInstance(%q, %q) = %v, want %v", tt.desc, tt.instance, got, tt.want)
+		}
+	}
+}
+
+func TestHostOverrideHelpers(t *testing.T) {
+	ho := hostOverride{IPs: []string{"10.0.0.1", "2001:db8::1"}}
+	if !ho.containsIP("10.0.0.1") {
+		t.Error("containsIP(10.0.0.1) = false, want true")
+	}
+	if !ho.containsIP("2001:DB8::1") {
+		t.Error("containsIP is not case-insensitive for IPv6")
+	}
+	if ho.containsIP("10.0.0.2") {
+		t.Error("containsIP(10.0.0.2) = true, want false")
+	}
+	got := ho.withoutIP("10.0.0.1")
+	if len(got) != 1 || got[0] != "2001:db8::1" {
+		t.Errorf("withoutIP = %v, want [2001:db8::1]", got)
+	}
+}
+
+func TestRecordTypeForIP(t *testing.T) {
+	if rt, ok := recordTypeForIP("10.0.0.1"); !ok || rt != "A" {
+		t.Errorf("recordTypeForIP(10.0.0.1) = %q,%v want A,true", rt, ok)
+	}
+	if rt, ok := recordTypeForIP("2001:db8::1"); !ok || rt != "AAAA" {
+		t.Errorf("recordTypeForIP(2001:db8::1) = %q,%v want AAAA,true", rt, ok)
+	}
+	if _, ok := recordTypeForIP("not-an-ip"); ok {
+		t.Error("recordTypeForIP(not-an-ip) ok = true, want false")
+	}
+}
+
+func TestFQDNHelpers(t *testing.T) {
+	h, d, ok := splitFQDN("web.example.com")
+	if !ok || h != "web" || d != "example.com" {
+		t.Errorf("splitFQDN = %q,%q,%v", h, d, ok)
+	}
+	if _, _, ok := splitFQDN("nodot"); ok {
+		t.Error("splitFQDN(nodot) ok = true, want false")
+	}
+	if got := joinFQDN("web", "example.com"); got != "web.example.com" {
+		t.Errorf("joinFQDN = %q", got)
+	}
+	if !inZone("web.example.com", "example.com") {
+		t.Error("inZone should match subdomain")
+	}
+	if inZone("web.other.com", "example.com") {
+		t.Error("inZone should not match different zone")
+	}
+}

--- a/providers/pfsense/provider.go
+++ b/providers/pfsense/provider.go
@@ -1,0 +1,333 @@
+package pfsense
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// Provider implements provider.Provider for pfSense host overrides.
+//
+// One provider instance covers exactly one pfSense resolver engine on one
+// firewall. Deploy multiple instances (same URL, different names) to write the
+// same record set to both engines.
+type Provider struct {
+	name   string
+	url    string // recorded for Identity reporting
+	zone   string
+	ttl    int
+	res    resolver
+	mode   ReconfigureMode
+	client *client
+	logger *slog.Logger
+
+	// construction-time only
+	httpClient *http.Client
+}
+
+// Compile-time interface check.
+var _ provider.Provider = (*Provider)(nil)
+
+// ProviderOption configures a Provider at construction time.
+type ProviderOption func(*Provider)
+
+// WithProviderLogger sets a structured logger for the provider.
+func WithProviderLogger(logger *slog.Logger) ProviderOption {
+	return func(p *Provider) {
+		if logger != nil {
+			p.logger = logger
+		}
+	}
+}
+
+// WithProviderHTTPClient sets the HTTP transport used by the API client. Used
+// by the factory to inject the framework's TLS-configured HTTP client, and by
+// tests to point at an httptest.Server.
+func WithProviderHTTPClient(h *http.Client) ProviderOption {
+	return func(p *Provider) {
+		if h != nil {
+			p.httpClient = h
+		}
+	}
+}
+
+// New constructs a pfSense Provider. cfg must be validated by the caller (or
+// via LoadConfig/LoadConfigFromMap, which validate on load).
+func New(name string, cfg *Config, opts ...ProviderOption) (*Provider, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	p := &Provider{
+		name:   name,
+		url:    cfg.URL,
+		zone:   cfg.Zone,
+		ttl:    cfg.TTL,
+		res:    resolverFor(cfg.Engine),
+		mode:   cfg.ReconfigureMode,
+		logger: slog.Default(),
+	}
+	for _, o := range opts {
+		o(p)
+	}
+
+	p.client = newClient(cfg.URL, cfg.APIKey, p.res,
+		withLogger(p.logger), withHTTPClient(p.httpClient))
+	return p, nil
+}
+
+// Name returns the provider instance name.
+func (p *Provider) Name() string { return p.name }
+
+// Type returns "pfsense".
+func (p *Provider) Type() string { return "pfsense" }
+
+// Identity uniquely identifies the backend this provider writes to. Two
+// pfsense instances share an identity when they target the same URL, engine,
+// and zone, so the reconciler treats them as first-match-wins to avoid
+// competing writes.
+func (p *Provider) Identity() provider.ProviderIdentity {
+	return provider.ProviderIdentity{
+		Type:     "pfsense/" + string(p.res.name),
+		Endpoint: p.url,
+		Zone:     p.zone,
+	}
+}
+
+// Capabilities describes what the pfSense provider can do. Host overrides do
+// not carry TXT records, so ownership TXT tracking is unavailable — the
+// reconciler falls back to target-matching for orphan detection. Native update
+// is unsupported in v1; the reconciler uses delete+create.
+func (p *Provider) Capabilities() provider.Capabilities {
+	return provider.Capabilities{
+		SupportsOwnershipTXT: false,
+		SupportsNativeUpdate: false,
+		SupportedRecordTypes: []provider.RecordType{
+			provider.RecordTypeA,
+			provider.RecordTypeAAAA,
+		},
+	}
+}
+
+// Ping checks connectivity by listing host overrides for the configured
+// resolver. A successful list proves the API is reachable, the key works, and
+// the REST API package exposes the resolver's endpoints — three failure modes
+// that all matter for downstream operations.
+func (p *Provider) Ping(ctx context.Context) error {
+	if _, err := p.client.list(ctx); err != nil {
+		if errors.Is(err, provider.ErrNotFound) {
+			return fmt.Errorf("%w: pfsense reachable but the %s host-override endpoint was not found (is the REST API package installed and the %s resolver enabled?)",
+				provider.ErrProviderUnavailable, p.res.name, p.res.name)
+		}
+		return err
+	}
+	return nil
+}
+
+// List returns all dnsweaver-managed host overrides in the configured zone.
+// Records without the dnsweaver ownership marker are omitted so operator-managed
+// host overrides cannot be deleted by orphan cleanup. Each IP on an override is
+// expanded into its own A/AAAA record.
+func (p *Provider) List(ctx context.Context) ([]provider.Record, error) {
+	overrides, err := p.client.list(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing records: %w", err)
+	}
+
+	records := make([]provider.Record, 0, len(overrides))
+	for _, ho := range overrides {
+		if !isOwnedBy(ho.Descr) {
+			continue
+		}
+		fqdn := joinFQDN(ho.Host, ho.Domain)
+		if p.zone != "" && !inZone(fqdn, p.zone) {
+			continue
+		}
+		for _, ip := range ho.IPs {
+			rt, ok := recordTypeForIP(ip)
+			if !ok {
+				p.logger.Debug("skipping host override IP that is not a valid address",
+					slog.String("provider", p.name),
+					slog.String("fqdn", fqdn),
+					slog.String("ip", ip),
+				)
+				continue
+			}
+			records = append(records, provider.Record{
+				Hostname:   fqdn,
+				Type:       rt,
+				Target:     ip,
+				TTL:        p.ttl,
+				ProviderID: ho.ID,
+			})
+		}
+	}
+
+	p.logger.Debug("listed records",
+		slog.String("provider", p.name),
+		slog.String("engine", string(p.res.name)),
+		slog.Int("overrides", len(overrides)),
+		slog.Int("matched", len(records)),
+	)
+	return records, nil
+}
+
+// Create adds or extends a host override. TXT records are silently skipped
+// (pfSense host overrides do not support TXT). On the Unbound resolver a new
+// IP is merged into an existing (host, domain) override; on the Dnsmasq
+// forwarder, which stores a single IP per override, a conflicting second IP is
+// reported as an error.
+func (p *Provider) Create(ctx context.Context, record provider.Record) error {
+	switch record.Type {
+	case provider.RecordTypeA, provider.RecordTypeAAAA:
+		// supported
+	case provider.RecordTypeTXT:
+		p.logger.Debug("skipping TXT record (pfsense host overrides do not support TXT)",
+			slog.String("provider", p.name),
+			slog.String("hostname", record.Hostname))
+		return nil
+	default:
+		return fmt.Errorf("%s records are not supported by the pfsense provider (v1: A/AAAA only)", record.Type)
+	}
+
+	if net.ParseIP(record.Target) == nil {
+		return fmt.Errorf("pfsense provider requires an IP target for %s, got %q", record.Type, record.Target)
+	}
+
+	host, domain, ok := splitFQDN(record.Hostname)
+	if !ok {
+		return fmt.Errorf("hostname %q must be a fully qualified name with at least one dot", record.Hostname)
+	}
+
+	existing, found, err := p.findOverride(ctx, host, domain)
+	if err != nil {
+		return fmt.Errorf("creating record %s: %w", record.Hostname, err)
+	}
+
+	switch {
+	case found && !isOwnedBy(existing.Descr):
+		return fmt.Errorf("refusing to modify host override %s: it exists on pfsense but is not managed by dnsweaver (description %q)",
+			record.Hostname, existing.Descr)
+	case found && existing.containsIP(record.Target):
+		// Already present — nothing to do.
+		return nil
+	case found && !p.res.multiIP:
+		return fmt.Errorf("the dnsmasq engine (DNS Forwarder) stores one IP per host override; %s already resolves to %v. Use the unbound engine for dual-stack (A+AAAA)",
+			record.Hostname, existing.IPs)
+	case found:
+		existing.IPs = append(existing.IPs, record.Target)
+		existing.Descr = ownershipDescription(p.name)
+		if err := p.client.update(ctx, existing); err != nil {
+			return fmt.Errorf("creating record %s: %w", record.Hostname, err)
+		}
+	default:
+		newHO := hostOverride{
+			Host:   host,
+			Domain: domain,
+			IPs:    []string{record.Target},
+			Descr:  ownershipDescription(p.name),
+		}
+		if err := p.client.create(ctx, newHO); err != nil {
+			return fmt.Errorf("creating record %s: %w", record.Hostname, err)
+		}
+	}
+
+	if err := p.maybeApply(ctx); err != nil {
+		return fmt.Errorf("record %s created but apply failed: %w", record.Hostname, err)
+	}
+
+	p.logger.Info("created DNS record",
+		slog.String("provider", p.name),
+		slog.String("engine", string(p.res.name)),
+		slog.String("hostname", record.Hostname),
+		slog.String("type", string(record.Type)),
+		slog.String("target", record.Target),
+	)
+	return nil
+}
+
+// Delete removes a host override, or a single IP from a multi-IP override. Only
+// records owned by this instance are touched, so operator-managed host
+// overrides are never deleted.
+func (p *Provider) Delete(ctx context.Context, record provider.Record) error {
+	switch record.Type {
+	case provider.RecordTypeA, provider.RecordTypeAAAA:
+		// supported
+	case provider.RecordTypeTXT:
+		return nil
+	default:
+		return fmt.Errorf("%s records are not supported by the pfsense provider", record.Type)
+	}
+
+	host, domain, ok := splitFQDN(record.Hostname)
+	if !ok {
+		return fmt.Errorf("hostname %q must be a fully qualified name with at least one dot", record.Hostname)
+	}
+
+	existing, found, err := p.findOverride(ctx, host, domain)
+	if err != nil {
+		return fmt.Errorf("deleting record %s: %w", record.Hostname, err)
+	}
+	if !found || !ownedByInstance(existing.Descr, p.name) {
+		return provider.ErrNotFound
+	}
+	if record.Target != "" && !existing.containsIP(record.Target) {
+		return provider.ErrNotFound
+	}
+
+	remaining := existing.withoutIP(record.Target)
+	if p.res.multiIP && record.Target != "" && len(remaining) > 0 {
+		existing.IPs = remaining
+		if err := p.client.update(ctx, existing); err != nil {
+			return fmt.Errorf("deleting record %s: %w", record.Hostname, err)
+		}
+	} else {
+		if err := p.client.remove(ctx, existing.ID); err != nil {
+			return fmt.Errorf("deleting record %s: %w", record.Hostname, err)
+		}
+	}
+
+	if err := p.maybeApply(ctx); err != nil {
+		return fmt.Errorf("record %s deleted but apply failed: %w", record.Hostname, err)
+	}
+
+	p.logger.Info("deleted DNS record",
+		slog.String("provider", p.name),
+		slog.String("engine", string(p.res.name)),
+		slog.String("hostname", record.Hostname),
+		slog.String("type", string(record.Type)),
+	)
+	return nil
+}
+
+// findOverride looks up the host override for a (host, domain) pair. It returns
+// every match regardless of ownership so callers can refuse to touch
+// operator-managed rows.
+func (p *Provider) findOverride(ctx context.Context, host, domain string) (hostOverride, bool, error) {
+	overrides, err := p.client.list(ctx)
+	if err != nil {
+		return hostOverride{}, false, err
+	}
+	for _, ho := range overrides {
+		if joinFQDN(ho.Host, ho.Domain) == joinFQDN(host, domain) {
+			return ho, true, nil
+		}
+	}
+	return hostOverride{}, false, nil
+}
+
+// maybeApply triggers a resolver reload when the configured mode calls for it.
+func (p *Provider) maybeApply(ctx context.Context) error {
+	if p.mode != ReconfigureModePerWrite {
+		return nil
+	}
+	return p.client.apply(ctx)
+}

--- a/providers/pfsense/provider_test.go
+++ b/providers/pfsense/provider_test.go
@@ -1,0 +1,472 @@
+package pfsense
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+// fakePfrest simulates the community pfSense-pkg-RESTAPI (pfrest) v2 host
+// override endpoints for a given engine. It enforces X-API-Key auth and the
+// unique (host, domain) constraint, and renders the ip field as an array
+// (Unbound) or scalar (Dnsmasq) so tests exercise both wire shapes.
+type fakePfrest struct {
+	t      *testing.T
+	res    resolver
+	apiKey string
+
+	mu         sync.Mutex
+	rows       []fakeRow
+	nextID     int
+	applyCount int
+}
+
+type fakeRow struct {
+	id     int
+	host   string
+	domain string
+	ips    []string
+	descr  string
+}
+
+func newFakePfrest(t *testing.T, engine Engine) *fakePfrest {
+	t.Helper()
+	return &fakePfrest{
+		t:      t,
+		res:    resolverFor(engine),
+		apiKey: "test-key",
+	}
+}
+
+func (f *fakePfrest) seed(row fakeRow) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	row.id = f.nextID
+	f.rows = append(f.rows, row)
+}
+
+func (f *fakePfrest) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != f.apiKey {
+			f.writeEnvelope(w, http.StatusUnauthorized, "error", "invalid API key", nil)
+			return
+		}
+		switch {
+		case r.URL.Path == f.res.plural && r.Method == http.MethodGet:
+			f.handleList(w)
+		case r.URL.Path == f.res.single && r.Method == http.MethodPost:
+			f.handleCreate(w, r)
+		case r.URL.Path == f.res.single && r.Method == http.MethodPatch:
+			f.handleUpdate(w, r)
+		case r.URL.Path == f.res.single && r.Method == http.MethodDelete:
+			f.handleDelete(w, r)
+		case r.URL.Path == f.res.apply && r.Method == http.MethodPost:
+			f.mu.Lock()
+			f.applyCount++
+			f.mu.Unlock()
+			f.writeEnvelope(w, http.StatusOK, "ok", "", map[string]any{"applied": true})
+		default:
+			f.writeEnvelope(w, http.StatusNotFound, "error", "endpoint not found", nil)
+		}
+	})
+}
+
+func (f *fakePfrest) renderIP(ips []string) any {
+	if f.res.multiIP {
+		return ips
+	}
+	if len(ips) == 0 {
+		return ""
+	}
+	return ips[0]
+}
+
+func (f *fakePfrest) rowJSON(row fakeRow) map[string]any {
+	return map[string]any{
+		"id":     row.id,
+		"host":   row.host,
+		"domain": row.domain,
+		"ip":     f.renderIP(row.ips),
+		"descr":  row.descr,
+	}
+}
+
+func (f *fakePfrest) handleList(w http.ResponseWriter) {
+	f.mu.Lock()
+	data := make([]map[string]any, 0, len(f.rows))
+	for _, row := range f.rows {
+		data = append(data, f.rowJSON(row))
+	}
+	f.mu.Unlock()
+	f.writeEnvelope(w, http.StatusOK, "ok", "", data)
+}
+
+type reqOverride struct {
+	ID     json.Number     `json:"id"`
+	Host   string          `json:"host"`
+	Domain string          `json:"domain"`
+	IP     json.RawMessage `json:"ip"`
+	Descr  string          `json:"descr"`
+}
+
+func (f *fakePfrest) decodeBody(r *http.Request) reqOverride {
+	var body reqOverride
+	raw, _ := io.ReadAll(r.Body)
+	_ = json.Unmarshal(raw, &body)
+	return body
+}
+
+func (f *fakePfrest) handleCreate(w http.ResponseWriter, r *http.Request) {
+	body := f.decodeBody(r)
+	ips := decodeIPs(body.IP)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, row := range f.rows {
+		if row.host == body.Host && row.domain == body.Domain {
+			f.writeEnvelopeLocked(w, http.StatusBadRequest, "error",
+				"A host override with this host and domain already exists.", nil)
+			return
+		}
+	}
+	f.nextID++
+	row := fakeRow{id: f.nextID, host: body.Host, domain: body.Domain, ips: ips, descr: body.Descr}
+	f.rows = append(f.rows, row)
+	f.writeEnvelopeLocked(w, http.StatusOK, "ok", "", f.rowJSON(row))
+}
+
+func (f *fakePfrest) handleUpdate(w http.ResponseWriter, r *http.Request) {
+	body := f.decodeBody(r)
+	ips := decodeIPs(body.IP)
+	id, _ := strconv.Atoi(body.ID.String())
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.rows {
+		if f.rows[i].id == id {
+			f.rows[i].host = body.Host
+			f.rows[i].domain = body.Domain
+			f.rows[i].ips = ips
+			f.rows[i].descr = body.Descr
+			f.writeEnvelopeLocked(w, http.StatusOK, "ok", "", f.rowJSON(f.rows[i]))
+			return
+		}
+	}
+	f.writeEnvelopeLocked(w, http.StatusNotFound, "error", "object not found", nil)
+}
+
+func (f *fakePfrest) handleDelete(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.URL.Query().Get("id"))
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.rows {
+		if f.rows[i].id == id {
+			removed := f.rows[i]
+			f.rows = append(f.rows[:i], f.rows[i+1:]...)
+			f.writeEnvelopeLocked(w, http.StatusOK, "ok", "", f.rowJSON(removed))
+			return
+		}
+	}
+	f.writeEnvelopeLocked(w, http.StatusNotFound, "error", "object not found", nil)
+}
+
+func (f *fakePfrest) writeEnvelope(w http.ResponseWriter, code int, status, message string, data any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writeEnvelopeLocked(w, code, status, message, data)
+}
+
+func (f *fakePfrest) writeEnvelopeLocked(w http.ResponseWriter, code int, status, message string, data any) {
+	rawData, _ := json.Marshal(data)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"code":        code,
+		"status":      status,
+		"response_id": "TEST",
+		"message":     message,
+		"data":        json.RawMessage(rawData),
+	})
+}
+
+func (f *fakePfrest) applies() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.applyCount
+}
+
+// newTestProvider wires a Provider to a fake pfrest server for the given engine.
+func newTestProvider(t *testing.T, fake *fakePfrest, engine Engine, mode ReconfigureMode) (*Provider, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	cfg := &Config{
+		URL:             srv.URL,
+		APIKey:          fake.apiKey,
+		Engine:          engine,
+		ReconfigureMode: mode,
+		TTL:             DefaultTTL,
+	}
+	p, err := New("edge-fw", cfg, WithProviderHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p, srv
+}
+
+func TestUnboundCreateAndList(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	p, _ := newTestProvider(t, fake, EngineUnbound, ReconfigureModePerWrite)
+	ctx := context.Background()
+
+	if err := p.Create(ctx, provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if fake.applies() != 1 {
+		t.Errorf("apply count = %d, want 1", fake.applies())
+	}
+
+	records, err := p.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("List = %d records, want 1", len(records))
+	}
+	if records[0].Hostname != "web.example.com" || records[0].Type != provider.RecordTypeA || records[0].Target != "10.0.0.1" {
+		t.Errorf("unexpected record: %+v", records[0])
+	}
+}
+
+func TestUnboundDualStackMerge(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	p, _ := newTestProvider(t, fake, EngineUnbound, ReconfigureModePerWrite)
+	ctx := context.Background()
+
+	if err := p.Create(ctx, provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1"}); err != nil {
+		t.Fatalf("Create A: %v", err)
+	}
+	if err := p.Create(ctx, provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeAAAA, Target: "2001:db8::1"}); err != nil {
+		t.Fatalf("Create AAAA: %v", err)
+	}
+
+	// Both IPs must live on a single override row (unique host+domain).
+	fake.mu.Lock()
+	rowCount := len(fake.rows)
+	fake.mu.Unlock()
+	if rowCount != 1 {
+		t.Fatalf("row count = %d, want 1 (dual-stack merged into one override)", rowCount)
+	}
+
+	records, err := p.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("List = %d records, want 2 (A + AAAA)", len(records))
+	}
+	types := []string{string(records[0].Type), string(records[1].Type)}
+	sort.Strings(types)
+	if types[0] != "A" || types[1] != "AAAA" {
+		t.Errorf("record types = %v, want [A AAAA]", types)
+	}
+}
+
+func TestUnboundCreateIdempotent(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	p, _ := newTestProvider(t, fake, EngineUnbound, ReconfigureModeNever)
+	ctx := context.Background()
+
+	rec := provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1"}
+	if err := p.Create(ctx, rec); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := p.Create(ctx, rec); err != nil {
+		t.Fatalf("Create (repeat): %v", err)
+	}
+	fake.mu.Lock()
+	rowCount := len(fake.rows)
+	ipCount := len(fake.rows[0].ips)
+	fake.mu.Unlock()
+	if rowCount != 1 || ipCount != 1 {
+		t.Errorf("rows=%d ips=%d, want 1/1 (idempotent create)", rowCount, ipCount)
+	}
+	if fake.applies() != 0 {
+		t.Errorf("apply count = %d, want 0 (RECONFIGURE_MODE=never)", fake.applies())
+	}
+}
+
+func TestRefuseOperatorOwnedOverride(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	fake.seed(fakeRow{host: "web", domain: "example.com", ips: []string{"10.0.0.9"}, descr: "managed by ops"})
+	p, _ := newTestProvider(t, fake, EngineUnbound, ReconfigureModePerWrite)
+
+	err := p.Create(context.Background(), provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1"})
+	if err == nil {
+		t.Fatal("expected error creating over an operator-owned override")
+	}
+}
+
+func TestDnsmasqSingleIPConflict(t *testing.T) {
+	fake := newFakePfrest(t, EngineDnsmasq)
+	p, _ := newTestProvider(t, fake, EngineDnsmasq, ReconfigureModePerWrite)
+	ctx := context.Background()
+
+	if err := p.Create(ctx, provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1"}); err != nil {
+		t.Fatalf("Create A: %v", err)
+	}
+	err := p.Create(ctx, provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeAAAA, Target: "2001:db8::1"})
+	if err == nil {
+		t.Fatal("expected dual-stack conflict error on dnsmasq forwarder")
+	}
+}
+
+func TestDnsmasqCreateListDelete(t *testing.T) {
+	fake := newFakePfrest(t, EngineDnsmasq)
+	p, _ := newTestProvider(t, fake, EngineDnsmasq, ReconfigureModePerWrite)
+	ctx := context.Background()
+
+	rec := provider.Record{Hostname: "api.example.com", Type: provider.RecordTypeA, Target: "10.0.0.5"}
+	if err := p.Create(ctx, rec); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	records, err := p.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(records) != 1 || records[0].Target != "10.0.0.5" {
+		t.Fatalf("List = %+v, want single 10.0.0.5", records)
+	}
+	if err := p.Delete(ctx, rec); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	fake.mu.Lock()
+	rowCount := len(fake.rows)
+	fake.mu.Unlock()
+	if rowCount != 0 {
+		t.Errorf("row count after delete = %d, want 0", rowCount)
+	}
+}
+
+func TestUnboundDeleteOneIPKeepsOverride(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	p, _ := newTestProvider(t, fake, EngineUnbound, ReconfigureModePerWrite)
+	ctx := context.Background()
+
+	_ = p.Create(ctx, provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1"})
+	_ = p.Create(ctx, provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeAAAA, Target: "2001:db8::1"})
+
+	if err := p.Delete(ctx, provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1"}); err != nil {
+		t.Fatalf("Delete A: %v", err)
+	}
+
+	fake.mu.Lock()
+	rowCount := len(fake.rows)
+	var remaining []string
+	if rowCount == 1 {
+		remaining = fake.rows[0].ips
+	}
+	fake.mu.Unlock()
+	if rowCount != 1 {
+		t.Fatalf("row count = %d, want 1 (override kept for remaining AAAA)", rowCount)
+	}
+	if len(remaining) != 1 || remaining[0] != "2001:db8::1" {
+		t.Errorf("remaining IPs = %v, want [2001:db8::1]", remaining)
+	}
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	p, _ := newTestProvider(t, fake, EngineUnbound, ReconfigureModePerWrite)
+
+	err := p.Delete(context.Background(), provider.Record{Hostname: "ghost.example.com", Type: provider.RecordTypeA, Target: "10.0.0.9"})
+	if !errors.Is(err, provider.ErrNotFound) {
+		t.Fatalf("Delete missing = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteIgnoresOperatorOwned(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	fake.seed(fakeRow{host: "web", domain: "example.com", ips: []string{"10.0.0.9"}, descr: "ops override"})
+	p, _ := newTestProvider(t, fake, EngineUnbound, ReconfigureModePerWrite)
+
+	err := p.Delete(context.Background(), provider.Record{Hostname: "web.example.com", Type: provider.RecordTypeA, Target: "10.0.0.9"})
+	if !errors.Is(err, provider.ErrNotFound) {
+		t.Fatalf("Delete operator-owned = %v, want ErrNotFound (never touched)", err)
+	}
+	fake.mu.Lock()
+	rowCount := len(fake.rows)
+	fake.mu.Unlock()
+	if rowCount != 1 {
+		t.Errorf("operator override was modified; row count = %d, want 1", rowCount)
+	}
+}
+
+func TestListFiltersByZone(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	fake.seed(fakeRow{host: "web", domain: "example.com", ips: []string{"10.0.0.1"}, descr: "dnsweaver:edge-fw"})
+	fake.seed(fakeRow{host: "api", domain: "other.com", ips: []string{"10.0.0.2"}, descr: "dnsweaver:edge-fw"})
+
+	cfg := &Config{URL: "http://x", APIKey: fake.apiKey, Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite, Zone: "example.com", TTL: DefaultTTL}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+	cfg.URL = srv.URL
+	p, err := New("edge-fw", cfg, WithProviderHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	records, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(records) != 1 || records[0].Hostname != "web.example.com" {
+		t.Fatalf("zone filter = %+v, want only web.example.com", records)
+	}
+}
+
+func TestPingUnauthorized(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	cfg := &Config{URL: srv.URL, APIKey: "wrong-key", Engine: EngineUnbound, ReconfigureMode: ReconfigureModePerWrite, TTL: DefaultTTL}
+	p, err := New("edge-fw", cfg, WithProviderHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := p.Ping(context.Background()); !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("Ping with bad key = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestPingSuccess(t *testing.T) {
+	fake := newFakePfrest(t, EngineUnbound)
+	p, _ := newTestProvider(t, fake, EngineUnbound, ReconfigureModePerWrite)
+	if err := p.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping = %v, want nil", err)
+	}
+}
+
+func TestIdentityAndType(t *testing.T) {
+	fake := newFakePfrest(t, EngineDnsmasq)
+	p, _ := newTestProvider(t, fake, EngineDnsmasq, ReconfigureModePerWrite)
+	if p.Type() != "pfsense" {
+		t.Errorf("Type = %q, want pfsense", p.Type())
+	}
+	id := p.Identity()
+	if id.Type != "pfsense/dnsmasq" {
+		t.Errorf("Identity.Type = %q, want pfsense/dnsmasq", id.Type)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `pfsense` provider that manages **host override** records on pfSense firewalls via the community [pfSense-pkg-RESTAPI](https://pfrest.org) package (REST API v2).

pfSense ships no REST API in its base system and Netgate offers no official one, so the provider targets pfrest — the de facto standard, which works on both pfSense CE and pfSense Plus. (An earlier draft wrapped this in a pluggable "API backend" abstraction; that was removed as speculative generality since no second API exists to abstract over.)

Like the OPNsense provider, pfSense exposes two DNS resolvers, selected with `ENGINE`:

- `unbound` (default) — the **DNS Resolver**
- `dnsmasq` — the **DNS Forwarder**

**Design highlights:**

- **REST-only transport** — never SSH/config.xml edits, so HA (CARP/XMLRPC) sync, upgrades, and backups stay consistent.
- **Ownership marking** — host overrides carry no TXT record, so each managed row is tagged with a `dnsweaver:{instance}` prefix in the description field. `List()` returns only owned rows, and `Create()` refuses to modify an existing `(host, domain)` override it doesn't own — operator-managed entries in the pfSense GUI are always safe.
- **Resolver differences handled** — the DNS Resolver stores multiple IPs per `(host, domain)` override, so a dual-stack name (A + AAAA) merges into a single override. The DNS Forwarder stores exactly one IP per override and can't hold both, which the provider surfaces as a clear error recommending the `unbound` engine.
- **v1 scope:** A and AAAA records. CNAME and other types deferred.

## Related issues

Closes #114

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] `gofmt` clean and `golangci-lint run ./...` passes (lint runs in CI)
- [x] `go test ./...` passes (added tests: config, ownership, host-override helpers, and an end-to-end fake pfrest server exercising both engines)
- [x] `go build ./...` succeeds
- [x] Docs updated (new `docs/providers/pfsense.md`, README + mkdocs nav + provider index)
- [x] CHANGELOG.md updated

## Notes

Fully backward-compatible — no existing provider, config, or behavior changes. Targets release **v2.5.0**.
