### PR TITLE
feat(incus): event-driven source via /1.0/events (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   de-prefixed `dnsweaver.hostname` label. The raw `user.label.*` key is always
   retained, and a stripped alias never overwrites an existing label.
   ([GitHub #131](https://github.com/maxfield-allison/dnsweaver/issues/131))
+- **Event-driven Incus source** for near-instant DNS updates. A new watcher
+  subscribes to the Incus event stream (`/1.0/events`, lifecycle events) and
+  triggers reconciliation the moment an instance changes, instead of waiting for
+  the next poll tick. It mirrors the Docker watcher: debounced triggering (bursts
+  such as `incus-compose up` collapse into a single reconcile), automatic
+  reconnect with backoff, and graceful shutdown. The instance lister remains the
+  source of truth and the periodic poll stays as a safety net. Uses the minimal
+  `github.com/coder/websocket` dependency rather than the full Incus SDK.
+  Thanks to [@jochumdev](https://github.com/jochumdev) for the request and
+  guidance. ([GitHub #132](https://github.com/maxfield-allison/dnsweaver/issues/132))
 
 ## [2.5.0] - 2026-07-09
 

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -307,8 +307,10 @@ func run() error {
 	}
 
 	// Initialize Incus lister when DNSWEAVER_INCUS_URL or _SOCKET_PATH is set.
+	var incusClient *incusclient.Client
 	if cfg.UseIncus() {
-		incusClient, err := incusclient.NewClient(incusclient.ClientConfig{
+		var err error
+		incusClient, err = incusclient.NewClient(incusclient.ClientConfig{
 			BaseURL:    cfg.IncusURL(),
 			SocketPath: cfg.IncusSocketPath(),
 			Project:    cfg.IncusProject(),
@@ -419,6 +421,14 @@ func run() error {
 		)
 	}
 
+	// Initialize Incus event watcher for near-instant DNS updates (#132)
+	var incusWatcher *incusclient.WorkloadWatcher
+	if incusClient != nil {
+		incusWatcher = incusclient.NewWatcher(incusClient, triggerReconcile,
+			incusclient.WithWatcherLogger(logger),
+		)
+	}
+
 	// Initialize file watcher for sources with file discovery (#22)
 	var fileWatcher *source.FileWatcher
 	if cfg.HasFileDiscovery() {
@@ -497,6 +507,12 @@ func run() error {
 		}
 	}
 
+	if incusWatcher != nil {
+		if err := incusWatcher.Start(ctx); err != nil {
+			return fmt.Errorf("starting incus watcher: %w", err)
+		}
+	}
+
 	if fileWatcher != nil {
 		if err := fileWatcher.Start(ctx); err != nil {
 			return fmt.Errorf("starting file watcher: %w", err)
@@ -569,6 +585,10 @@ func run() error {
 	if k8sWatcher != nil {
 		k8sWatcher.Stop()
 		logger.Debug("kubernetes watcher stopped")
+	}
+	if incusWatcher != nil {
+		incusWatcher.Stop()
+		logger.Debug("incus watcher stopped")
 	}
 	if fileWatcher != nil {
 		fileWatcher.Stop()

--- a/docs/sources/incus.md
+++ b/docs/sources/incus.md
@@ -6,7 +6,7 @@ icon: material/cube-outline
 
 # Incus Source
 
-The Incus source creates DNS A records for running [Incus](https://linuxcontainers.org/incus/) system containers and virtual machines. It polls the Incus REST API to discover instances, resolves each instance's IP address from its network state, then registers an A record mapping `<instance-name>.<domain>` to that IP.
+The Incus source creates DNS A records for running [Incus](https://linuxcontainers.org/incus/) system containers and virtual machines. It polls the Incus REST API to discover instances, resolves each instance's IP address from its network state, then registers an A record mapping `<instance-name>.<domain>` to that IP. It also subscribes to the Incus event stream so instance changes are reflected in DNS almost immediately (see [Event-Driven Updates](#event-driven-updates)).
 
 It connects either to a **local Unix socket** (agent running on the Incus host) or to a **remote HTTPS endpoint** secured with a client certificate.
 
@@ -25,6 +25,50 @@ flowchart LR
 2. **IP resolver** scans each instance's network interfaces, skipping loopback and non-routable addresses, and selects the first global IPv4 address
 3. **Source** maps the instance name + configured domain suffix to a fully-qualified hostname
 4. **Reconciler** creates or updates A records via the matching DNS provider
+
+A background **event watcher** subscribes to the Incus event stream and triggers
+an out-of-band reconcile whenever an instance changes, so updates do not have to
+wait for the next poll. See [Event-Driven Updates](#event-driven-updates).
+
+## Event-Driven Updates
+
+Alongside the periodic poll, the Incus source runs an event watcher that
+subscribes to the Incus event stream at `/1.0/events` (filtered to `lifecycle`
+events). When an instance is created, started, stopped, or deleted, the watcher
+triggers a reconcile within a short debounce window, giving near-instant DNS
+updates instead of waiting for `DNSWEAVER_RECONCILE_INTERVAL`.
+
+```mermaid
+flowchart LR
+    A["Incus event stream<br/>/1.0/events (lifecycle)"] -->|"instance-started<br/>instance-stopped<br/>..."| B["Event watcher"]
+    B -->|"debounce 2s"| C["Trigger reconcile"]
+    C --> D["Lister re-reads state<br/>/1.0/instances"]
+    D --> E["Reconciler → DNS"]
+```
+
+Design notes:
+
+- **The lister remains the source of truth.** Events only *trigger* a reconcile;
+  the current instance state (and each instance's IP) is always re-read from
+  `/1.0/instances`. The periodic poll stays enabled as a safety net for any
+  missed event.
+- **Bursts coalesce.** A 2-second debounce collapses a burst of events (for
+  example, an `incus-compose up` that starts many instances at once) into a
+  single reconcile.
+- **Resilient connection.** The watcher reconnects with a short backoff if the
+  stream drops, and shuts down cleanly on exit. It reuses the same transport as
+  the lister, so it works over both the local Unix socket and a remote
+  HTTPS + TLS endpoint.
+- **No extra configuration.** The watcher starts automatically whenever the
+  Incus source is active (`DNSWEAVER_INCUS_URL` or
+  `DNSWEAVER_INCUS_SOCKET_PATH` is set).
+
+### Metrics
+
+| Metric | Type | Description |
+| :----- | :--- | :---------- |
+| `dnsweaver_incus_events_processed_total{action}` | counter | Incus events processed, labeled by lifecycle action (e.g. `instance-started`). |
+| `dnsweaver_incus_watcher_reconnects_total` | counter | Number of times the event watcher reconnected after a stream error. |
 
 ## Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/coder/websocket v1.8.15
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/miekg/dns v1.1.72
 	github.com/pkg/sftp v1.13.10

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/internal/incus/events.go
+++ b/internal/incus/events.go
@@ -1,0 +1,147 @@
+// Package incus events streaming.
+//
+// The Incus REST API exposes an event stream at GET /1.0/events, upgraded to a
+// WebSocket connection. Events are JSON messages describing lifecycle changes
+// (instance created/started/stopped/deleted), logging, and operations. dnsweaver
+// subscribes to the "lifecycle" type so it can trigger a reconcile the moment an
+// instance changes, instead of waiting for the next poll tick.
+//
+// The stream deliberately uses github.com/coder/websocket (a minimal, near
+// zero-dependency WebSocket library) rather than the official lxc/incus SDK, in
+// keeping with the client's stdlib-first design (see client.go).
+package incus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// EventTypeLifecycle is the Incus event type for instance lifecycle changes
+// (created, started, stopped, deleted, etc.). This is the only type dnsweaver
+// needs to trigger reconciliation.
+const EventTypeLifecycle = "lifecycle"
+
+// Event is a single Incus event as delivered over /1.0/events. Only the fields
+// relevant to reconciliation triggering are modeled; Metadata is left raw so
+// callers can decode the action for logging without this package taking on a
+// dependency on the full event schema.
+type Event struct {
+	// Type is the event class: "lifecycle", "logging", or "operation".
+	Type string `json:"type"`
+
+	// Project is the Incus project the event originated from.
+	Project string `json:"project"`
+
+	// Metadata holds the type-specific payload. For lifecycle events it decodes
+	// into LifecycleMetadata.
+	Metadata json.RawMessage `json:"metadata"`
+}
+
+// LifecycleMetadata is the payload of a lifecycle Event.
+type LifecycleMetadata struct {
+	// Action is the lifecycle action, e.g. "instance-started",
+	// "instance-stopped", "instance-created", "instance-deleted".
+	Action string `json:"action"`
+
+	// Source is the API path of the affected object, e.g. "/1.0/instances/web".
+	Source string `json:"source"`
+}
+
+// Action decodes and returns the lifecycle action for the event, or "" if the
+// event is not a lifecycle event or the metadata cannot be decoded.
+func (e Event) Action() string {
+	if e.Type != EventTypeLifecycle || len(e.Metadata) == 0 {
+		return ""
+	}
+	var m LifecycleMetadata
+	if err := json.Unmarshal(e.Metadata, &m); err != nil {
+		return ""
+	}
+	return m.Action
+}
+
+// eventsURL builds the WebSocket URL for the events endpoint, restricted to the
+// given event types and the client's configured project. The base URL scheme is
+// switched to ws/wss because coder/websocket dials WebSocket schemes; the custom
+// transport on the client's http.Client (unix socket dialer or TLS config) is
+// reused for the handshake, so socket and remote HTTPS endpoints both work.
+func (c *Client) eventsURL(types []string) string {
+	base := c.baseURL
+	switch {
+	case strings.HasPrefix(base, "https://"):
+		base = "wss://" + strings.TrimPrefix(base, "https://")
+	case strings.HasPrefix(base, "http://"):
+		base = "ws://" + strings.TrimPrefix(base, "http://")
+	}
+
+	url := base + "/1.0/events"
+	params := make([]string, 0, 2)
+	if len(types) > 0 {
+		params = append(params, "type="+strings.Join(types, ","))
+	}
+	if c.project != "" {
+		params = append(params, "project="+c.project)
+	}
+	if len(params) > 0 {
+		url += "?" + strings.Join(params, "&")
+	}
+	return url
+}
+
+// StreamEvents connects to the Incus events endpoint and invokes handler for
+// each received event of the given types until ctx is canceled or the stream
+// errors. It blocks for the lifetime of the connection; callers that want
+// reconnect behavior should wrap it (see WorkloadWatcher).
+//
+// A nil or empty types slice subscribes to lifecycle events only.
+func (c *Client) StreamEvents(ctx context.Context, types []string, handler func(Event)) error {
+	if len(types) == 0 {
+		types = []string{EventTypeLifecycle}
+	}
+
+	url := c.eventsURL(types)
+
+	// coder/websocket treats a non-zero http.Client.Timeout as a deadline on the
+	// whole connection, which would force-drop this long-lived event stream (the
+	// Incus client sets a 15s request timeout for normal REST reads). Dial with a
+	// timeout-free shallow copy that keeps the same transport (unix-socket dialer
+	// or TLS config).
+	dialClient := c.http
+	if dialClient.Timeout != 0 {
+		clone := *dialClient
+		clone.Timeout = 0
+		dialClient = &clone
+	}
+
+	// bodyclose is a false positive here: after a successful WebSocket upgrade,
+	// coder/websocket owns the response body and closing it would tear down the
+	// connection. The connection (and thus the body) is released via conn.Close.
+	conn, _, err := websocket.Dial(ctx, url, &websocket.DialOptions{ //nolint:bodyclose
+		HTTPClient: dialClient,
+	})
+	if err != nil {
+		return fmt.Errorf("dialing incus events stream: %w", err)
+	}
+	// Generous read limit: Incus lifecycle payloads are small, but operation
+	// events can be larger. 1 MiB is ample and bounds memory.
+	conn.SetReadLimit(1 << 20)
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			return fmt.Errorf("reading incus event: %w", err)
+		}
+
+		var ev Event
+		if err := json.Unmarshal(data, &ev); err != nil {
+			c.logger.Debug("skipping undecodable incus event", "error", err)
+			continue
+		}
+		handler(ev)
+	}
+}

--- a/internal/incus/events_test.go
+++ b/internal/incus/events_test.go
@@ -1,0 +1,127 @@
+package incus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// eventsTestServer starts an httptest server that upgrades /1.0/events to a
+// WebSocket and writes each provided message (raw JSON) to the client, then
+// blocks until the client disconnects. It returns an incus Client pointed at it.
+func eventsTestServer(t *testing.T, messages []string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/1.0/events") {
+			http.NotFound(w, r)
+			return
+		}
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close(websocket.StatusNormalClosure, "") }()
+		ctx := r.Context()
+		for _, m := range messages {
+			if err := c.Write(ctx, websocket.MessageText, []byte(m)); err != nil {
+				return
+			}
+		}
+		<-ctx.Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(ClientConfig{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}
+
+func TestEventAction(t *testing.T) {
+	ev := Event{
+		Type:     EventTypeLifecycle,
+		Metadata: []byte(`{"action":"instance-started","source":"/1.0/instances/web"}`),
+	}
+	if got := ev.Action(); got != "instance-started" {
+		t.Errorf("Action() = %q, want instance-started", got)
+	}
+
+	// Non-lifecycle event returns empty action.
+	other := Event{Type: "logging", Metadata: []byte(`{"message":"hi"}`)}
+	if got := other.Action(); got != "" {
+		t.Errorf("Action() = %q, want empty for non-lifecycle", got)
+	}
+}
+
+func TestEventsURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		project string
+		want    string
+	}{
+		{"socket", "http://incus", "", "ws://incus/1.0/events?type=lifecycle"},
+		{"https", "https://incus:8443", "", "wss://incus:8443/1.0/events?type=lifecycle"},
+		{"with project", "https://incus:8443", "prod", "wss://incus:8443/1.0/events?type=lifecycle&project=prod"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{baseURL: tt.base, project: tt.project}
+			got := c.eventsURL([]string{EventTypeLifecycle})
+			if got != tt.want {
+				t.Errorf("eventsURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStreamEvents(t *testing.T) {
+	client := eventsTestServer(t, []string{
+		`{"type":"lifecycle","project":"default","metadata":{"action":"instance-started","source":"/1.0/instances/web"}}`,
+		`{"type":"lifecycle","project":"default","metadata":{"action":"instance-stopped","source":"/1.0/instances/web"}}`,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		mu      sync.Mutex
+		actions []string
+	)
+	got2 := make(chan struct{})
+	go func() {
+		_ = client.StreamEvents(ctx, nil, func(ev Event) {
+			mu.Lock()
+			actions = append(actions, ev.Action())
+			n := len(actions)
+			mu.Unlock()
+			if n == 2 {
+				close(got2)
+			}
+		})
+	}()
+
+	select {
+	case <-got2:
+		// Received both events; cancel to unblock the stream.
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("StreamEvents did not deliver both events in time")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(actions) < 2 {
+		t.Fatalf("expected 2 actions, got %d: %v", len(actions), actions)
+	}
+	if actions[0] != "instance-started" || actions[1] != "instance-stopped" {
+		t.Errorf("unexpected actions: %v", actions)
+	}
+}

--- a/internal/incus/watcher.go
+++ b/internal/incus/watcher.go
@@ -1,0 +1,206 @@
+// Package incus event watcher.
+//
+// WorkloadWatcher monitors the Incus event stream (/1.0/events) and triggers
+// reconciliation when instances change, giving near-instant DNS updates instead
+// of waiting for the next poll tick. It mirrors the Docker watcher
+// (internal/watcher): debounced triggering, automatic reconnect with backoff,
+// and graceful shutdown via context cancellation.
+//
+// The watcher only *triggers* reconciliation; the WorkloadListerAdapter remains
+// the source of truth for instance state. The periodic reconcile timer is kept
+// as a safety net for any missed events.
+package incus
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/maxfield-allison/dnsweaver/internal/metrics"
+)
+
+// ReconcileFunc is called when an Incus event requires reconciliation.
+type ReconcileFunc func()
+
+// WatcherConfig holds event watcher configuration.
+type WatcherConfig struct {
+	// DebounceInterval is how long to wait for additional events before
+	// triggering reconciliation, coalescing bursts (e.g. `incus-compose up`
+	// starting several instances). Default: 2s.
+	DebounceInterval time.Duration
+
+	// ReconnectInterval is how long to wait before reconnecting after a stream
+	// error. Default: 5s.
+	ReconnectInterval time.Duration
+
+	// EventTypes restricts the subscription to these Incus event types. Default:
+	// ["lifecycle"].
+	EventTypes []string
+}
+
+// DefaultWatcherConfig returns a WatcherConfig with sensible defaults.
+func DefaultWatcherConfig() WatcherConfig {
+	return WatcherConfig{
+		DebounceInterval:  2 * time.Second,
+		ReconnectInterval: 5 * time.Second,
+		EventTypes:        []string{EventTypeLifecycle},
+	}
+}
+
+// WorkloadWatcher watches Incus events and triggers reconciliation on instance
+// changes.
+type WorkloadWatcher struct {
+	client      *Client
+	onReconcile ReconcileFunc
+	config      WatcherConfig
+	logger      *slog.Logger
+
+	mu       sync.Mutex
+	cancel   context.CancelFunc
+	running  bool
+	debounce *time.Timer
+}
+
+// WatcherOption is a functional option for configuring the WorkloadWatcher.
+type WatcherOption func(*WorkloadWatcher)
+
+// WithWatcherConfig sets the watcher configuration.
+func WithWatcherConfig(cfg WatcherConfig) WatcherOption {
+	return func(w *WorkloadWatcher) {
+		w.config = cfg
+	}
+}
+
+// WithWatcherLogger sets a custom logger.
+func WithWatcherLogger(logger *slog.Logger) WatcherOption {
+	return func(w *WorkloadWatcher) {
+		if logger != nil {
+			w.logger = logger
+		}
+	}
+}
+
+// NewWatcher creates a new Incus event watcher.
+func NewWatcher(client *Client, onReconcile ReconcileFunc, opts ...WatcherOption) *WorkloadWatcher {
+	w := &WorkloadWatcher{
+		client:      client,
+		onReconcile: onReconcile,
+		config:      DefaultWatcherConfig(),
+		logger:      slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	if len(w.config.EventTypes) == 0 {
+		w.config.EventTypes = []string{EventTypeLifecycle}
+	}
+	return w
+}
+
+// Start begins watching Incus events. Non-blocking: it starts a goroutine and
+// returns immediately. Call Stop() to halt watching.
+func (w *WorkloadWatcher) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return nil
+	}
+	ctx, w.cancel = context.WithCancel(ctx)
+	w.running = true
+	w.mu.Unlock()
+
+	go w.watchLoop(ctx)
+
+	w.logger.Info("incus event watcher started",
+		slog.Duration("debounce", w.config.DebounceInterval),
+		slog.Any("event_types", w.config.EventTypes),
+	)
+	return nil
+}
+
+// Stop halts the event watcher.
+func (w *WorkloadWatcher) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.cancel != nil {
+		w.cancel()
+		w.cancel = nil
+	}
+	if w.debounce != nil {
+		w.debounce.Stop()
+		w.debounce = nil
+	}
+	w.running = false
+	w.logger.Info("incus event watcher stopped")
+}
+
+// IsRunning returns whether the watcher is currently running.
+func (w *WorkloadWatcher) IsRunning() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.running
+}
+
+func (w *WorkloadWatcher) watchLoop(ctx context.Context) {
+	defer func() {
+		w.mu.Lock()
+		w.running = false
+		w.mu.Unlock()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			err := w.client.StreamEvents(ctx, w.config.EventTypes, w.handleEvent)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				w.logger.Warn("incus event stream error, reconnecting",
+					slog.String("error", err.Error()),
+					slog.Duration("retry_in", w.config.ReconnectInterval),
+				)
+				metrics.IncusWatcherReconnects.Inc()
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(w.config.ReconnectInterval):
+				}
+			}
+		}
+	}
+}
+
+func (w *WorkloadWatcher) handleEvent(ev Event) {
+	action := ev.Action()
+	w.logger.Debug("received incus event",
+		slog.String("type", ev.Type),
+		slog.String("action", action),
+		slog.String("project", ev.Project),
+	)
+	label := action
+	if label == "" {
+		label = ev.Type
+	}
+	metrics.IncusEventsProcessed.WithLabelValues(label).Inc()
+
+	// Debounce: reset the timer on each event so bursts collapse into one
+	// reconcile.
+	w.mu.Lock()
+	if w.debounce != nil {
+		w.debounce.Stop()
+	}
+	w.debounce = time.AfterFunc(w.config.DebounceInterval, w.triggerReconcile)
+	w.mu.Unlock()
+}
+
+func (w *WorkloadWatcher) triggerReconcile() {
+	w.logger.Info("triggering reconciliation due to incus event")
+	if w.onReconcile != nil {
+		w.onReconcile()
+	}
+}

--- a/internal/incus/watcher_test.go
+++ b/internal/incus/watcher_test.go
@@ -1,0 +1,101 @@
+package incus
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWatcher_DebouncesAndTriggers(t *testing.T) {
+	client := eventsTestServer(t, []string{
+		`{"type":"lifecycle","project":"default","metadata":{"action":"instance-started","source":"/1.0/instances/a"}}`,
+		`{"type":"lifecycle","project":"default","metadata":{"action":"instance-started","source":"/1.0/instances/b"}}`,
+		`{"type":"lifecycle","project":"default","metadata":{"action":"instance-started","source":"/1.0/instances/c"}}`,
+	})
+
+	var calls int32
+	fired := make(chan struct{}, 1)
+	w := NewWatcher(client, func() {
+		atomic.AddInt32(&calls, 1)
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+	}, WithWatcherConfig(WatcherConfig{
+		DebounceInterval:  100 * time.Millisecond,
+		ReconnectInterval: 50 * time.Millisecond,
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !w.IsRunning() {
+		t.Fatal("watcher should be running after Start")
+	}
+
+	select {
+	case <-fired:
+	case <-time.After(3 * time.Second):
+		t.Fatal("reconcile was not triggered")
+	}
+
+	// The three events arrive in a burst well within the 100ms debounce, so
+	// they should collapse into a single reconcile.
+	time.Sleep(300 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected 1 debounced reconcile, got %d", got)
+	}
+
+	w.Stop()
+	if w.IsRunning() {
+		t.Error("watcher should not be running after Stop")
+	}
+}
+
+func TestWatcher_StartIdempotent(t *testing.T) {
+	client := eventsTestServer(t, nil)
+	w := NewWatcher(client, func() {})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = w.Start(ctx)
+	// Second Start is a no-op and must not panic or spawn a second loop.
+	_ = w.Start(ctx)
+	w.Stop()
+}
+
+func TestWatcher_DefaultsApplied(t *testing.T) {
+	client := eventsTestServer(t, nil)
+	w := NewWatcher(client, func() {}, WithWatcherConfig(WatcherConfig{}))
+	if len(w.config.EventTypes) != 1 || w.config.EventTypes[0] != EventTypeLifecycle {
+		t.Errorf("expected default event types [lifecycle], got %v", w.config.EventTypes)
+	}
+}
+
+// TestWatcher_ConcurrentStopSafe ensures Stop is safe to call while events are
+// in flight.
+func TestWatcher_ConcurrentStopSafe(t *testing.T) {
+	client := eventsTestServer(t, []string{
+		`{"type":"lifecycle","project":"default","metadata":{"action":"instance-started","source":"/1.0/instances/a"}}`,
+	})
+	w := NewWatcher(client, func() {}, WithWatcherConfig(WatcherConfig{
+		DebounceInterval:  10 * time.Millisecond,
+		ReconnectInterval: 10 * time.Millisecond,
+	}))
+	ctx := context.Background()
+	_ = w.Start(ctx)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w.Stop()
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -231,6 +231,29 @@ var (
 	)
 )
 
+// Incus watcher metrics.
+var (
+	// IncusEventsProcessed counts Incus events processed, labeled by lifecycle
+	// action (e.g. "instance-started") or event type when no action is present.
+	IncusEventsProcessed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "incus_events_processed_total",
+			Help:      "Total number of Incus events processed.",
+		},
+		[]string{"action"},
+	)
+
+	// IncusWatcherReconnects counts Incus event watcher reconnections.
+	IncusWatcherReconnects = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "incus_watcher_reconnects_total",
+			Help:      "Total number of Incus watcher reconnections.",
+		},
+	)
+)
+
 // SetBuildInfo sets the build info metric with version and go version.
 func SetBuildInfo(version, goVersion string) {
 	BuildInfo.WithLabelValues(version, goVersion).Set(1)


### PR DESCRIPTION
## Summary

Makes the Incus source event-driven for near-instant DNS updates. A new watcher subscribes to the Incus event stream (`GET /1.0/events`, filtered to `lifecycle` events) and triggers reconciliation the moment an instance is created, started, stopped, or deleted, instead of waiting for the next poll tick.

It mirrors the existing Docker watcher:

- **Debounced triggering** — a burst of events (e.g. `incus-compose up` starting many instances) collapses into a single reconcile.
- **Reconnect with backoff** on stream errors; clean shutdown on context cancel.
- **Lister stays the source of truth** — events only *trigger* a reconcile; instance state (and each IP) is always re-read from `/1.0/instances`. The periodic poll remains as a safety net.

The stream uses the minimal `github.com/coder/websocket` dependency (no transitive deps) rather than the full `lxc/incus` SDK, in keeping with the client's stdlib-first design. It reuses the existing transport, so it works over both the local Unix socket and remote HTTPS + TLS.

New Prometheus metrics: `dnsweaver_incus_events_processed_total{action}` and `dnsweaver_incus_watcher_reconnects_total`.

### Validation

Tested end-to-end against a real Incus 7.2 server (Zabbly stable) over HTTPS + TLS:

- WebSocket upgrade (`101`) over the mutual-TLS endpoint.
- `instance-shutdown` / `instance-started` events each triggered a reconcile after the 2s debounce.
- Stress test with the incus-compose [`many-dependencies`](https://github.com/lxc/incus-compose/tree/main/examples/many-dependencies) example (20+ instances, replicas): **52 events coalesced into 20 reconciles, 0 reconnects**; metrics captured the full lifecycle action spectrum.

## Related issues

Closes #132

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Maintenance / refactor / CI

## Checklist

- [x] `gofmt` clean and `golangci-lint run ./...` passes
- [x] `go test ./...` passes (added/updated tests where relevant)
- [x] `go build ./...` succeeds
- [x] Docs updated (README / docs site) if behavior or config changed
- [x] CHANGELOG.md updated under the Unreleased section if user-facing
