### PR TITLE
feat(incus): trust-token certificate enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Incus trust-token authentication.** dnsweaver can enroll its own client
+  certificate against the Incus API using a one-time trust token instead of a
+  pre-provisioned certificate. Set `DNSWEAVER_INCUS_TRUST_TOKEN` and a writable
+  `DNSWEAVER_INCUS_CERT_STORE`: on first start dnsweaver generates an ECDSA
+  keypair + self-signed client certificate, registers it via `POST
+  /1.0/certificates`, and persists it (mode `0600`) for reuse. Because trust
+  tokens are single-use, subsequent starts reuse the persisted certificate and
+  ignore the token (idempotent). When `DNSWEAVER_INCUS_PROJECTS` is set the
+  certificate is registered restricted to those projects. Falls back to the
+  existing `DNSWEAVER_INCUS_TLS_CERT_FILE` / `_KEY_FILE` when no token is set.
+  Thanks to [@jochumdev](https://github.com/jochumdev) for the request and the
+  reference flow. ([GitHub #134](https://github.com/maxfield-allison/dnsweaver/issues/134))
 - **Automatic target IP detection** for provider instances. Set
   `DNSWEAVER_{NAME}_TARGET_MODE` to resolve a record's target at runtime instead
   of hardcoding it: `public` discovers the host's public IP via HTTP echo

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -27,6 +27,7 @@ import (
 	proxmoxclient "github.com/maxfield-allison/dnsweaver/internal/proxmox"
 	"github.com/maxfield-allison/dnsweaver/internal/reconciler"
 	"github.com/maxfield-allison/dnsweaver/internal/watcher"
+	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
 	"github.com/maxfield-allison/dnsweaver/pkg/provider"
 	"github.com/maxfield-allison/dnsweaver/pkg/source"
 	"github.com/maxfield-allison/dnsweaver/pkg/workload"
@@ -313,10 +314,41 @@ func run() error {
 	// one client per project), or DNSWEAVER_INCUS_PROJECT (a single project).
 	var incusClients []*incusclient.Client
 	if cfg.UseIncus() {
+		incusTLS := cfg.IncusTLS()
+
+		// Resolve the client certificate: reuse a persisted keypair, enroll a
+		// new one via a trust token, or fall back to configured cert/key files
+		// (#134). Only applies to remote HTTPS endpoints; socket mode needs no
+		// client certificate.
+		if cfg.IncusURL() != "" {
+			var fallbackCert, fallbackKey string
+			if incusTLS != nil {
+				fallbackCert, fallbackKey = incusTLS.CertFile, incusTLS.KeyFile
+			}
+			cc, err := incusclient.EnsureClientCert(ctx, incusclient.EnrollConfig{
+				BaseURL:   cfg.IncusURL(),
+				Token:     cfg.IncusTrustToken(),
+				CertStore: cfg.IncusCertStore(),
+				Projects:  cfg.IncusProjects(),
+				TLS:       incusTLS,
+				Logger:    logger,
+			}, fallbackCert, fallbackKey)
+			if err != nil {
+				return fmt.Errorf("resolving incus client certificate: %w", err)
+			}
+			if cc.CertFile != "" || cc.KeyFile != "" {
+				if incusTLS == nil {
+					incusTLS = &httputil.TLSConfig{}
+				}
+				incusTLS.CertFile = cc.CertFile
+				incusTLS.KeyFile = cc.KeyFile
+			}
+		}
+
 		baseCfg := incusclient.ClientConfig{
 			BaseURL:    cfg.IncusURL(),
 			SocketPath: cfg.IncusSocketPath(),
-			TLS:        cfg.IncusTLS(),
+			TLS:        incusTLS,
 			Logger:     logger,
 		}
 

--- a/docs/sources/incus.md
+++ b/docs/sources/incus.md
@@ -124,6 +124,8 @@ DNSWEAVER_INCUS_DOMAIN_SUFFIX=home.example.com
 | `DNSWEAVER_INCUS_TLS_CA_FILE` | No | — | Path to PEM CA bundle that issued the Incus server certificate (remote HTTPS). |
 | `DNSWEAVER_INCUS_TLS_CERT_FILE` | No | — | Client certificate for mutual TLS against the Incus API (pair with `TLS_KEY_FILE`). |
 | `DNSWEAVER_INCUS_TLS_KEY_FILE` | No | — | Client private key for mutual TLS. |
+| `DNSWEAVER_INCUS_TRUST_TOKEN` | No | — | One-time Incus trust token to enroll a client certificate. See [Trust-Token Authentication](#trust-token-authentication). |
+| `DNSWEAVER_INCUS_CERT_STORE` | No | — | Writable directory where the enrolled client keypair is persisted. Required with `TRUST_TOKEN`. |
 | `DNSWEAVER_INCUS_TLS_SERVER_NAME` | No | — | SNI / verification hostname override. |
 | `DNSWEAVER_INCUS_TLS_MIN_VERSION` | No | `1.2` | Minimum TLS protocol version (`1.2` or `1.3`). |
 | `DNSWEAVER_INCUS_TLS_SKIP_VERIFY` | No | `false` | Skip Incus TLS certificate verification. Prefer `TLS_CA_FILE`. |
@@ -289,6 +291,45 @@ DNSWEAVER_INCUS_TLS_CA_FILE=/run/secrets/incus_server_ca
     When using `DNSWEAVER_INCUS_SOCKET_PATH`, no TLS configuration is required —
     access is governed by Unix socket file permissions. Mount the socket into the
     container and ensure the dnsweaver process can read it.
+
+### Trust-Token Authentication
+
+Instead of pre-provisioning a client certificate, dnsweaver can enroll itself
+using an Incus [trust token](https://linuxcontainers.org/incus/docs/main/authentication/#adding-client-certificates-using-tokens).
+On first start it generates a client keypair, registers it with the token, and
+**persists it to a writable cert store** for reuse. Trust tokens are one-time
+use, so the cert store must survive restarts.
+
+```bash
+# On the Incus host: issue a one-time token for dnsweaver
+incus config trust add dnsweaver
+# (copy the printed token)
+```
+
+```bash
+# dnsweaver
+DNSWEAVER_INCUS_URL=https://incus-host.home.example.com:8443
+DNSWEAVER_INCUS_TRUST_TOKEN=<one-time token>
+DNSWEAVER_INCUS_CERT_STORE=/var/lib/dnsweaver/incus   # writable, persistent
+DNSWEAVER_INCUS_TLS_CA_FILE=/run/secrets/incus_server_ca   # optional
+```
+
+Behavior:
+
+- **First start:** generates an ECDSA keypair + self-signed client certificate,
+  `POST`s it to `/1.0/certificates` with the token, and writes `client.crt` /
+  `client.key` (mode `0600`) into the cert store.
+- **Subsequent starts:** reuses the persisted certificate; the (now-consumed)
+  token is ignored. Enrollment is idempotent.
+- **Restricted to projects:** when `DNSWEAVER_INCUS_PROJECTS` is set, the
+  certificate is registered restricted to those projects.
+- **Fallback:** if no token is set, dnsweaver uses
+  `DNSWEAVER_INCUS_TLS_CERT_FILE` / `DNSWEAVER_INCUS_TLS_KEY_FILE` as before.
+
+!!! warning "The cert store must be persistent"
+    Because trust tokens are single-use, a non-persistent cert store means every
+    restart needs a fresh token. Mount `DNSWEAVER_INCUS_CERT_STORE` on a durable
+    volume. The directory is created `0700` and the keypair written `0600`.
 
 ## Workload Metadata
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -459,6 +459,18 @@ func (c *Config) IncusTargetMode() string {
 	return c.Global.IncusTargetMode
 }
 
+// IncusTrustToken returns the one-time Incus trust token used to enroll a
+// client certificate. Empty when not configured.
+func (c *Config) IncusTrustToken() string {
+	return c.Global.IncusTrustToken
+}
+
+// IncusCertStore returns the writable directory where an enrolled Incus client
+// keypair is persisted. Empty when not configured.
+func (c *Config) IncusCertStore() string {
+	return c.Global.IncusCertStore
+}
+
 // IncusTLS returns the unified TLS configuration for the remote Incus API
 // client. Returns nil when no DNSWEAVER_INCUS_TLS_* env vars are set — in that
 // case the client uses stdlib defaults (system roots, verification on, TLS 1.2

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -124,6 +124,13 @@ type GlobalConfig struct {
 	IncusTLSSkipVerify bool
 	IncusTLSMinVersion string
 
+	// Incus trust-token enrollment (#134). When IncusTrustToken is set and no
+	// persisted certificate exists in IncusCertStore, dnsweaver generates a
+	// client keypair, registers it with the token, and persists it to the
+	// cert store for reuse.
+	IncusTrustToken string
+	IncusCertStore  string
+
 	// Multi-instance coordination
 	InstanceID string // Unique identifier for this dnsweaver instance (for shared zone management)
 }
@@ -498,6 +505,10 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	if v := getEnv("DNSWEAVER_INCUS_TLS_SKIP_VERIFY"); v != "" {
 		cfg.IncusTLSSkipVerify = parseBool(v, false)
 	}
+
+	// Incus trust-token enrollment (#134).
+	cfg.IncusTrustToken = getEnv("DNSWEAVER_INCUS_TRUST_TOKEN")
+	cfg.IncusCertStore = getEnv("DNSWEAVER_INCUS_CERT_STORE")
 
 	return cfg, errs
 }

--- a/internal/incus/enroll.go
+++ b/internal/incus/enroll.go
@@ -1,0 +1,316 @@
+// Package incus certificate enrollment via trust tokens.
+//
+// Incus authenticates remote clients with a TLS client certificate. Rather than
+// requiring operators to pre-provision a certificate, Incus can issue a
+// one-time trust token that a client uses to register its own certificate into
+// the server's trust store (see
+// https://linuxcontainers.org/incus/docs/main/authentication/#adding-client-certificates-using-tokens).
+//
+// Because trust tokens are single-use, the generated keypair must be persisted
+// and reused on subsequent starts. This file implements that flow with the
+// standard library only (no Incus SDK):
+//
+//  1. If a persisted certificate exists in the cert store, use it (the token,
+//     if any, is ignored — enrollment is idempotent).
+//  2. Otherwise, if a trust token is configured, generate an ECDSA P-384
+//     keypair + self-signed client certificate, POST it to /1.0/certificates
+//     with the token, and persist the keypair on success.
+//  3. Otherwise, fall back to any pre-provisioned cert/key files.
+package incus
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
+)
+
+// Cert store filenames for the persisted client keypair.
+const (
+	certFileName = "client.crt"
+	keyFileName  = "client.key"
+
+	// defaultCertName is the certificate name registered in the Incus trust
+	// store, and the CommonName of the generated certificate, when unset.
+	defaultCertName = "dnsweaver"
+)
+
+// EnrollConfig configures trust-token enrollment.
+type EnrollConfig struct {
+	// BaseURL is the remote Incus API base URL (https://host:8443). Required.
+	BaseURL string
+
+	// Token is the one-time Incus trust token. When empty, no enrollment is
+	// attempted (the persisted cert, or the fallback cert/key, is used).
+	Token string
+
+	// CertStore is the writable directory where the enrolled keypair is
+	// persisted (client.crt / client.key). Required when Token is set.
+	CertStore string
+
+	// Name is the certificate name registered in the Incus trust store.
+	// Defaults to "dnsweaver" when empty.
+	Name string
+
+	// Projects, when non-empty, registers the certificate as restricted to
+	// those projects. Empty registers an unrestricted certificate.
+	Projects []string
+
+	// TLS is the TLS config used to reach the server during enrollment. Its
+	// CAFile/ServerName/InsecureSkip settings apply to server verification.
+	// CertFile/KeyFile are ignored (enrollment presents no client cert).
+	TLS *httputil.TLSConfig
+
+	// Logger defaults to slog.Default() if nil.
+	Logger *slog.Logger
+}
+
+// ClientCert is the resolved certificate/key pair the Incus client should use.
+type ClientCert struct {
+	CertFile string
+	KeyFile  string
+}
+
+// certificatesPost is the /1.0/certificates request body. Mirrors the subset of
+// the Incus API we need. The certificate itself is presented in the TLS
+// handshake (mTLS), not in the body: an untrusted client registering via a
+// trust token authenticates by presenting the very certificate it wants added,
+// and Incus reads it from the connection's peer certificate. The server adds it
+// to the trust store when the trust token is valid.
+type certificatesPost struct {
+	Name       string   `json:"name"`
+	Type       string   `json:"type"`
+	TrustToken string   `json:"trust_token"`
+	Restricted bool     `json:"restricted,omitempty"`
+	Projects   []string `json:"projects,omitempty"`
+}
+
+// EnsureClientCert resolves the client certificate to use for the Incus API.
+//
+// Precedence:
+//  1. A persisted keypair in CertStore (idempotent reuse; token ignored).
+//  2. Fresh enrollment with Token (generates + persists a keypair).
+//  3. The fallback CertFile/KeyFile (returned when no token is configured).
+//
+// The returned ClientCert has empty fields when neither a persisted cert, a
+// token, nor fallback files are available; the caller then proceeds without a
+// client certificate.
+func EnsureClientCert(ctx context.Context, cfg EnrollConfig, fallbackCert, fallbackKey string) (ClientCert, error) {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// 1. Reuse a persisted keypair if present.
+	if cfg.CertStore != "" {
+		certPath := filepath.Join(cfg.CertStore, certFileName)
+		keyPath := filepath.Join(cfg.CertStore, keyFileName)
+		if fileExists(certPath) && fileExists(keyPath) {
+			logger.Info("using persisted incus client certificate",
+				slog.String("cert_store", cfg.CertStore),
+			)
+			return ClientCert{CertFile: certPath, KeyFile: keyPath}, nil
+		}
+	}
+
+	// 2. Enroll with a trust token.
+	if cfg.Token != "" {
+		if cfg.CertStore == "" {
+			return ClientCert{}, fmt.Errorf("incus: DNSWEAVER_INCUS_CERT_STORE is required when a trust token is set (tokens are one-time use and the enrolled certificate must be persisted)")
+		}
+		cc, err := enroll(ctx, cfg, logger)
+		if err != nil {
+			return ClientCert{}, err
+		}
+		return cc, nil
+	}
+
+	// 3. Fall back to pre-provisioned cert/key files.
+	return ClientCert{CertFile: fallbackCert, KeyFile: fallbackKey}, nil
+}
+
+// enroll generates a keypair, registers it with the trust token, and persists
+// it to the cert store.
+//
+// The generated certificate is presented as the TLS client certificate during
+// the POST: Incus reads the enrolling certificate from the mTLS handshake, not
+// the request body. Because the certificate is brand-new and not yet in the
+// trust store, the connection is inherently "untrusted" until the token is
+// validated server-side; the trust token in the body is what authorizes it.
+func enroll(ctx context.Context, cfg EnrollConfig, logger *slog.Logger) (ClientCert, error) {
+	certPEM, keyPEM, _, err := generateClientCert(cfg.Name)
+	if err != nil {
+		return ClientCert{}, fmt.Errorf("incus: generating client certificate: %w", err)
+	}
+
+	clientCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return ClientCert{}, fmt.Errorf("incus: loading generated keypair: %w", err)
+	}
+
+	name := cfg.Name
+	if name == "" {
+		name = defaultCertName
+	}
+	body := certificatesPost{
+		Name:       name,
+		Type:       "client",
+		TrustToken: cfg.Token,
+		Restricted: len(cfg.Projects) > 0,
+		Projects:   cfg.Projects,
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return ClientCert{}, fmt.Errorf("incus: encoding certificate request: %w", err)
+	}
+
+	client, err := enrollmentClient(cfg.TLS, clientCert)
+	if err != nil {
+		return ClientCert{}, fmt.Errorf("incus: building enrollment client: %w", err)
+	}
+
+	url := strings.TrimRight(cfg.BaseURL, "/") + "/1.0/certificates"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return ClientCert{}, fmt.Errorf("incus: creating certificate request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return ClientCert{}, fmt.Errorf("incus: registering certificate with token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return ClientCert{}, fmt.Errorf("incus: certificate registration failed: %s", decodeAPIError(resp))
+	}
+
+	// Persist only after a successful registration so a failed attempt is
+	// retried on the next start.
+	if err := os.MkdirAll(cfg.CertStore, 0o700); err != nil {
+		return ClientCert{}, fmt.Errorf("incus: creating cert store %q: %w", cfg.CertStore, err)
+	}
+	certPath := filepath.Join(cfg.CertStore, certFileName)
+	keyPath := filepath.Join(cfg.CertStore, keyFileName)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		return ClientCert{}, fmt.Errorf("incus: writing key to cert store: %w", err)
+	}
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		return ClientCert{}, fmt.Errorf("incus: writing certificate to cert store: %w", err)
+	}
+
+	logger.Info("enrolled and persisted incus client certificate via trust token",
+		slog.String("name", name),
+		slog.String("cert_store", cfg.CertStore),
+		slog.Bool("restricted", len(cfg.Projects) > 0),
+	)
+	return ClientCert{CertFile: certPath, KeyFile: keyPath}, nil
+}
+
+// generateClientCert returns a fresh ECDSA P-384 keypair and self-signed X.509
+// client certificate, PEM-encoded, plus the raw certificate DER.
+func generateClientCert(commonName string) (certPEM, keyPEM, certDER []byte, err error) {
+	if commonName == "" {
+		commonName = defaultCertName
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("ecdsa key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("serial: %w", err)
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating cert: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshaling key: %w", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, der, nil
+}
+
+// enrollmentClient builds an HTTP client that presents clientCert in the TLS
+// handshake. Server verification honors the operator's TLS settings (CAFile,
+// ServerName, InsecureSkip) from cfg; any CertFile/KeyFile on cfg is ignored
+// because the enrollment cert is the freshly generated one, not a persisted
+// pair. When no TLS config is supplied a default is used.
+func enrollmentClient(cfg *httputil.TLSConfig, clientCert tls.Certificate) (*http.Client, error) {
+	var tlsConf *tls.Config
+	if cfg != nil {
+		serverConf := *cfg
+		// The generated keypair is presented explicitly below; drop any
+		// file-based client cert so Build() doesn't try to load one.
+		serverConf.CertFile = ""
+		serverConf.KeyFile = ""
+		built, err := serverConf.Build()
+		if err != nil {
+			return nil, err
+		}
+		tlsConf = built
+	}
+	if tlsConf == nil {
+		tlsConf = &tls.Config{MinVersion: httputil.DefaultTLSMinVersion} //nolint:gosec // DefaultTLSMinVersion is TLS 1.2
+	}
+	tlsConf.Certificates = []tls.Certificate{clientCert}
+
+	return &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConf,
+		},
+	}, nil
+}
+
+// decodeAPIError extracts a useful message from an Incus error response.
+func decodeAPIError(resp *http.Response) string {
+	var env struct {
+		Error string `json:"error"`
+	}
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&env); err == nil && env.Error != "" {
+		return fmt.Sprintf("status %d: %s", resp.StatusCode, env.Error)
+	}
+	return fmt.Sprintf("status %d", resp.StatusCode)
+}
+
+// fileExists reports whether path exists.
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/incus/enroll_test.go
+++ b/internal/incus/enroll_test.go
@@ -1,0 +1,193 @@
+package incus
+
+import (
+	"context"
+	gotls "crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
+)
+
+// tlsSkip returns a TLS config that skips server verification, for the
+// self-signed cert used by httptest.NewTLSServer.
+func tlsSkip() *httputil.TLSConfig {
+	return &httputil.TLSConfig{InsecureSkip: true}
+}
+
+func TestGenerateClientCert(t *testing.T) {
+	certPEM, keyPEM, der, err := generateClientCert("dnsweaver-test")
+	if err != nil {
+		t.Fatalf("generateClientCert: %v", err)
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != "CERTIFICATE" {
+		t.Fatal("cert PEM did not decode")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	if cert.Subject.CommonName != "dnsweaver-test" {
+		t.Errorf("CN = %q, want dnsweaver-test", cert.Subject.CommonName)
+	}
+	if len(der) == 0 {
+		t.Error("empty DER")
+	}
+	if kb, _ := pem.Decode(keyPEM); kb == nil || kb.Type != "PRIVATE KEY" {
+		t.Error("key PEM did not decode")
+	}
+}
+
+func TestEnsureClientCert_PersistedReuse(t *testing.T) {
+	store := t.TempDir()
+	certPath := filepath.Join(store, certFileName)
+	keyPath := filepath.Join(store, keyFileName)
+	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A token is set, but the persisted cert must win (idempotent) and no HTTP
+	// call should occur (BaseURL is unreachable).
+	cc, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL:   "https://127.0.0.1:1",
+		Token:     "some-token",
+		CertStore: store,
+	}, "", "")
+	if err != nil {
+		t.Fatalf("EnsureClientCert: %v", err)
+	}
+	if cc.CertFile != certPath || cc.KeyFile != keyPath {
+		t.Errorf("got %+v, want persisted paths", cc)
+	}
+}
+
+func TestEnsureClientCert_Fallback(t *testing.T) {
+	cc, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL: "https://incus:8443",
+	}, "/etc/fallback.crt", "/etc/fallback.key")
+	if err != nil {
+		t.Fatalf("EnsureClientCert: %v", err)
+	}
+	if cc.CertFile != "/etc/fallback.crt" || cc.KeyFile != "/etc/fallback.key" {
+		t.Errorf("got %+v, want fallback paths", cc)
+	}
+}
+
+func TestEnsureClientCert_TokenRequiresStore(t *testing.T) {
+	_, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL: "https://incus:8443",
+		Token:   "tok",
+	}, "", "")
+	if err == nil {
+		t.Fatal("expected error when token set without cert store")
+	}
+}
+
+func TestEnsureClientCert_FreshEnrollment(t *testing.T) {
+	var gotBody certificatesPost
+	var peerCommonName string
+	var peerPresented bool
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1.0/certificates" || r.Method != http.MethodPost {
+			http.Error(w, "bad", http.StatusBadRequest)
+			return
+		}
+		// Incus reads the enrolling certificate from the TLS handshake, not
+		// the body. Verify dnsweaver presented it there.
+		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+			peerPresented = true
+			peerCommonName = r.TLS.PeerCertificates[0].Subject.CommonName
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"type":"sync","status_code":200,"metadata":{}}`))
+	}))
+	// Request (but do not verify) a client certificate so the handshake
+	// exposes the enrolling cert as a peer certificate.
+	srv.TLS = &gotls.Config{ClientAuth: gotls.RequireAnyClientCert} //nolint:gosec // test server
+	srv.StartTLS()
+	defer srv.Close()
+
+	store := t.TempDir()
+	// The httptest TLS server uses a self-signed cert; skip verification.
+	tls := tlsSkip()
+	cc, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL:   srv.URL,
+		Token:     "enroll-token",
+		CertStore: store,
+		Name:      "dnsweaver",
+		Projects:  []string{"prod"},
+		TLS:       tls,
+	}, "", "")
+	if err != nil {
+		t.Fatalf("EnsureClientCert: %v", err)
+	}
+
+	// Cert + key persisted.
+	if !fileExists(cc.CertFile) || !fileExists(cc.KeyFile) {
+		t.Fatalf("keypair not persisted: %+v", cc)
+	}
+	// Request carried the token, type, and restricted projects.
+	if gotBody.TrustToken != "enroll-token" {
+		t.Errorf("TrustToken = %q", gotBody.TrustToken)
+	}
+	if gotBody.Type != "client" {
+		t.Errorf("Type = %q, want client", gotBody.Type)
+	}
+	if !gotBody.Restricted || len(gotBody.Projects) != 1 || gotBody.Projects[0] != "prod" {
+		t.Errorf("restriction not sent: restricted=%v projects=%v", gotBody.Restricted, gotBody.Projects)
+	}
+	// The generated certificate was presented in the TLS handshake.
+	if !peerPresented {
+		t.Error("client certificate was not presented in the TLS handshake")
+	}
+	if peerCommonName != "dnsweaver" {
+		t.Errorf("peer certificate CommonName = %q, want dnsweaver", peerCommonName)
+	}
+
+	// A second call reuses the persisted cert (idempotent) without re-enrolling.
+	cc2, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL:   srv.URL,
+		Token:     "enroll-token",
+		CertStore: store,
+		TLS:       tls,
+	}, "", "")
+	if err != nil {
+		t.Fatalf("second EnsureClientCert: %v", err)
+	}
+	if cc2.CertFile != cc.CertFile {
+		t.Errorf("reuse path mismatch: %q vs %q", cc2.CertFile, cc.CertFile)
+	}
+}
+
+func TestEnsureClientCert_EnrollmentFailureNotPersisted(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"invalid token"}`))
+	}))
+	defer srv.Close()
+
+	store := t.TempDir()
+	_, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL:   srv.URL,
+		Token:     "bad-token",
+		CertStore: store,
+		TLS:       tlsSkip(),
+	}, "", "")
+	if err == nil {
+		t.Fatal("expected enrollment error")
+	}
+	if fileExists(filepath.Join(store, certFileName)) {
+		t.Error("certificate must not be persisted on failed enrollment")
+	}
+}


