### PR TITLE
feat(proxmox): add hostname tag prefix support for FQDN resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   honor the selected scope. Thanks to
   [@jochumdev](https://github.com/jochumdev) for the request.
   ([GitHub #137](https://github.com/maxfield-allison/dnsweaver/issues/137))
+- **Proxmox hostname override tags.** The Proxmox source now supports an
+  optional `DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX` value to derive hostnames from
+  tags using `<prefix>+<hostname>` syntax. Explicit FQDN overrides are accepted
+  directly, and plain hostnames are combined with `DNSWEAVER_PROXMOX_DOMAIN_SUFFIX` when present.
 
 ## [2.5.0] - 2026-07-09
 

--- a/cmd/dnsweaver/setup.go
+++ b/cmd/dnsweaver/setup.go
@@ -155,6 +155,7 @@ func registerSources(registry *source.Registry, cfg *config.Config, logger *slog
 		case "proxmox":
 			src := proxmoxsource.New(
 				proxmoxsource.WithDomain(cfg.ProxmoxDomainSuffix()),
+				proxmoxsource.WithHostnameTagPrefix(cfg.ProxmoxHostnameTagPrefix()),
 				proxmoxsource.WithTargetMode(proxmoxTargetMode(cfg)),
 				proxmoxsource.WithLogger(logger),
 			)
@@ -201,6 +202,7 @@ func registerSources(registry *source.Registry, cfg *config.Config, logger *slog
 		if registry.Get("proxmox") == nil {
 			src := proxmoxsource.New(
 				proxmoxsource.WithDomain(cfg.ProxmoxDomainSuffix()),
+				proxmoxsource.WithHostnameTagPrefix(cfg.ProxmoxHostnameTagPrefix()),
 				proxmoxsource.WithTargetMode(proxmoxTargetMode(cfg)),
 				proxmoxsource.WithLogger(logger),
 			)

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -303,6 +303,7 @@ full setup including the required PVE role privileges.
 | `DNSWEAVER_PROXMOX_VERIFY_TLS` | No | `true` | **Deprecated** — inverted-polarity alias of `TLS_SKIP_VERIFY`. Will be removed in a future major release. |
 | `DNSWEAVER_PROXMOX_NODE_FILTER` | No | *(all)* | Restrict discovery to a single PVE node name |
 | `DNSWEAVER_PROXMOX_TAG_FILTER` | No | *(all)* | Only include resources with this tag (prefix match) |
+| `DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX` | No | — | Optional tag prefix in the form `<prefix>+<hostname>` used to override the discovered hostname |
 | `DNSWEAVER_PROXMOX_STATE_FILTER` | No | `running` | Resource status filter (`running`, `stopped`, etc.) |
 | `DNSWEAVER_PROXMOX_DOMAIN_SUFFIX` | No | — | Domain suffix appended to VM names |
 

--- a/docs/sources/proxmox.md
+++ b/docs/sources/proxmox.md
@@ -43,6 +43,7 @@ flowchart LR
 | `DNSWEAVER_PROXMOX_VERIFY_TLS` | No | `true` | **Deprecated** inverted-polarity alias of `TLS_SKIP_VERIFY` (will be removed in a future major release). |
 | `DNSWEAVER_PROXMOX_NODE_FILTER` | No | _(all nodes)_ | Restrict discovery to a single PVE node name |
 | `DNSWEAVER_PROXMOX_TAG_FILTER` | No | _(all tags)_ | Only include resources with this tag (prefix match) |
+| `DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX` | No | — | Optional tag prefix in the form `<prefix>+<hostname>` used to override the discovered hostname. The first matching tag wins if multiple tags share the prefix. |
 | `DNSWEAVER_PROXMOX_STATE_FILTER` | No | `running` | PVE resource status filter (`running`, `stopped`, etc.) |
 | `DNSWEAVER_PROXMOX_DOMAIN_SUFFIX` | No | — | Domain suffix appended to VM names, e.g. `home.example.com` |
 | `DNSWEAVER_PROXMOX_TARGET_MODE` | No | `guest-ip` | Target resolution mode. `guest-ip` (default) emits an A record per VM IP. `instance` defers record type and target to the matching provider instance — useful for pointing all VMs at a reverse proxy via CNAME. |
@@ -67,6 +68,15 @@ The source determines the DNS hostname for each workload using this logic:
 1. **VM name contains a dot** — used directly as an FQDN (e.g., `webserver.home.example.com`)
 2. **Domain suffix configured** — appended to the VM name (e.g., `webserver` + `home.example.com` → `webserver.home.example.com`)
 3. **Neither condition** — the workload is skipped; a debug log entry is emitted
+
+When `DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX` is configured, the source uses the first
+matching `<prefix>+<hostname>` tag it finds and ignores any later matches.
+
+!!! note "Proxmox tag restrictions"
+    Proxmox normalizes tag values, and stricter datacenter `tag-style` /
+    `allowed-characters` settings may reject `.` or `+`. If you plan to use
+    dotted FQDN overrides with `DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX`, ensure
+    your PVE tag style allows those characters.
 
 !!! warning "Domain suffix is strongly recommended"
     Without a domain suffix, only VMs whose names already contain a dot will

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -345,6 +345,12 @@ func (c *Config) ProxmoxDomainSuffix() string {
 	return c.Global.ProxmoxDomainSuffix
 }
 
+// ProxmoxHostnameTagPrefix returns the optional tag prefix used to derive an
+// explicit hostname from Proxmox tags.
+func (c *Config) ProxmoxHostnameTagPrefix() string {
+	return c.Global.ProxmoxHostnameTagPrefix
+}
+
 // ProxmoxTargetMode returns the configured target resolution mode
 // ("guest-ip" or "instance"). Empty string means use the default.
 func (c *Config) ProxmoxTargetMode() string {

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -85,15 +85,16 @@ type GlobalConfig struct {
 	Source string // traefik, labels, or custom source name
 
 	// Proxmox VE settings
-	ProxmoxURL          string // PVE API base URL (e.g., https://pve-00:8006)
-	ProxmoxTokenID      string // PVE API token ID (e.g., user@pam!dnsweaver)
-	ProxmoxTokenSecret  string // PVE API token secret (UUID); supports _FILE suffix
-	ProxmoxNodeFilter   string // Optional: limit to a specific node (empty = all nodes)
-	ProxmoxTagFilter    string // Optional: prefix match on PVE tags to filter workloads
-	ProxmoxStateFilter  string // Filter by PVE resource status (default: "running")
-	ProxmoxDomainSuffix string // Domain suffix to append to VM names (e.g., "home.example.com")
-	ProxmoxVerifyTLS    bool   // Verify TLS certificate on PVE API endpoint (DEPRECATED in v1.5: prefer ProxmoxTLSSkipVerify)
-	ProxmoxTargetMode   string // Target resolution mode: "guest-ip" (default) or "instance"
+	ProxmoxURL               string // PVE API base URL (e.g., https://pve-00:8006)
+	ProxmoxTokenID           string // PVE API token ID (e.g., user@pam!dnsweaver)
+	ProxmoxTokenSecret       string // PVE API token secret (UUID); supports _FILE suffix
+	ProxmoxNodeFilter        string // Optional: limit to a specific node (empty = all nodes)
+	ProxmoxTagFilter         string // Optional: prefix match on PVE tags to filter workloads
+	ProxmoxStateFilter       string // Filter by PVE resource status (default: "running")
+	ProxmoxDomainSuffix      string // Domain suffix to append to VM names (e.g., "home.example.com")
+	ProxmoxHostnameTagPrefix string // Optional: tag prefix for hostname override tags (e.g. "dnsweaver")
+	ProxmoxVerifyTLS         bool   // Verify TLS certificate on PVE API endpoint (DEPRECATED in v1.5: prefer ProxmoxTLSSkipVerify)
+	ProxmoxTargetMode        string // Target resolution mode: "guest-ip" (default) or "instance"
 
 	// Unified PVE TLS configuration (v1.5+). Populated from DNSWEAVER_PROXMOX_TLS_*
 	// env vars and consumed by internal/proxmox via httputil.TLSConfig.
@@ -421,6 +422,7 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	cfg.ProxmoxTagFilter = getEnv("DNSWEAVER_PROXMOX_TAG_FILTER")
 	cfg.ProxmoxStateFilter = getEnv("DNSWEAVER_PROXMOX_STATE_FILTER")
 	cfg.ProxmoxDomainSuffix = getEnv("DNSWEAVER_PROXMOX_DOMAIN_SUFFIX")
+	cfg.ProxmoxHostnameTagPrefix = getEnv("DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX")
 	cfg.ProxmoxTargetMode = getEnv("DNSWEAVER_PROXMOX_TARGET_MODE")
 	if cfg.ProxmoxTargetMode != "" {
 		switch strings.ToLower(strings.TrimSpace(cfg.ProxmoxTargetMode)) {

--- a/sources/proxmox/proxmox.go
+++ b/sources/proxmox/proxmox.go
@@ -63,9 +63,10 @@ func ParseTargetMode(s string) (TargetMode, error) {
 
 // Proxmox implements the source.Source interface for Proxmox VE workloads.
 type Proxmox struct {
-	domain     string
-	targetMode TargetMode
-	logger     *slog.Logger
+	domain            string
+	targetMode        TargetMode
+	hostnameTagPrefix string
+	logger            *slog.Logger
 }
 
 // Option is a functional option for configuring Proxmox.
@@ -87,6 +88,16 @@ func WithLogger(logger *slog.Logger) Option {
 func WithDomain(domain string) Option {
 	return func(p *Proxmox) {
 		p.domain = strings.TrimPrefix(strings.TrimSpace(domain), ".")
+	}
+}
+
+// WithHostnameTagPrefix sets an optional tag prefix used to derive an explicit
+// hostname from Proxmox tags. Tags matching "<prefix>+<hostname>" are treated
+// as hostname overrides. Explicit FQDN values are used verbatim, and bare
+// hostnames are appended with the configured domain suffix when present.
+func WithHostnameTagPrefix(prefix string) Option {
+	return func(p *Proxmox) {
+		p.hostnameTagPrefix = strings.TrimSpace(prefix)
 	}
 }
 
@@ -162,7 +173,7 @@ func (p *Proxmox) Extract(_ context.Context, w workload.Workload) ([]source.Host
 		return nil, nil
 	}
 
-	hostname, err := p.resolveHostname(w.Name)
+	hostname, err := p.resolveHostname(w)
 	if err != nil {
 		p.logger.Debug("could not determine hostname for proxmox workload; skipping",
 			slog.String("workload", w.Name),
@@ -194,13 +205,63 @@ func (p *Proxmox) Extract(_ context.Context, w workload.Workload) ([]source.Host
 
 // resolveHostname determines the FQDN for a given VM name.
 // Returns an error (logged as debug, not returned to caller) if no hostname can be determined.
-func (p *Proxmox) resolveHostname(name string) (string, error) {
-	if strings.Contains(name, ".") {
+func (p *Proxmox) resolveHostname(w workload.Workload) (string, error) {
+	if tagHostname := p.resolveHostnameFromTags(w); tagHostname != "" {
+		return tagHostname, nil
+	}
+	if strings.Contains(w.Name, ".") {
 		// VM name already looks like an FQDN — use it directly.
-		return name, nil
+		return w.Name, nil
 	}
 	if p.domain != "" {
-		return name + "." + p.domain, nil
+		return w.Name + "." + p.domain, nil
 	}
-	return "", fmt.Errorf("VM name %q is not an FQDN and no domain suffix is configured", name)
+	return "", fmt.Errorf("VM name %q is not an FQDN and no domain suffix is configured", w.Name)
+}
+
+func (p *Proxmox) resolveHostnameFromTags(w workload.Workload) string {
+	if p.hostnameTagPrefix == "" {
+		return ""
+	}
+
+	tags := w.Metadata["tags"]
+	if tags == "" {
+		return ""
+	}
+
+	prefix := p.hostnameTagPrefix + "+"
+	var firstMatch string
+	for _, tag := range strings.Split(tags, ";") {
+		tag = strings.TrimSpace(tag)
+		if !strings.HasPrefix(tag, prefix) {
+			continue
+		}
+		override := strings.TrimSpace(strings.TrimPrefix(tag, prefix))
+		if override == "" {
+			continue
+		}
+		if firstMatch == "" {
+			firstMatch = override
+			continue
+		}
+		if p.logger != nil {
+			p.logger.Debug("multiple hostname override tags found; using first match",
+				"tags", tags,
+				"prefix", p.hostnameTagPrefix,
+				"first", firstMatch,
+				"next", override)
+		}
+		break
+	}
+
+	if firstMatch == "" {
+		return ""
+	}
+	if strings.Contains(firstMatch, ".") {
+		return firstMatch
+	}
+	if p.domain != "" {
+		return firstMatch + "." + p.domain
+	}
+	return firstMatch
 }

--- a/sources/proxmox/proxmox_test.go
+++ b/sources/proxmox/proxmox_test.go
@@ -90,6 +90,63 @@ func TestExtract_WithDomain(t *testing.T) {
 	}
 }
 
+func TestExtract_WithHostnameTagPrefixOverrideFQDN(t *testing.T) {
+	src := New(WithDomain("home.example.com"), WithHostnameTagPrefix("dnsweaver"))
+	w := workload.Workload{
+		Platform: workload.PlatformProxmox,
+		Name:     "webserver",
+		Metadata: map[string]string{"ip": "10.1.20.5", "node": "pve-00", "vmid": "100", "tags": "dnsweaver+webapp.home.example.com;other:keep"},
+	}
+	hostnames, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hostnames) != 1 {
+		t.Fatalf("expected 1 hostname, got %d", len(hostnames))
+	}
+	if hostnames[0].Name != "webapp.home.example.com" {
+		t.Errorf("expected Name=%q, got %q", "webapp.home.example.com", hostnames[0].Name)
+	}
+}
+
+func TestExtract_WithHostnameTagPrefixOverridePlainName(t *testing.T) {
+	src := New(WithDomain("home.example.com"), WithHostnameTagPrefix("dnsweaver"))
+	w := workload.Workload{
+		Platform: workload.PlatformProxmox,
+		Name:     "webserver",
+		Metadata: map[string]string{"ip": "10.1.20.5", "node": "pve-00", "vmid": "100", "tags": "dnsweaver+webapp;other:keep"},
+	}
+	hostnames, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hostnames) != 1 {
+		t.Fatalf("expected 1 hostname, got %d", len(hostnames))
+	}
+	if hostnames[0].Name != "webapp.home.example.com" {
+		t.Errorf("expected Name=%q, got %q", "webapp.home.example.com", hostnames[0].Name)
+	}
+}
+
+func TestExtract_WithHostnameTagPrefixMissingFallsBack(t *testing.T) {
+	src := New(WithDomain("home.example.com"), WithHostnameTagPrefix("dnsweaver"))
+	w := workload.Workload{
+		Platform: workload.PlatformProxmox,
+		Name:     "webserver",
+		Metadata: map[string]string{"ip": "10.1.20.5", "node": "pve-00", "vmid": "100", "tags": "other:keep;foo:bar"},
+	}
+	hostnames, err := src.Extract(context.Background(), w)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hostnames) != 1 {
+		t.Fatalf("expected 1 hostname, got %d", len(hostnames))
+	}
+	if hostnames[0].Name != "webserver.home.example.com" {
+		t.Errorf("expected Name=%q, got %q", "webserver.home.example.com", hostnames[0].Name)
+	}
+}
+
 func TestExtract_NameIsFQDN(t *testing.T) {
 	src := New() // no domain — VM name is already FQDN
 	w := workload.Workload{


### PR DESCRIPTION
## Summary

Adds hostname override support for Proxmox sources using a configurable tag prefix. When `DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX` is set, dnsweaver now looks for Proxmox tags in the form `<prefix>+<hostname>` and uses that hostname before falling back to the VM name or domain suffix. Full FQDN overrides are accepted directly, and plain hostnames are combined with `DNSWEAVER_PROXMOX_DOMAIN_SUFFIX`.

Also updates config wiring, tests, and documentation to reflect the new Proxmox hostname tag prefix behavior.

## Related issues

N/A

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Maintenance / refactor / CI

## Checklist

- [x] `gofmt` clean and `golangci-lint run Desktop.` passes
- [x] `go test Desktop.` passes
- [x] `go build Desktop.` succeeds
- [x] Docs updated (README / docs site) if behavior or config changed
- [x] CHANGELOG.md updated under the Unreleased section if user-facing