### PR TITLE
feat(incus): multi-project support (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `github.com/coder/websocket` dependency rather than the full Incus SDK.
   Thanks to [@jochumdev](https://github.com/jochumdev) for the request and
   guidance. ([GitHub #132](https://github.com/maxfield-allison/dnsweaver/issues/132))
+- **Multi-project support for the Incus source.** A single dnsweaver instance can
+  now watch many Incus projects, so one deployment can serve an entire cluster
+  instead of running one dnsweaver per project. Set
+  `DNSWEAVER_INCUS_ALL_PROJECTS=true` to watch every project (including ones
+  created later) via the API's all-projects mode, or
+  `DNSWEAVER_INCUS_PROJECTS=a,b,c` for an explicit list (projects that do not
+  exist yet are still watched and picked up when they appear). The existing
+  `DNSWEAVER_INCUS_PROJECT` single-project behavior is unchanged. All-projects
+  mode requires server-wide credentials. Both the lister and the event watcher
+  honor the selected scope. Thanks to
+  [@jochumdev](https://github.com/jochumdev) for the request.
+  ([GitHub #137](https://github.com/maxfield-allison/dnsweaver/issues/137))
 
 ## [2.5.0] - 2026-07-09
 

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -306,27 +307,57 @@ func run() error {
 		)
 	}
 
-	// Initialize Incus lister when DNSWEAVER_INCUS_URL or _SOCKET_PATH is set.
-	var incusClient *incusclient.Client
+	// Initialize Incus lister(s) when DNSWEAVER_INCUS_URL or _SOCKET_PATH is set.
+	// Project scope is controlled by DNSWEAVER_INCUS_ALL_PROJECTS (watch every
+	// project via all-projects mode), DNSWEAVER_INCUS_PROJECTS (an explicit list,
+	// one client per project), or DNSWEAVER_INCUS_PROJECT (a single project).
+	var incusClients []*incusclient.Client
 	if cfg.UseIncus() {
-		var err error
-		incusClient, err = incusclient.NewClient(incusclient.ClientConfig{
+		baseCfg := incusclient.ClientConfig{
 			BaseURL:    cfg.IncusURL(),
 			SocketPath: cfg.IncusSocketPath(),
-			Project:    cfg.IncusProject(),
 			TLS:        cfg.IncusTLS(),
 			Logger:     logger,
-		})
-		if err != nil {
-			return fmt.Errorf("creating incus client: %w", err)
 		}
-		incusLister := incusclient.NewWorkloadListerAdapter(incusClient, incusclient.AdapterConfig{
-			StateFilter: cfg.IncusStateFilter(),
-		}, logger)
-		listers = append(listers, incusLister)
+
+		var clientCfgs []incusclient.ClientConfig
+		var scope string
+		switch {
+		case cfg.IncusAllProjects():
+			c := baseCfg
+			c.AllProjects = true
+			clientCfgs = append(clientCfgs, c)
+			scope = "all-projects"
+		case len(cfg.IncusProjects()) > 0:
+			for _, p := range cfg.IncusProjects() {
+				c := baseCfg
+				c.Project = p
+				clientCfgs = append(clientCfgs, c)
+			}
+			scope = strings.Join(cfg.IncusProjects(), ",")
+		default:
+			c := baseCfg
+			c.Project = cfg.IncusProject()
+			clientCfgs = append(clientCfgs, c)
+			if scope = cfg.IncusProject(); scope == "" {
+				scope = "default"
+			}
+		}
+
+		for _, cc := range clientCfgs {
+			incusClient, err := incusclient.NewClient(cc)
+			if err != nil {
+				return fmt.Errorf("creating incus client: %w", err)
+			}
+			incusClients = append(incusClients, incusClient)
+			incusLister := incusclient.NewWorkloadListerAdapter(incusClient, incusclient.AdapterConfig{
+				StateFilter: cfg.IncusStateFilter(),
+			}, logger)
+			listers = append(listers, incusLister)
+		}
 		logger.Info("incus lister configured",
 			slog.String("endpoint", incusEndpoint(cfg)),
-			slog.String("project", cfg.IncusProject()),
+			slog.String("projects", scope),
 		)
 	}
 
@@ -421,11 +452,15 @@ func run() error {
 		)
 	}
 
-	// Initialize Incus event watcher for near-instant DNS updates (#132)
-	var incusWatcher *incusclient.WorkloadWatcher
-	if incusClient != nil {
-		incusWatcher = incusclient.NewWatcher(incusClient, triggerReconcile,
-			incusclient.WithWatcherLogger(logger),
+	// Initialize Incus event watcher(s) for near-instant DNS updates (#132).
+	// One watcher per Incus client (one per project, or a single all-projects
+	// watcher).
+	var incusWatchers []*incusclient.WorkloadWatcher
+	for _, incusClient := range incusClients {
+		incusWatchers = append(incusWatchers,
+			incusclient.NewWatcher(incusClient, triggerReconcile,
+				incusclient.WithWatcherLogger(logger),
+			),
 		)
 	}
 
@@ -507,7 +542,7 @@ func run() error {
 		}
 	}
 
-	if incusWatcher != nil {
+	for _, incusWatcher := range incusWatchers {
 		if err := incusWatcher.Start(ctx); err != nil {
 			return fmt.Errorf("starting incus watcher: %w", err)
 		}
@@ -586,9 +621,11 @@ func run() error {
 		k8sWatcher.Stop()
 		logger.Debug("kubernetes watcher stopped")
 	}
-	if incusWatcher != nil {
+	for _, incusWatcher := range incusWatchers {
 		incusWatcher.Stop()
-		logger.Debug("incus watcher stopped")
+	}
+	if len(incusWatchers) > 0 {
+		logger.Debug("incus watchers stopped")
 	}
 	if fileWatcher != nil {
 		fileWatcher.Stop()

--- a/docs/sources/incus.md
+++ b/docs/sources/incus.md
@@ -70,6 +70,43 @@ Design notes:
 | `dnsweaver_incus_events_processed_total{action}` | counter | Incus events processed, labeled by lifecycle action (e.g. `instance-started`). |
 | `dnsweaver_incus_watcher_reconnects_total` | counter | Number of times the event watcher reconnected after a stream error. |
 
+## Multiple Projects
+
+Incus organizes instances into [projects](https://linuxcontainers.org/incus/docs/main/projects/).
+By default the Incus source watches a single project. A single dnsweaver instance
+can watch many projects at once, so one deployment can serve an entire Incus
+cluster rather than running one dnsweaver per project.
+
+There are three modes, in order of precedence:
+
+| Mode | Configuration | Behavior |
+| :--- | :------------ | :------- |
+| **All projects** | `DNSWEAVER_INCUS_ALL_PROJECTS=true` | Watch every project the credentials can see, including projects created later. Lowest friction for large deployments. |
+| **Explicit list** | `DNSWEAVER_INCUS_PROJECTS=team-a,team-b` | Watch exactly the listed projects. Projects that do not exist yet are still watched and picked up the moment they appear. |
+| **Single project** | `DNSWEAVER_INCUS_PROJECT=team-a` | Watch one project (the original behavior). Empty = the Incus `default` project. |
+
+`DNSWEAVER_INCUS_PROJECTS` also accepts `*` or `all` as a shorthand that is
+equivalent to `DNSWEAVER_INCUS_ALL_PROJECTS=true`.
+
+Each instance's project is preserved in its [workload metadata](#workload-metadata),
+so records stay correctly attributed no matter how many projects are in scope.
+Both the periodic lister and the [event watcher](#event-driven-updates) honor the
+selected scope: all-projects mode uses one stream for the whole server, while an
+explicit list uses one stream per project.
+
+!!! warning "All-projects requires unrestricted credentials"
+    `DNSWEAVER_INCUS_ALL_PROJECTS=true` (and the `*` / `all` shorthand) use the
+    Incus API's all-projects mode, which requires **server-wide (unrestricted)**
+    credentials. A project-restricted certificate cannot list or watch other
+    projects — use `DNSWEAVER_INCUS_PROJECTS` with an explicit list in that case.
+
+```bash
+# Watch an entire Incus cluster with one dnsweaver instance
+DNSWEAVER_INCUS_URL=https://incus-host:8443
+DNSWEAVER_INCUS_ALL_PROJECTS=true
+DNSWEAVER_INCUS_DOMAIN_SUFFIX=home.example.com
+```
+
 ## Configuration
 
 ### Environment Variables
@@ -79,6 +116,8 @@ Design notes:
 | `DNSWEAVER_INCUS_URL` | Alt | — | Remote Incus API base URL, e.g. `https://incus-host:8443`. Mutually exclusive with `DNSWEAVER_INCUS_SOCKET_PATH`. |
 | `DNSWEAVER_INCUS_SOCKET_PATH` | Alt | — | Path to the local Incus Unix socket, e.g. `/var/lib/incus/unix.socket`. Mutually exclusive with `DNSWEAVER_INCUS_URL`. |
 | `DNSWEAVER_INCUS_PROJECT` | No | _(all / default)_ | Restrict discovery to a single Incus project |
+| `DNSWEAVER_INCUS_PROJECTS` | No | — | Comma-separated list of Incus projects to watch, e.g. `team-a,team-b`. Use `*` or `all` as a shorthand for all projects. See [Multiple Projects](#multiple-projects). |
+| `DNSWEAVER_INCUS_ALL_PROJECTS` | No | `false` | Watch **every** Incus project via the API's all-projects mode. Requires server-wide (unrestricted) credentials. See [Multiple Projects](#multiple-projects). |
 | `DNSWEAVER_INCUS_STATE_FILTER` | No | `running` | Instance status filter (`running`, `stopped`, etc.) |
 | `DNSWEAVER_INCUS_DOMAIN_SUFFIX` | No | — | Domain suffix appended to instance names, e.g. `home.example.com` |
 | `DNSWEAVER_INCUS_TARGET_MODE` | No | `guest-ip` | Target resolution mode. `guest-ip` (default) emits an A record per instance IP. `instance` defers record type and target to the matching provider instance — useful for pointing all instances at a reverse proxy via CNAME. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
@@ -408,6 +409,38 @@ func (c *Config) IncusSocketPath() string {
 // Incus default project.
 func (c *Config) IncusProject() string {
 	return c.Global.IncusProject
+}
+
+// IncusAllProjects reports whether dnsweaver should watch every Incus project
+// via the API's all-projects mode. True when DNSWEAVER_INCUS_ALL_PROJECTS is
+// set, or when DNSWEAVER_INCUS_PROJECTS contains a wildcard ("*" or "all").
+func (c *Config) IncusAllProjects() bool {
+	if c.Global.IncusAllProjects {
+		return true
+	}
+	for _, p := range c.Global.IncusProjects {
+		if p == "*" || strings.EqualFold(p, "all") {
+			return true
+		}
+	}
+	return false
+}
+
+// IncusProjects returns the explicit list of Incus projects to watch, in order,
+// with any wildcard entries ("*"/"all") removed. Empty when no explicit list is
+// configured or when all-projects mode is active. See IncusAllProjects.
+func (c *Config) IncusProjects() []string {
+	if c.IncusAllProjects() {
+		return nil
+	}
+	out := make([]string, 0, len(c.Global.IncusProjects))
+	for _, p := range c.Global.IncusProjects {
+		if p == "*" || strings.EqualFold(p, "all") {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // IncusStateFilter returns the instance state filter (default: "running").

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -105,12 +105,14 @@ type GlobalConfig struct {
 	ProxmoxTLSMinVersion string
 
 	// Incus settings
-	IncusURL          string // Remote Incus API base URL (e.g., https://incus.example.com:8443)
-	IncusSocketPath   string // Local Incus Unix socket path (e.g., /var/lib/incus/unix.socket)
-	IncusProject      string // Incus project to query (default: "default")
-	IncusStateFilter  string // Filter by instance status (default: "running")
-	IncusDomainSuffix string // Domain suffix to append to instance names (e.g., "home.example.com")
-	IncusTargetMode   string // Target resolution mode: "guest-ip" (default) or "instance"
+	IncusURL          string   // Remote Incus API base URL (e.g., https://incus.example.com:8443)
+	IncusSocketPath   string   // Local Incus Unix socket path (e.g., /var/lib/incus/unix.socket)
+	IncusProject      string   // Incus project to query (default: "default")
+	IncusProjects     []string // Explicit list of Incus projects to watch (DNSWEAVER_INCUS_PROJECTS)
+	IncusAllProjects  bool     // Watch all projects via all-projects=true (DNSWEAVER_INCUS_ALL_PROJECTS)
+	IncusStateFilter  string   // Filter by instance status (default: "running")
+	IncusDomainSuffix string   // Domain suffix to append to instance names (e.g., "home.example.com")
+	IncusTargetMode   string   // Target resolution mode: "guest-ip" (default) or "instance"
 
 	// Unified Incus TLS configuration for remote HTTPS endpoints. Populated from
 	// DNSWEAVER_INCUS_TLS_* env vars and consumed by internal/incus via httputil.TLSConfig.
@@ -459,6 +461,8 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	cfg.IncusURL = getEnv("DNSWEAVER_INCUS_URL")
 	cfg.IncusSocketPath = getEnv("DNSWEAVER_INCUS_SOCKET_PATH")
 	cfg.IncusProject = getEnv("DNSWEAVER_INCUS_PROJECT")
+	cfg.IncusProjects = splitCommaList(getEnv("DNSWEAVER_INCUS_PROJECTS"))
+	cfg.IncusAllProjects = parseBool(getEnv("DNSWEAVER_INCUS_ALL_PROJECTS"), false)
 	cfg.IncusStateFilter = getEnv("DNSWEAVER_INCUS_STATE_FILTER")
 	cfg.IncusDomainSuffix = getEnv("DNSWEAVER_INCUS_DOMAIN_SUFFIX")
 	cfg.IncusTargetMode = getEnv("DNSWEAVER_INCUS_TARGET_MODE")

--- a/internal/config/incus_projects_test.go
+++ b/internal/config/incus_projects_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIncusProjectModes(t *testing.T) {
+	tests := []struct {
+		name            string
+		project         string
+		projects        []string
+		allProjectsFlag bool
+		wantAll         bool
+		wantProjects    []string
+	}{
+		{
+			name:         "single default",
+			project:      "",
+			wantAll:      false,
+			wantProjects: []string{},
+		},
+		{
+			name:         "single named",
+			project:      "prod",
+			wantAll:      false,
+			wantProjects: []string{},
+		},
+		{
+			name:         "explicit list",
+			projects:     []string{"a", "b", "c"},
+			wantAll:      false,
+			wantProjects: []string{"a", "b", "c"},
+		},
+		{
+			name:            "all-projects flag",
+			allProjectsFlag: true,
+			wantAll:         true,
+			wantProjects:    nil,
+		},
+		{
+			name:         "wildcard star in list means all",
+			projects:     []string{"a", "*"},
+			wantAll:      true,
+			wantProjects: nil,
+		},
+		{
+			name:         "wildcard all keyword means all",
+			projects:     []string{"all"},
+			wantAll:      true,
+			wantProjects: nil,
+		},
+		{
+			name:            "flag wins over list",
+			projects:        []string{"a", "b"},
+			allProjectsFlag: true,
+			wantAll:         true,
+			wantProjects:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{Global: &GlobalConfig{
+				IncusProject:     tt.project,
+				IncusProjects:    tt.projects,
+				IncusAllProjects: tt.allProjectsFlag,
+			}}
+			if got := c.IncusAllProjects(); got != tt.wantAll {
+				t.Errorf("IncusAllProjects() = %v, want %v", got, tt.wantAll)
+			}
+			if got := c.IncusProjects(); !reflect.DeepEqual(got, tt.wantProjects) {
+				t.Errorf("IncusProjects() = %v, want %v", got, tt.wantProjects)
+			}
+			if got := c.IncusProject(); got != tt.project {
+				t.Errorf("IncusProject() = %q, want %q", got, tt.project)
+			}
+		})
+	}
+}
+
+func TestSplitCommaList(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"a", []string{"a"}},
+		{"a,b,c", []string{"a", "b", "c"}},
+		{" a , b ,, c ", []string{"a", "b", "c"}},
+	}
+	for _, tt := range tests {
+		if got := splitCommaList(tt.in); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("splitCommaList(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -67,6 +67,18 @@ func parseBool(s string, defaultValue bool) bool {
 	}
 }
 
+// splitCommaList splits a comma-separated string into a trimmed, non-empty
+// slice. Returns nil for an empty or all-whitespace input.
+func splitCommaList(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // normalizeInstanceName converts an instance name to environment variable format.
 // Example: "internal-dns" → "INTERNAL_DNS"
 func normalizeInstanceName(name string) string {

--- a/internal/incus/client.go
+++ b/internal/incus/client.go
@@ -59,8 +59,13 @@ type ClientConfig struct {
 	SocketPath string
 
 	// Project is the Incus project to query. Empty string uses the Incus
-	// default project ("default").
+	// default project ("default"). Ignored when AllProjects is true.
 	Project string
+
+	// AllProjects queries every project the client's credentials can see, via
+	// the API's all-projects mode, instead of a single project. When true,
+	// Project is ignored. Requires server-wide (unrestricted) credentials.
+	AllProjects bool
 
 	// TLS is the unified TLS configuration for remote HTTPS endpoints. Incus
 	// remote authentication uses a client certificate/key pair (CertFile and
@@ -76,10 +81,11 @@ type ClientConfig struct {
 
 // Client is an Incus REST API client.
 type Client struct {
-	baseURL string
-	project string
-	http    *http.Client
-	logger  *slog.Logger
+	baseURL     string
+	project     string
+	allProjects bool
+	http        *http.Client
+	logger      *slog.Logger
 }
 
 // NewClient creates a new Incus API client from the given config. Exactly one
@@ -128,10 +134,11 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		baseURL: baseURL,
-		project: cfg.Project,
-		http:    httpClient,
-		logger:  logger,
+		baseURL:     baseURL,
+		project:     cfg.Project,
+		allProjects: cfg.AllProjects,
+		http:        httpClient,
+		logger:      logger,
 	}, nil
 }
 
@@ -200,12 +207,16 @@ type InstanceAddress struct {
 }
 
 // ListInstances returns all instances (containers and VMs) in the configured
-// project, including their runtime network state. The state is required for
-// IP resolution, so recursion=2 is always requested.
+// project (or across all projects when AllProjects is set), including their
+// runtime network state. The state is required for IP resolution, so
+// recursion=2 is always requested.
 func (c *Client) ListInstances(ctx context.Context) ([]Instance, error) {
 	q := url.Values{}
 	q.Set("recursion", "2")
-	if c.project != "" {
+	switch {
+	case c.allProjects:
+		q.Set("all-projects", "true")
+	case c.project != "":
 		q.Set("project", c.project)
 	}
 

--- a/internal/incus/client_test.go
+++ b/internal/incus/client_test.go
@@ -111,6 +111,30 @@ func TestListInstancesHTTP(t *testing.T) {
 	}
 }
 
+// TestListInstancesAllProjects verifies the client requests all-projects mode
+// (and does not send a project filter) when AllProjects is set.
+func TestListInstancesAllProjects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("all-projects") != "true" {
+			t.Errorf("expected all-projects=true, got %q", r.URL.RawQuery)
+		}
+		if r.URL.Query().Get("project") != "" {
+			t.Errorf("expected no project filter, got %q", r.URL.Query().Get("project"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"type":"sync","status_code":200,"metadata":[]}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(ClientConfig{BaseURL: srv.URL, Project: "ignored", AllProjects: true})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := client.ListInstances(context.Background()); err != nil {
+		t.Fatalf("ListInstances: %v", err)
+	}
+}
+
 func TestListInstancesAPIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/incus/events.go
+++ b/internal/incus/events.go
@@ -65,7 +65,8 @@ func (e Event) Action() string {
 }
 
 // eventsURL builds the WebSocket URL for the events endpoint, restricted to the
-// given event types and the client's configured project. The base URL scheme is
+// given event types and the client's configured project (or all projects when
+// AllProjects is set). The base URL scheme is
 // switched to ws/wss because coder/websocket dials WebSocket schemes; the custom
 // transport on the client's http.Client (unix socket dialer or TLS config) is
 // reused for the handshake, so socket and remote HTTPS endpoints both work.
@@ -83,7 +84,10 @@ func (c *Client) eventsURL(types []string) string {
 	if len(types) > 0 {
 		params = append(params, "type="+strings.Join(types, ","))
 	}
-	if c.project != "" {
+	switch {
+	case c.allProjects:
+		params = append(params, "all-projects=true")
+	case c.project != "":
 		params = append(params, "project="+c.project)
 	}
 	if len(params) > 0 {

--- a/internal/incus/events_test.go
+++ b/internal/incus/events_test.go
@@ -62,18 +62,21 @@ func TestEventAction(t *testing.T) {
 
 func TestEventsURL(t *testing.T) {
 	tests := []struct {
-		name    string
-		base    string
-		project string
-		want    string
+		name        string
+		base        string
+		project     string
+		allProjects bool
+		want        string
 	}{
-		{"socket", "http://incus", "", "ws://incus/1.0/events?type=lifecycle"},
-		{"https", "https://incus:8443", "", "wss://incus:8443/1.0/events?type=lifecycle"},
-		{"with project", "https://incus:8443", "prod", "wss://incus:8443/1.0/events?type=lifecycle&project=prod"},
+		{"socket", "http://incus", "", false, "ws://incus/1.0/events?type=lifecycle"},
+		{"https", "https://incus:8443", "", false, "wss://incus:8443/1.0/events?type=lifecycle"},
+		{"with project", "https://incus:8443", "prod", false, "wss://incus:8443/1.0/events?type=lifecycle&project=prod"},
+		{"all projects", "https://incus:8443", "", true, "wss://incus:8443/1.0/events?type=lifecycle&all-projects=true"},
+		{"all projects overrides project", "https://incus:8443", "prod", true, "wss://incus:8443/1.0/events?type=lifecycle&all-projects=true"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Client{baseURL: tt.base, project: tt.project}
+			c := &Client{baseURL: tt.base, project: tt.project, allProjects: tt.allProjects}
 			got := c.eventsURL([]string{EventTypeLifecycle})
 			if got != tt.want {
 				t.Errorf("eventsURL() = %q, want %q", got, tt.want)


### PR DESCRIPTION
## Summary

Adds multi-project support to the Incus source. A single dnsweaver instance can now watch many Incus projects, so one deployment can serve an entire cluster instead of running one dnsweaver per project.

Three modes, in precedence order:

- **All projects** — `DNSWEAVER_INCUS_ALL_PROJECTS=true` watches every project via the API's all-projects mode (one lister + one event stream for the whole server), including projects created later. `*` or `all` in the list below is a shorthand for this.
- **Explicit list** — `DNSWEAVER_INCUS_PROJECTS=a,b,c` watches exactly those projects (one client — lister + watcher — per project). Projects that don't exist yet are still watched and picked up the moment they appear.
- **Single project** — `DNSWEAVER_INCUS_PROJECT=a` is the original behavior, unchanged.

### Why this matters

`/1.0/events` is **project-scoped**: with no project filter a watcher only receives events for its connection's project. The previous single-project watcher silently missed events in other projects. `GET /1.0/events?all-projects=true` (and `/1.0/instances?all-projects=true`) delivers every project's data in one stream, each item tagged with its `project`. Subscribing to a not-yet-existing project works too, so new projects are auto-discovered.

Each instance's project is preserved in its workload metadata, so records stay correctly attributed. All-projects mode requires server-wide (unrestricted) credentials, which is documented.

### Validation

Tested against a real Incus 7.2 server: one all-projects instance discovered **23 instances across 2 projects** (`default` + `many-dependencies`), and a single event stream received lifecycle events tagged `project=default` and `project=many-dependencies`.

## Related issues

Closes #137

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Maintenance / refactor / CI

## Checklist

- [x] `gofmt` clean and `golangci-lint run ./...` passes
- [x] `go test ./...` passes (added/updated tests where relevant)
- [x] `go build ./...` succeeds
- [x] Docs updated (README / docs site) if behavior or config changed
- [x] CHANGELOG.md updated under the Unreleased section if user-facing