### PR DESCRIPTION
## Summary

Adds trust-token certificate enrollment for the Incus API, so operators can avoid pre-provisioning a client certificate. Requested in #134.

Set a one-time trust token plus a writable cert store:

```bash
DNSWEAVER_INCUS_URL=https://incus-host:8443
DNSWEAVER_INCUS_TRUST_TOKEN=<one-time token from `incus config trust add dnsweaver`>
DNSWEAVER_INCUS_CERT_STORE=/var/lib/dnsweaver/incus   # writable, persistent
```

On first start dnsweaver generates an ECDSA P-384 keypair + self-signed client certificate, registers it via `POST /1.0/certificates`, and persists it for reuse. Because trust tokens are single-use, subsequent starts reuse the persisted keypair and ignore the token (idempotent). Falls back to the existing `DNSWEAVER_INCUS_TLS_CERT_FILE` / `_KEY_FILE` when no token is set.

## Implementation note

Incus reads the enrolling certificate from the **mTLS handshake**, not the request body. The enrollment client therefore presents the freshly generated certificate as its TLS client certificate while honoring the operator's CA / ServerName / skip-verify settings for server verification. When `DNSWEAVER_INCUS_PROJECTS` is set, the certificate is registered restricted to those projects.

## Persistence

This is the first feature with a hard persistence requirement (the keypair must survive restarts). It is opt-in and scoped: only enrollment needs the cert store; every other mode remains stateless. The broader "should dnsweaver adopt a general state directory" question is open in Discussion #141.

## Testing

- Unit tests: fresh enrollment (asserts the cert is presented in the TLS handshake), persisted reuse, token-without-store error, enrollment-failure-not-persisted, cert generation.
- `golangci-lint`, `go test -race ./...`, `go build ./...` all green.
- End-to-end on a live Incus 7.2 host:
  - Fresh token enrollment registered the certificate in the server trust store and reconciled records.
  - Restart without a token reused the persisted certificate ("using persisted incus client certificate") and reconciled cleanly, proving idempotency.

Closes #134
