### PR TITLE
feat(incus): support incus-compose labels (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **incus-compose label support** for the Incus source. [incus-compose](https://github.com/lxc/incus-compose)
+  stores Compose `labels:` entries as `user.label.<key>` instance config keys.
+  The Incus adapter now surfaces each such key under its stripped `<key>` form
+  (in addition to the verbatim key), so the existing `traefik`, `caddy`,
+  `nginx-proxy`, and `dnsweaver` sources consume incus-compose labels with no
+  extra configuration. The Incus source's own hostname override also honors the
+  de-prefixed `dnsweaver.hostname` label. The raw `user.label.*` key is always
+  retained, and a stripped alias never overwrites an existing label.
+  ([GitHub #131](https://github.com/maxfield-allison/dnsweaver/issues/131))
+
 ## [2.5.0] - 2026-07-09
 
 ### Added

--- a/docs/sources/incus.md
+++ b/docs/sources/incus.md
@@ -69,14 +69,60 @@ DNSWEAVER_SOURCES=incus
 The source determines the DNS hostname for each instance using this logic, in order of precedence:
 
 1. **`user.dnsweaver.hostname` config key** — set on the instance, its value is used verbatim as the hostname (e.g. `incus config set web user.dnsweaver.hostname=app.example.net`)
-2. **Instance name contains a dot** — used directly as an FQDN (e.g., `db.home.example.com`)
-3. **Domain suffix configured** — appended to the instance name (e.g., `web` + `home.example.com` → `web.home.example.com`)
-4. **None of the above** — the instance is skipped; a debug log entry is emitted
+2. **`dnsweaver.hostname` label** — the [incus-compose](#incus-compose-labels) form of the override; used verbatim when the native `user.dnsweaver.hostname` key is not set
+3. **Instance name contains a dot** — used directly as an FQDN (e.g., `db.home.example.com`)
+4. **Domain suffix configured** — appended to the instance name (e.g., `web` + `home.example.com` → `web.home.example.com`)
+5. **None of the above** — the instance is skipped; a debug log entry is emitted
 
 !!! warning "Domain suffix is strongly recommended"
     Without a domain suffix, only instances whose names already contain a dot (or
     that set `user.dnsweaver.hostname`) will produce DNS records. Set
     `DNSWEAVER_INCUS_DOMAIN_SUFFIX` to ensure all instances are registered.
+
+## incus-compose Labels
+
+[incus-compose](https://github.com/lxc/incus-compose) runs Docker Compose files
+against Incus. Since v1.0.0-rc.2 it stores each Compose `labels:` entry as an
+instance config key prefixed `user.label.` — for example, a Compose label
+`traefik.http.routers.app.rule` becomes the instance config key
+`user.label.traefik.http.routers.app.rule`.
+
+dnsweaver's Incus adapter surfaces every instance config key as a workload
+label, and **additionally** exposes each `user.label.<key>` under its stripped
+`<key>` form. The raw `user.label.*` key is always retained for transparency,
+and a stripped alias never overwrites a label that is already present.
+
+This means the existing label-based sources consume incus-compose labels with
+no extra configuration — just enable the source that matches your labels
+alongside `incus`:
+
+| Compose label | Stored as | Read by source |
+| :------------ | :-------- | :------------- |
+| `dnsweaver.hostname=app.example.com` | `user.label.dnsweaver.hostname` | `dnsweaver` (or the Incus source's own override) |
+| `traefik.http.routers.app.rule=Host(...)` | `user.label.traefik.http.routers.app.rule` | `traefik` |
+| `caddy=app.example.com` | `user.label.caddy` | `caddy` |
+
+Example — a Compose service whose Traefik router labels drive DNS:
+
+```yaml
+services:
+  app:
+    image: docker.io/nginx:alpine
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.app.rule: "Host(`app.example.com`)"
+```
+
+```bash
+DNSWEAVER_SOURCES=traefik,incus
+DNSWEAVER_INCUS_SOCKET_PATH=/var/lib/incus/unix.socket
+```
+
+!!! note "Two always-present labels"
+    incus-compose always adds `user.label.incus-compose.project` and
+    `user.label.incus-compose.service` (the Compose project and service names).
+    These are surfaced de-prefixed as `incus-compose.project` /
+    `incus-compose.service` and can be read by any source or used for debugging.
 
 ### Per-instance hostname override
 

--- a/internal/incus/adapter.go
+++ b/internal/incus/adapter.go
@@ -14,6 +14,15 @@ const (
 	instanceTypeVM        = "virtual-machine"
 )
 
+// composeLabelPrefix is the config-key prefix that incus-compose
+// (https://github.com/lxc/incus-compose) uses to store Compose `labels:`
+// entries on an instance. For example, a Compose label
+// "traefik.http.routers.api.rule" is stored as the instance config key
+// "user.label.traefik.http.routers.api.rule". Stripping this prefix lets the
+// existing label-based sources (traefik, caddy, nginx-proxy, dnsweaver) match
+// incus-compose instances unchanged.
+const composeLabelPrefix = "user.label."
+
 // AdapterConfig holds filtering options for the WorkloadListerAdapter.
 type AdapterConfig struct {
 	// StateFilter restricts listing to instances in the given state. Typical
@@ -120,6 +129,21 @@ func toWorkload(inst Instance, ip string) workload.Workload {
 	labels := make(map[string]string, len(inst.Config))
 	for k, v := range inst.Config {
 		labels[k] = v
+	}
+
+	// Additionally surface incus-compose labels under their stripped form so the
+	// existing label-based sources match them. A key like
+	// "user.label.dnsweaver.hostname" is also exposed as "dnsweaver.hostname".
+	// The raw "user.label.*" key is retained for transparency, and the stripped
+	// alias never overwrites a label that is already present.
+	for k, v := range inst.Config {
+		stripped, ok := strings.CutPrefix(k, composeLabelPrefix)
+		if !ok || stripped == "" {
+			continue
+		}
+		if _, exists := labels[stripped]; !exists {
+			labels[stripped] = v
+		}
 	}
 
 	return workload.Workload{

--- a/internal/incus/adapter_test.go
+++ b/internal/incus/adapter_test.go
@@ -132,3 +132,63 @@ func TestAdapterStateFilter(t *testing.T) {
 		t.Fatalf("expected only stopped instance b, got %+v", workloads)
 	}
 }
+
+// TestAdapterComposeLabels verifies that incus-compose "user.label.*" config
+// keys are surfaced both verbatim and under their stripped form, and that the
+// stripped alias never overwrites an existing label.
+func TestAdapterComposeLabels(t *testing.T) {
+	client := newAdapterTestServer(t, []map[string]any{
+		{
+			"name":    "app",
+			"type":    "container",
+			"status":  "Running",
+			"project": "default",
+			"config": map[string]string{
+				"user.label.traefik.http.routers.app.rule": "Host(`app.example.com`)",
+				"user.label.dnsweaver.hostname":            "app.example.net",
+				"user.label.incus-compose.service":         "app",
+				// Pre-existing stripped key must win over the compose alias.
+				"dnsweaver.enabled":            "true",
+				"user.label.dnsweaver.enabled": "false",
+			},
+			"state": map[string]any{
+				"network": map[string]any{
+					"eth0": map[string]any{
+						"addresses": []map[string]any{
+							{"family": "inet", "address": "10.0.0.9", "scope": "global"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	workloads, err := NewWorkloadListerAdapter(client, AdapterConfig{}, nil).
+		ListWorkloads(context.Background())
+	if err != nil {
+		t.Fatalf("ListWorkloads: %v", err)
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(workloads))
+	}
+	labels := workloads[0].Labels
+
+	// Raw keys retained.
+	if labels["user.label.traefik.http.routers.app.rule"] != "Host(`app.example.com`)" {
+		t.Errorf("raw traefik label missing: %v", labels)
+	}
+	// Stripped aliases added.
+	if labels["traefik.http.routers.app.rule"] != "Host(`app.example.com`)" {
+		t.Errorf("stripped traefik label missing: %v", labels)
+	}
+	if labels["dnsweaver.hostname"] != "app.example.net" {
+		t.Errorf("stripped dnsweaver.hostname missing: %v", labels)
+	}
+	if labels["incus-compose.service"] != "app" {
+		t.Errorf("stripped incus-compose.service missing: %v", labels)
+	}
+	// Existing stripped key not overwritten by the compose alias.
+	if labels["dnsweaver.enabled"] != "true" {
+		t.Errorf("dnsweaver.enabled = %q, want true (must not be overwritten)", labels["dnsweaver.enabled"])
+	}
+}

--- a/sources/incus/incus.go
+++ b/sources/incus/incus.go
@@ -42,6 +42,14 @@ const sourceName = "incus"
 // overrides the derived hostname with an explicit value.
 const hostnameLabel = "user.dnsweaver.hostname"
 
+// composeHostnameLabel is the incus-compose form of the hostname override.
+// incus-compose (https://github.com/lxc/incus-compose) stores Compose labels as
+// "user.label.<key>" config keys, which the Incus adapter surfaces de-prefixed.
+// A Compose "dnsweaver.hostname" label therefore appears as "dnsweaver.hostname"
+// — matching the native dnsweaver source's label. Checked after the native
+// "user.dnsweaver.hostname" key.
+const composeHostnameLabel = "dnsweaver.hostname"
+
 // TargetMode controls how the Incus source builds DNS record targets.
 type TargetMode string
 
@@ -203,11 +211,15 @@ func (s *Incus) Extract(_ context.Context, w workload.Workload) ([]source.Hostna
 
 // resolveHostname determines the FQDN for an Incus workload.
 //
-// Precedence: explicit "user.dnsweaver.hostname" label > FQDN instance name >
-// "<name>.<domain>". Returns an error (logged as debug, not surfaced to the
-// caller) when no hostname can be determined.
+// Precedence: explicit "user.dnsweaver.hostname" label > incus-compose
+// "dnsweaver.hostname" label > FQDN instance name > "<name>.<domain>". Returns
+// an error (logged as debug, not surfaced to the caller) when no hostname can
+// be determined.
 func (s *Incus) resolveHostname(w workload.Workload) (string, error) {
 	if override := strings.TrimSpace(w.GetLabel(hostnameLabel)); override != "" {
+		return override, nil
+	}
+	if override := strings.TrimSpace(w.GetLabel(composeHostnameLabel)); override != "" {
 		return override, nil
 	}
 	if strings.Contains(w.Name, ".") {

--- a/sources/incus/incus_test.go
+++ b/sources/incus/incus_test.go
@@ -111,6 +111,40 @@ func TestExtract_HostnameLabelOverride(t *testing.T) {
 	}
 }
 
+// TestExtract_ComposeHostnameLabel verifies the incus-compose "dnsweaver.hostname"
+// label (de-prefixed from "user.label.dnsweaver.hostname") overrides the derived
+// hostname.
+func TestExtract_ComposeHostnameLabel(t *testing.T) {
+	src := New(WithDomain("home.example.com"))
+	w := incusWorkload("web", "10.0.0.5", map[string]string{
+		composeHostnameLabel: "compose.example.net",
+	})
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "compose.example.net" {
+		t.Fatalf("expected compose override hostname, got %+v", got)
+	}
+}
+
+// TestExtract_NativeHostnameLabelWins verifies the native "user.dnsweaver.hostname"
+// key takes precedence over the incus-compose "dnsweaver.hostname" label.
+func TestExtract_NativeHostnameLabelWins(t *testing.T) {
+	src := New(WithDomain("home.example.com"))
+	w := incusWorkload("web", "10.0.0.5", map[string]string{
+		hostnameLabel:        "native.example.net",
+		composeHostnameLabel: "compose.example.net",
+	})
+	got, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "native.example.net" {
+		t.Fatalf("expected native override to win, got %+v", got)
+	}
+}
+
 func TestExtract_InstanceTargetMode_NoRecordHints(t *testing.T) {
 	src := New(WithDomain("home.example.com"), WithTargetMode(TargetModeInstance))
 	w := incusWorkload("web", "10.0.0.5", nil)


### PR DESCRIPTION
## Summary

Adds incus-compose label support to the Incus source.

[incus-compose](https://github.com/lxc/incus-compose) runs Docker Compose files against Incus. Since v1.0.0-rc.2 it stores each Compose `labels:` entry as an instance config key prefixed `user.label.` — for example, a Compose label `traefik.http.routers.app.rule` becomes the instance config key `user.label.traefik.http.routers.app.rule`.

The Incus adapter already surfaces every instance config key as a workload label. This PR additionally exposes each `user.label.<key>` under its stripped `<key>` form, so the existing `traefik`, `caddy`, `nginx-proxy`, and `dnsweaver` label parsers match incus-compose instances with no extra configuration. The Incus source's own hostname override also honors the de-prefixed `dnsweaver.hostname` label.

The raw `user.label.*` key is always retained for transparency, and a stripped alias never overwrites a label that is already present (native keys win).

## Related issues

Closes #131

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Maintenance / refactor / CI

## Checklist

- [x] `gofmt` clean and `golangci-lint run ./...` passes
- [x] `go test ./...` passes (added/updated tests where relevant)
- [x] `go build ./...` succeeds
- [x] Docs updated (README / docs site) if behavior or config changed
- [x] CHANGELOG.md updated under the Unreleased section if user-facing
