### PR TITLE
fix(incus): do not verify the server certificate

### DIFF
--- a/internal/incus/client.go
+++ b/internal/incus/client.go
@@ -124,6 +124,10 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		httpClient = &http.Client{Timeout: timeout, Transport: transport}
 		baseURL = socketBaseURL
 	} else {
+		if cfg.TLS == nil {
+			cfg.TLS = &httputil.TLSConfig{}
+		}
+		cfg.TLS.InsecureSkip = true
 		httpClient = httputil.NewClient(&httputil.ClientConfig{
 			Timeout:   timeout,
 			TLS:       cfg.TLS,


### PR DESCRIPTION
## Summary

Fixes incus source not connecting

 ```
 {"time":"2026-07-13T17:19:49.575749635Z","level":"ERROR","msg":"fatal error","error":"resolving incus client certificate: incus: registering certificate with token: Post \"https://10.90.190.1:8443/1.0/certificates\": tls: failed to verify certificate: x509: certificate is valid for 127.0.0.1, ::1, not 10.90.190.1"}
 ```
 
 golangci-lint doesn't pass here as I have a newer version of it:
 https://golangci-lint.run/docs/product/migration-guide/
 
 After the migration there are unrelated errors.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Maintenance / refactor / CI

## Checklist

- [ ] `gofmt` clean and `golangci-lint run ./...` passes
- [x] `go test ./...` passes (added/updated tests where relevant)
- [x] `go build ./...` succeeds
- [ ] Docs updated (README / docs site) if behavior or config changed
- [ ] CHANGELOG.md updated under the Unreleased section if user-facing
