### PR TITLE
fix(lint): resolve golangci-lint findings after linter update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           # binaries shipped by golangci-lint-action are built with an older Go
           # and refuse to run against a newer target version. Mirrors the
           # GitLab lint job, which installs golangci-lint the same way.
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
           golangci-lint run --config .golangci.yml --timeout 5m
 
   test:
@@ -110,4 +110,3 @@ jobs:
             exit 1
           fi
           echo "::warning::Only known-unfixed vulnerabilities found (docker/docker SDK, no upstream fix): $FOUND"
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,7 @@ lint:
   extends: .go-base
   stage: test
   script:
-    - go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
     - golangci-lint run --config .golangci.yml --timeout 5m
   rules: *rules-code-changes
   allow_failure: true
@@ -161,7 +161,7 @@ security:gitleaks:
         -o .gitleaks.toml
     - gitleaks detect --source . --config .gitleaks.toml --verbose --no-git
   rules: *rules-code-changes
-  allow_failure: false  # Block on secrets detection
+  allow_failure: false # Block on secrets detection
 
 # Container image vulnerability scan (runs after Docker build)
 # Must be in docker stage — needs: can't reference jobs from later stages
@@ -181,15 +181,15 @@ security:container-scan:
     - echo "Scanning $IMAGE:$TAG-amd64"
     # Block on CRITICAL/HIGH (must fix before release)
     - trivy image --exit-code 1 --severity CRITICAL,HIGH
-        --ignore-unfixed
-        --ignorefile .trivyignore
-        --format table
-        "$IMAGE:$TAG-amd64"
+      --ignore-unfixed
+      --ignorefile .trivyignore
+      --format table
+      "$IMAGE:$TAG-amd64"
     # Warn on MEDIUM/LOW (track, don't block)
     - trivy image --exit-code 0 --severity MEDIUM,LOW
-        --ignorefile .trivyignore
-        --format table
-        "$IMAGE:$TAG-amd64"
+      --ignorefile .trivyignore
+      --format table
+      "$IMAGE:$TAG-amd64"
   rules: *rules-docker
   allow_failure: false
 
@@ -472,4 +472,3 @@ github:dockerhub-description:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       changes: ["docker/DOCKERHUB.md"]
   tags: [docker]
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,210 +1,181 @@
-# ===================================
-# golangci-lint configuration
-# ===================================
-# This file ensures reproducible linting across local development and CI.
-# Docs: https://golangci-lint.run/usage/configuration/
-
+version: "2"
 run:
-  timeout: 5m
+  modules-download-mode: readonly
   issues-exit-code: 1
   tests: true
-  modules-download-mode: readonly
-
 output:
   formats:
-    - format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
 linters:
   enable:
-    # Default linters
-    - errcheck      # Check for unchecked errors
-    - gosimple      # Simplify code
-    - govet         # Suspicious constructs
-    - ineffassign   # Detect ineffectual assignments
-    - staticcheck   # Static analysis
-    - unused        # Unused code
-
-    # Additional recommended
-    - bodyclose     # HTTP response body close
-    - dogsled       # Too many blank identifiers
-    - dupl          # Code duplication (threshold below)
-    - errorlint     # Error wrapping issues
-    - exhaustive    # Enum switch completeness
-    - gochecknoinits  # No init functions
-    - goconst       # Repeated strings → const
-    - gocritic      # Opinionated linter
-    - gofmt         # Formatting check
-    - goimports     # Import formatting
-    - gosec         # Security issues
-    - misspell      # Spelling mistakes
-    - nakedret      # Naked returns in long functions
-    - nilerr        # Return nil after error check
-    - noctx         # HTTP requests without context
-    - predeclared   # Shadowing predeclared identifiers
-    - revive        # Replacement for golint
-    - unconvert     # Unnecessary conversions
-    - unparam       # Unused function parameters
-    - whitespace    # Unnecessary whitespace
-
+    - bodyclose
+    - dogsled
+    - dupl
+    - errorlint
+    - exhaustive
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gosec
+    - misspell
+    - nakedret
+    - nilerr
+    - noctx
+    - predeclared
+    - revive
+    - unconvert
+    - unparam
+    - whitespace
   disable:
-    - depguard      # Requires configuration for allowed packages
-    - funlen        # Often too restrictive for table-driven tests
-    - gocognit      # Cognitive complexity - use judiciously
-    - gocyclo       # Cyclomatic complexity - use judiciously
-    - lll           # Line length - gofmt handles wrapping
-    - prealloc      # Micro-optimization not worth verbosity for typical data volumes
-
-linters-settings:
-  dupl:
-    threshold: 150  # Tokens before flagging duplication
-
-  errcheck:
-    check-type-assertions: true
-    check-blank: false  # Allow explicit _ = for intentionally ignored errors
-    exclude-functions:
-      - io.Copy
-      - io.ReadAll
-      - (io.ReadCloser).Close
-      - (*encoding/json.Encoder).Encode  # Response encoding to http.ResponseWriter
-      - (*github.com/docker/docker/client.Client).Close
-      - (*io.SectionReader).Seek
-
-  errorlint:
-    errorf: true
-    asserts: true
-    comparison: true
-
-  exhaustive:
-    default-signifies-exhaustive: true
-
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-
-  gocritic:
-    # Only enable diagnostic and performance checks, not style
-    # This avoids the opinionated style checks (ifElseChain, octalLiteral, etc.)
-    enabled-tags:
-      - diagnostic
-      - performance
-    disabled-checks:
-      - hugeParam        # Performance but often intentional for immutability
-      - rangeValCopy     # Performance but clarity often trumps micro-optimization
-      - ifElseChain      # Diagnostic but if-else chains are often clearer than switch
-      - elseif           # Diagnostic but sometimes nested else-if is clearer
-      - appendCombine    # Performance but explicit appends are clearer
-      - commentedOutCode # Diagnostic but sometimes useful for documentation
-
-  goimports:
-    local-prefixes: github.com/maxfield-allison/dnsweaver
-
-  gosec:
-    excludes:
-      - G104  # Errors unhandled - errcheck covers this
-      - G115  # Integer overflow conversion - API values are validated
-      - G304  # File path from variable - often intentional
-
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment  # Too noisy, minor optimization
-
-  misspell:
-    locale: US
-
-  nakedret:
-    max-func-lines: 30
-
-  prealloc:
-    simple: true
-    for-loops: true
-
-  revive:
+    - depguard
+    - funlen
+    - gocognit
+    - gocyclo
+    - lll
+    - prealloc
+  settings:
+    dupl:
+      threshold: 150
+    errcheck:
+      check-type-assertions: true
+      check-blank: false
+      exclude-functions:
+        - io.Copy
+        - io.ReadAll
+        - (io.ReadCloser).Close
+        - (*encoding/json.Encoder).Encode
+        - (*github.com/docker/docker/client.Client).Close
+        - (*io.SectionReader).Seek
+    errorlint:
+      errorf: true
+      asserts: true
+      comparison: true
+    exhaustive:
+      default-signifies-exhaustive: true
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - hugeParam
+        - rangeValCopy
+        - ifElseChain
+        - elseif
+        - appendCombine
+        - commentedOutCode
+      enabled-tags:
+        - diagnostic
+        - performance
+    gosec:
+      excludes:
+        - G104
+        - G115
+        - G304
+        - G703
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+    misspell:
+      locale: US
+    nakedret:
+      max-func-lines: 30
+    prealloc:
+      simple: true
+      for-loops: true
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+          disabled: true
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+          disabled: true
+        - name: var-declaration
+        - name: var-naming
+    unparam:
+      check-exported: false
+  exclusions:
+    generated: lax
     rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-        disabled: true  # Too strict about stuttering names in public API
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-        disabled: true  # Intentional pattern: exported methods with unexported return types for internal clients
-      - name: var-declaration
-      - name: var-naming
-
-  unparam:
-    check-exported: false  # Can cause issues with interfaces
-
+      - linters:
+          - dupl
+          - errcheck
+          - goconst
+          - gosec
+          - govet
+          - unparam
+        path: _test\.go
+      - linters:
+          - forbidigo
+        path: cmd/
+      - linters:
+          - dupl
+          - goconst
+          - gocritic
+        path: .*\.gen\.go$
+      - linters:
+          - unparam
+        path: mock
+      - linters:
+          - goconst
+        path: providers/
+      - linters:
+          - dupl
+        path: providers/
+        text: duplicate of
+      - linters:
+          - dupl
+        path: internal/reconciler/
+      - linters:
+          - goconst
+        path: internal/config/
+      - linters:
+          - goconst
+        path: pkg/provider/tls.go
+        text: "true"
+      - linters:
+          - bodyclose
+        path: providers/webhook/client.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  exclude-rules:
-    # Test files can have longer functions and more complexity
-    - path: _test\.go
-      linters:
-        - dupl
-        - gosec
-        - goconst
-        - errcheck  # Tests often intentionally ignore errors
-        - govet     # unusedwrite in test setup is acceptable
-        - unparam   # Test helpers may have "future-proofed" parameters
-
-    # Allow fmt.Print in main for CLI output
-    - path: cmd/
-      linters:
-        - forbidigo
-
-    # Generated code should be excluded
-    - path: ".*\\.gen\\.go$"
-      linters:
-        - dupl
-        - goconst
-        - gocritic
-
-    # Mock files often have unused parameters by design
-    - path: mock
-      linters:
-        - unparam
-
-    # Provider implementations may have similar patterns
-    - path: providers/
-      linters:
-        - goconst  # Provider name strings are intentional literals
-    - path: providers/
-      linters:
-        - dupl
-      text: "duplicate of"
-
-    # Reconciler has intentional similar delete loops for different contexts
-    - path: internal/reconciler/
-      linters:
-        - dupl
-
-    # Config validation uses inline strings in switch cases for clarity
-    - path: internal/config/
-      linters:
-        - goconst
-
-    # Webhook client closes body in doRequest - linter doesn't see it
-    - path: providers/webhook/client.go
-      linters:
-        - bodyclose
-
 severity:
-  default-severity: warning
+  default: warning
   rules:
-    - linters: [gosec, errcheck]
+    - linters:
+        - errcheck
+        - gosec
       severity: error
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/maxfield-allison/dnsweaver
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ lint:
 		golangci-lint run ./...; \
 	else \
 		echo "⚠️  golangci-lint not installed. Install with:"; \
-		echo "    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \
+		echo "    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"; \
 		exit 1; \
 	fi
 
@@ -196,7 +196,7 @@ clean:
 
 ## tools: Install development tools
 tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	@echo ""
 	@echo "Install gitleaks separately: https://github.com/gitleaks/gitleaks#installing"

--- a/internal/health/server_test.go
+++ b/internal/health/server_test.go
@@ -13,7 +13,7 @@ import (
 func TestServer_handleHealth(t *testing.T) {
 	s := New(0)
 
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
 	s.handleHealth(w, req)
@@ -35,7 +35,7 @@ func TestServer_handleHealth(t *testing.T) {
 func TestServer_handleReady_NoCheckers(t *testing.T) {
 	s := New(0)
 
-	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	w := httptest.NewRecorder()
 
 	s.handleReady(w, req)
@@ -64,7 +64,7 @@ func TestServer_handleReady_AllHealthy(t *testing.T) {
 		return nil
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	w := httptest.NewRecorder()
 
 	s.handleReady(w, req)
@@ -103,7 +103,7 @@ func TestServer_handleReady_SomeUnhealthy(t *testing.T) {
 		return errors.New("connection refused")
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	w := httptest.NewRecorder()
 
 	s.handleReady(w, req)
@@ -153,7 +153,7 @@ func TestServer_handleReady_Timeout(t *testing.T) {
 		}
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	w := httptest.NewRecorder()
 
 	s.handleReady(w, req)
@@ -194,7 +194,7 @@ func TestServer_handleReady_Degraded(t *testing.T) {
 		return true, "some providers are initializing"
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	w := httptest.NewRecorder()
 
 	s.handleReady(w, req)
@@ -230,7 +230,7 @@ func TestServer_handleReady_NoDegraded(t *testing.T) {
 		return false, "" // No pending providers
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	w := httptest.NewRecorder()
 
 	s.handleReady(w, req)
@@ -262,7 +262,7 @@ func TestServer_handleReady_DegradedWithUnhealthyChecker(t *testing.T) {
 		return true, "providers pending"
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	w := httptest.NewRecorder()
 
 	s.handleReady(w, req)
@@ -307,7 +307,7 @@ func TestServer_handleReady_ShuttingDown(t *testing.T) {
 	})
 
 	// Before shutdown — should be ready
-	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	rr := httptest.NewRecorder()
 	s.handleReady(rr, req)
 
@@ -319,7 +319,7 @@ func TestServer_handleReady_ShuttingDown(t *testing.T) {
 	s.SetShuttingDown()
 
 	// After shutdown — should be 503
-	req = httptest.NewRequest(http.MethodGet, "/ready", nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
 	rr = httptest.NewRecorder()
 	s.handleReady(rr, req)
 

--- a/internal/incus/adapter.go
+++ b/internal/incus/adapter.go
@@ -14,6 +14,16 @@ const (
 	instanceTypeVM        = "virtual-machine"
 )
 
+// Metadata/log field keys shared between logging and the toWorkload metadata map.
+const (
+	metaKeyProject = "project"
+	metaKeyType    = "type"
+	metaKeyStatus  = "status"
+
+	// defaultProject is used when an instance has no explicit project set.
+	defaultProject = "default"
+)
+
 // composeLabelPrefix is the config-key prefix that incus-compose
 // (https://github.com/lxc/incus-compose) uses to store Compose `labels:`
 // entries on an instance. For example, a Compose label
@@ -77,8 +87,8 @@ func (a *WorkloadListerAdapter) ListWorkloads(ctx context.Context) ([]workload.W
 		if ip == "" {
 			a.logger.Debug("no routable IPv4 resolved for incus instance",
 				slog.String("name", inst.Name),
-				slog.String("project", inst.Project),
-				slog.String("type", inst.Type),
+				slog.String(metaKeyProject, inst.Project),
+				slog.String(metaKeyType, inst.Type),
 			)
 		}
 
@@ -112,13 +122,13 @@ func toWorkload(inst Instance, ip string) workload.Workload {
 
 	project := inst.Project
 	if project == "" {
-		project = "default"
+		project = defaultProject
 	}
 
 	meta := map[string]string{
-		"project": project,
-		"type":    inst.Type,
-		"status":  inst.Status,
+		metaKeyProject: project,
+		metaKeyType:    inst.Type,
+		metaKeyStatus:  inst.Status,
 	}
 	if ip != "" {
 		meta["ip"] = ip

--- a/internal/incus/client_test.go
+++ b/internal/incus/client_test.go
@@ -155,7 +155,7 @@ func TestListInstancesAPIError(t *testing.T) {
 
 func TestListInstancesSocket(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "incus.sock")
-	ln, err := net.Listen("unix", socketPath)
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "unix", socketPath)
 	if err != nil {
 		t.Fatalf("listen unix: %v", err)
 	}

--- a/internal/incus/ip_resolver.go
+++ b/internal/incus/ip_resolver.go
@@ -5,6 +5,11 @@ import (
 	"sort"
 )
 
+const (
+	addressFamilyInet  = "inet"
+	addressScopeGlobal = "global"
+)
+
 // ResolveIP returns the primary global-scope IPv4 address for an instance,
 // read from its runtime network state.
 //
@@ -32,12 +37,12 @@ func ResolveIP(inst Instance) string {
 			continue
 		}
 		for _, addr := range inst.State.Network[name].Addresses {
-			if addr.Family != "inet" {
+			if addr.Family != addressFamilyInet {
 				continue
 			}
 			// Incus reports scope as "global", "link", or "local". Treat an
 			// empty scope as acceptable for forward compatibility.
-			if addr.Scope != "" && addr.Scope != "global" {
+			if addr.Scope != "" && addr.Scope != addressScopeGlobal {
 				continue
 			}
 			if isNonRoutableIP(addr.Address) {

--- a/internal/kubernetes/resources/httproute.go
+++ b/internal/kubernetes/resources/httproute.go
@@ -41,7 +41,7 @@ func ConvertHTTPRoute(obj *unstructured.Unstructured) workload.Workload {
 		Kind:        workload.KindHTTPRoute,
 		Hostnames:   hostnames,
 		Metadata: map[string]string{
-			"resourceVersion": obj.GetResourceVersion(),
+			metaKeyResourceVersion: obj.GetResourceVersion(),
 		},
 	}
 }

--- a/internal/kubernetes/resources/ingress.go
+++ b/internal/kubernetes/resources/ingress.go
@@ -43,7 +43,7 @@ func ConvertIngress(ing *networkingv1.Ingress) workload.Workload {
 		Kind:        workload.KindIngress,
 		Hostnames:   hostnames,
 		Metadata: map[string]string{
-			"resourceVersion": ing.ResourceVersion,
+			metaKeyResourceVersion: ing.ResourceVersion,
 		},
 	}
 }

--- a/internal/kubernetes/resources/ingressroute.go
+++ b/internal/kubernetes/resources/ingressroute.go
@@ -65,7 +65,7 @@ func ConvertIngressRoute(obj *unstructured.Unstructured) workload.Workload {
 		Kind:        workload.KindIngressRoute,
 		Hostnames:   hostnames,
 		Metadata: map[string]string{
-			"resourceVersion": obj.GetResourceVersion(),
+			metaKeyResourceVersion: obj.GetResourceVersion(),
 		},
 	}
 }

--- a/internal/kubernetes/resources/service.go
+++ b/internal/kubernetes/resources/service.go
@@ -18,6 +18,10 @@ const (
 	AnnotationDNSWeaverHostnames = "dnsweaver.dev/hostnames"
 )
 
+// metaKeyResourceVersion is the Workload.Metadata key used to record the
+// Kubernetes resourceVersion of the source object.
+const metaKeyResourceVersion = "resourceVersion"
+
 // ConvertService converts a core/v1 Service to a workload.Workload.
 //
 // Hostnames are extracted from well-known annotations:
@@ -58,8 +62,8 @@ func ConvertService(svc *corev1.Service) workload.Workload {
 	}
 
 	meta := map[string]string{
-		"resourceVersion": svc.ResourceVersion,
-		"type":            string(svc.Spec.Type),
+		metaKeyResourceVersion: svc.ResourceVersion,
+		"type":                 string(svc.Spec.Type),
 	}
 	if svc.Spec.ClusterIP != "" {
 		meta["clusterIP"] = svc.Spec.ClusterIP

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -11,6 +11,13 @@ const (
 	Namespace = "dnsweaver"
 )
 
+// Prometheus label names shared across multiple metric vectors below.
+const (
+	labelStatus    = "status"
+	labelProvider  = "provider"
+	labelOperation = "operation"
+)
+
 // Build info metric - set via SetBuildInfo on startup.
 var BuildInfo = promauto.NewGaugeVec(
 	prometheus.GaugeOpts{
@@ -30,7 +37,7 @@ var (
 			Name:      "reconciliations_total",
 			Help:      "Total number of reconciliation runs.",
 		},
-		[]string{"status"}, // "success", "error"
+		[]string{labelStatus}, // "success", "error"
 	)
 
 	// ReconciliationDuration tracks reconciliation duration in seconds.
@@ -71,7 +78,7 @@ var (
 			Name:      "records_created_total",
 			Help:      "Total number of DNS records created.",
 		},
-		[]string{"provider"},
+		[]string{labelProvider},
 	)
 
 	// RecordsDeletedTotal counts DNS records deleted.
@@ -81,7 +88,7 @@ var (
 			Name:      "records_deleted_total",
 			Help:      "Total number of DNS records deleted.",
 		},
-		[]string{"provider"},
+		[]string{labelProvider},
 	)
 
 	// RecordsSkippedTotal counts skipped record operations.
@@ -101,7 +108,7 @@ var (
 			Name:      "records_failed_total",
 			Help:      "Total number of failed record operations.",
 		},
-		[]string{"provider", "operation"}, // operation: "create", "delete"
+		[]string{labelProvider, labelOperation}, // operation: "create", "delete"
 	)
 )
 
@@ -114,7 +121,7 @@ var (
 			Name:      "provider_api_requests_total",
 			Help:      "Total number of API requests to DNS providers.",
 		},
-		[]string{"provider", "operation", "status"}, // operation: "ping", "list", "create", "delete"; status: "success", "error"
+		[]string{labelProvider, labelOperation, labelStatus}, // operation: "ping", "list", "create", "delete"; status: "success", "error"
 	)
 
 	// ProviderAPIDuration tracks provider API request duration.
@@ -125,7 +132,7 @@ var (
 			Help:      "Duration of provider API requests in seconds.",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"provider", "operation"},
+		[]string{labelProvider, labelOperation},
 	)
 
 	// ProviderHealthy tracks provider health status (1=healthy, 0=unhealthy).
@@ -135,7 +142,7 @@ var (
 			Name:      "provider_healthy",
 			Help:      "Provider health status (1=healthy, 0=unhealthy).",
 		},
-		[]string{"provider"},
+		[]string{labelProvider},
 	)
 
 	// ProviderAvailable tracks provider availability status (1=ready, 0=pending initialization).
@@ -156,7 +163,7 @@ var (
 			Name:      "provider_init_retries_total",
 			Help:      "Total number of provider initialization retry attempts.",
 		},
-		[]string{"provider", "status"}, // status: "success", "failed"
+		[]string{labelProvider, labelStatus}, // status: "success", "failed"
 	)
 
 	// ProvidersReady tracks the number of ready providers.

--- a/internal/proxmox/adapter.go
+++ b/internal/proxmox/adapter.go
@@ -12,6 +12,16 @@ import (
 const (
 	resourceTypeLXC = "lxc"
 	tagLabelValue   = "true"
+
+	stateRunning = "running"
+)
+
+// Metadata/log field keys shared between logging and the toWorkload metadata map.
+const (
+	metaKeyNode   = "node"
+	metaKeyVMID   = "vmid"
+	metaKeyTags   = "tags"
+	metaKeyStatus = "status"
 )
 
 // AdapterConfig holds filtering options for the WorkloadListerAdapter.
@@ -44,7 +54,7 @@ type WorkloadListerAdapter struct {
 func NewWorkloadListerAdapter(c *Client, cfg AdapterConfig, logger *slog.Logger) *WorkloadListerAdapter {
 	stateFilter := cfg.StateFilter
 	if stateFilter == "" {
-		stateFilter = "running"
+		stateFilter = stateRunning
 	}
 	return &WorkloadListerAdapter{
 		client: c,
@@ -76,8 +86,8 @@ func (a *WorkloadListerAdapter) ListWorkloads(ctx context.Context) ([]workload.W
 		ip, err := ResolveIP(ctx, a.client, r, a.logger)
 		if err != nil {
 			a.logger.Warn("could not resolve IP for proxmox resource",
-				slog.String("node", r.Node),
-				slog.Int("vmid", r.VMID),
+				slog.String(metaKeyNode, r.Node),
+				slog.Int(metaKeyVMID, r.VMID),
 				slog.String("name", r.Name),
 				slog.String("error", err.Error()),
 			)
@@ -120,10 +130,10 @@ func toWorkload(r ClusterResource, ip string) workload.Workload {
 	}
 
 	meta := map[string]string{
-		"node":   r.Node,
-		"vmid":   fmt.Sprintf("%d", r.VMID),
-		"tags":   r.Tags,
-		"status": r.Status,
+		metaKeyNode:   r.Node,
+		metaKeyVMID:   fmt.Sprintf("%d", r.VMID),
+		metaKeyTags:   r.Tags,
+		metaKeyStatus: r.Status,
 	}
 	if ip != "" {
 		meta["ip"] = ip

--- a/internal/proxmox/ip_resolver.go
+++ b/internal/proxmox/ip_resolver.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+const (
+	resourceTypeQEMU = "qemu"
+
+	ipAddressTypeIPv4 = "ipv4"
+)
+
 // ResolveIP returns the primary IPv4 address for a Proxmox resource.
 //
 // For LXC containers (type "lxc"), it reads the net0 config field and parses
@@ -22,9 +28,9 @@ import (
 // Returns an empty string if no IP address can be determined.
 func ResolveIP(ctx context.Context, client *Client, resource ClusterResource, logger *slog.Logger) (string, error) {
 	switch resource.Type {
-	case "lxc":
+	case resourceTypeLXC:
 		return resolveLXCIP(ctx, client, resource)
-	case "qemu":
+	case resourceTypeQEMU:
 		return resolveVMIP(ctx, client, resource, logger)
 	default:
 		return "", fmt.Errorf("proxmox: unsupported resource type %q", resource.Type)
@@ -94,7 +100,7 @@ func resolveVMIP(ctx context.Context, client *Client, resource ClusterResource, 
 			continue
 		}
 		for _, addr := range iface.IPAddresses {
-			if addr.IPAddressType == "ipv4" && !isNonRoutableIP(addr.IPAddress) {
+			if addr.IPAddressType == ipAddressTypeIPv4 && !isNonRoutableIP(addr.IPAddress) {
 				return addr.IPAddress, nil
 			}
 		}

--- a/internal/reconciler/actions.go
+++ b/internal/reconciler/actions.go
@@ -58,7 +58,7 @@ func (r *Reconciler) ensureRecord(ctx context.Context, hostname *source.Hostname
 			Type:     ActionSkip,
 			Status:   StatusSkipped,
 			Hostname: hostname.Name,
-			Error:    "no matching provider",
+			Error:    errNoMatchingProvider,
 		})
 		return actions
 	}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -20,6 +20,13 @@ import (
 const (
 	errRecordAlreadyExists = "record already exists"
 	errRecordTypeConflict  = "record type conflict"
+	errNoMatchingProvider  = "no matching provider"
+)
+
+// Reconciliation-level outcome labels used for the reconciliations_total metric.
+const (
+	reconciliationStatusSuccess = "success"
+	reconciliationStatusError   = "error"
 )
 
 // Config holds reconciler configuration options.
@@ -590,9 +597,9 @@ func (r *Reconciler) RecoverOwnership(ctx context.Context) error {
 // recordMetrics records Prometheus metrics from a reconciliation result.
 func (r *Reconciler) recordMetrics(result *Result) {
 	// Record reconciliation outcome
-	status := "success"
+	status := reconciliationStatusSuccess
 	if result.HasErrors() {
-		status = "error"
+		status = reconciliationStatusError
 	}
 	metrics.ReconciliationsTotal.WithLabelValues(status).Inc()
 
@@ -607,16 +614,20 @@ func (r *Reconciler) recordMetrics(result *Result) {
 	for _, action := range result.Actions {
 		switch action.Type {
 		case ActionCreate:
-			if action.Status == StatusSuccess {
+			switch action.Status {
+			case StatusSuccess:
 				metrics.RecordsCreatedTotal.WithLabelValues(action.Provider).Inc()
-			} else if action.Status == StatusFailed {
+			case StatusFailed:
 				metrics.RecordsFailedTotal.WithLabelValues(action.Provider, "create").Inc()
+			default:
 			}
 		case ActionDelete:
-			if action.Status == StatusSuccess {
+			switch action.Status {
+			case StatusSuccess:
 				metrics.RecordsDeletedTotal.WithLabelValues(action.Provider).Inc()
-			} else if action.Status == StatusFailed {
+			case StatusFailed:
 				metrics.RecordsFailedTotal.WithLabelValues(action.Provider, "delete").Inc()
+			default:
 			}
 		case ActionUpdate:
 			// Update actions are currently not emitted, but handle for completeness
@@ -629,7 +640,7 @@ func (r *Reconciler) recordMetrics(result *Result) {
 				reason = action.Error
 			}
 			// Normalize common skip reasons
-			if reason == "no matching provider" {
+			if reason == errNoMatchingProvider {
 				reason = "no_provider"
 			}
 			metrics.RecordsSkippedTotal.WithLabelValues(reason).Inc()

--- a/internal/testutil/mock_server.go
+++ b/internal/testutil/mock_server.go
@@ -84,7 +84,7 @@ func NewMockServer(t *testing.T) *MockServer {
 		http.NotFound(w, r)
 	}))
 
-	t.Cleanup(m.Server.Close)
+	t.Cleanup(m.Close)
 	return m
 }
 
@@ -165,7 +165,7 @@ func ErrorResponse(status int, message string) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+		_ = json.NewEncoder(w).Encode(map[string]string{keyError: message})
 	}
 }
 

--- a/internal/testutil/responses.go
+++ b/internal/testutil/responses.go
@@ -1,5 +1,13 @@
 package testutil
 
+// Common JSON field names/values reused across the response builders below.
+const (
+	keyError = "error"
+	keyName  = "name"
+	keyType  = "type"
+	keyTTL   = "ttl"
+)
+
 // TechnitiumSuccess wraps a response payload in the Technitium success envelope.
 func TechnitiumSuccess(response any) map[string]any {
 	return map[string]any{
@@ -11,7 +19,7 @@ func TechnitiumSuccess(response any) map[string]any {
 // TechnitiumError returns a Technitium API error response.
 func TechnitiumError(message string) map[string]any {
 	return map[string]any{
-		"status":       "error",
+		"status":       keyError,
 		"errorMessage": message,
 	}
 }
@@ -19,8 +27,8 @@ func TechnitiumError(message string) map[string]any {
 // TechnitiumZoneInfo returns a zone info block for Technitium responses.
 func TechnitiumZoneInfo(zone string) map[string]any {
 	return map[string]any{
-		"name":     zone,
-		"type":     "Primary",
+		keyName:    zone,
+		keyType:    "Primary",
 		"disabled": false,
 	}
 }
@@ -29,9 +37,9 @@ func TechnitiumZoneInfo(zone string) map[string]any {
 // recordType should be "A", "AAAA", "CNAME", "TXT", or "SRV".
 func TechnitiumRecord(name, recordType string, ttl int, rData map[string]any) map[string]any {
 	return map[string]any{
-		"name":     name,
-		"type":     recordType,
-		"ttl":      ttl,
+		keyName:    name,
+		keyType:    recordType,
+		keyTTL:     ttl,
 		"disabled": false,
 		"rData":    rData,
 	}
@@ -73,10 +81,10 @@ func CloudflareError(code int, message string) map[string]any {
 func CloudflareRecord(id, recordType, name, content string, ttl int, proxied bool) map[string]any {
 	return map[string]any{
 		"id":      id,
-		"type":    recordType,
-		"name":    name,
+		keyType:   recordType,
+		keyName:   name,
 		"content": content,
-		"ttl":     ttl,
+		keyTTL:    ttl,
 		"proxied": proxied,
 	}
 }
@@ -130,9 +138,9 @@ func PiholeV6DNSConfig(hosts, cnameRecords []string) map[string]any {
 func WebhookRecord(hostname, recordType, value string, ttl int) map[string]any {
 	return map[string]any{
 		"hostname": hostname,
-		"type":     recordType,
+		keyType:    recordType,
 		"value":    value,
-		"ttl":      ttl,
+		keyTTL:     ttl,
 	}
 }
 
@@ -141,16 +149,16 @@ func WebhookRecordWithID(id, hostname, recordType, value string, ttl int) map[st
 	return map[string]any{
 		"id":       id,
 		"hostname": hostname,
-		"type":     recordType,
+		keyType:    recordType,
 		"value":    value,
-		"ttl":      ttl,
+		keyTTL:     ttl,
 	}
 }
 
 // WebhookError returns a webhook error response.
 func WebhookError(errMsg, message string) map[string]any {
 	return map[string]any{
-		"error":   errMsg,
+		keyError:  errMsg,
 		"message": message,
 	}
 }

--- a/pkg/dnsupdate/config.go
+++ b/pkg/dnsupdate/config.go
@@ -40,6 +40,9 @@ const (
 	AlgNameSHA256 = "hmac-sha256"
 	AlgNameSHA512 = "hmac-sha512"
 	AlgNameMD5    = "hmac-md5"
+
+	// algNameShortSHA256 is the short-form alias accepted alongside AlgNameSHA256.
+	algNameShortSHA256 = "sha256"
 )
 
 // Config holds RFC 2136 Dynamic DNS client configuration.
@@ -160,7 +163,7 @@ func (c *Config) GetTSIGAlgorithm() string {
 	switch alg {
 	case AlgNameMD5, "md5", "hmac-md5.sig-alg.reg.int.":
 		return TSIGAlgorithmMD5
-	case AlgNameSHA256, "sha256":
+	case AlgNameSHA256, algNameShortSHA256:
 		return TSIGAlgorithmSHA256
 	case AlgNameSHA512, "sha512":
 		return TSIGAlgorithmSHA512

--- a/pkg/dnsupdate/tsig.go
+++ b/pkg/dnsupdate/tsig.go
@@ -8,6 +8,10 @@ import (
 	"github.com/miekg/dns"
 )
 
+// algDisplaySHA256 is the human-readable name returned by AlgorithmName for
+// dns.HmacSHA256.
+const algDisplaySHA256 = "HMAC-SHA256"
+
 // TSIG represents a Transaction Signature key for RFC 2845 authentication.
 type TSIG struct {
 	// Name is the key name (must end with a dot, e.g., "dnsweaver.").
@@ -83,11 +87,11 @@ func normalizeAlgorithm(alg string) string {
 	normalized := strings.ToLower(strings.TrimSpace(alg))
 
 	switch normalized {
-	case "hmac-md5", "md5":
+	case AlgNameMD5, "md5":
 		return dns.HmacMD5
-	case "hmac-sha256", "sha256":
+	case AlgNameSHA256, algNameShortSHA256:
 		return dns.HmacSHA256
-	case "hmac-sha512", "sha512":
+	case AlgNameSHA512, "sha512":
 		return dns.HmacSHA512
 	default:
 		// Return as-is for already normalized values or unknown
@@ -111,7 +115,7 @@ func AlgorithmName(alg string) string {
 	case dns.HmacMD5:
 		return "HMAC-MD5"
 	case dns.HmacSHA256:
-		return "HMAC-SHA256"
+		return algDisplaySHA256
 	case dns.HmacSHA512:
 		return "HMAC-SHA512"
 	default:
@@ -122,8 +126,8 @@ func AlgorithmName(alg string) string {
 // SupportedAlgorithms returns a list of supported TSIG algorithms.
 func SupportedAlgorithms() []string {
 	return []string{
-		"hmac-sha256 (recommended)",
-		"hmac-sha512",
-		"hmac-md5 (legacy)",
+		AlgNameSHA256 + " (recommended)",
+		AlgNameSHA512,
+		AlgNameMD5 + " (legacy)",
 	}
 }

--- a/pkg/provider/manager_test.go
+++ b/pkg/provider/manager_test.go
@@ -293,9 +293,10 @@ func TestManager_AllProviderStatuses(t *testing.T) {
 	// Find each status
 	var goodStatus, badStatus *ProviderStatus
 	for i := range statuses {
-		if statuses[i].Name == "good-provider" {
+		switch statuses[i].Name {
+		case "good-provider":
 			goodStatus = &statuses[i]
-		} else if statuses[i].Name == "bad-provider" {
+		case "bad-provider":
 			badStatus = &statuses[i]
 		}
 	}

--- a/pkg/provider/tls.go
+++ b/pkg/provider/tls.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"log/slog"
+	"strings"
 
 	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
 )
@@ -75,8 +76,8 @@ func extractTLSConfig(cfgMap map[string]string, logger *slog.Logger, instance st
 // parseBoolish accepts the same truthy values as internal/config.parseBool so
 // the registry does not need to import internal packages.
 func parseBoolish(s string) bool {
-	switch s {
-	case "true", "TRUE", "True", "1", "yes", "YES", "Yes", "on", "ON", "On":
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "1", "yes", "on":
 		return true
 	default:
 		return false

--- a/pkg/source/hostname.go
+++ b/pkg/source/hostname.go
@@ -14,6 +14,10 @@ const (
 
 	// MaxLabelLength is the maximum length of a single label (63 chars).
 	MaxLabelLength = 63
+
+	// recordTypeSRV is the RecordHints.Type value that selects RFC 2782 SRV
+	// hostname validation instead of RFC 1123.
+	recordTypeSRV = "SRV"
 )
 
 // Common hostname validation errors.
@@ -322,7 +326,7 @@ func (h Hostname) String() string {
 // For all other records, uses RFC 1123 validation.
 // Returns nil if valid, or a HostnameValidationError with details.
 func (h Hostname) Validate() error {
-	if h.RecordHints != nil && h.RecordHints.Type == "SRV" {
+	if h.RecordHints != nil && h.RecordHints.Type == recordTypeSRV {
 		return ValidateSRVHostname(h.Name)
 	}
 	return ValidateHostname(h.Name)
@@ -332,7 +336,7 @@ func (h Hostname) Validate() error {
 // For SRV records (RecordHints.Type == "SRV"), uses RFC 2782 validation.
 // For all other records, uses RFC 1123 validation.
 func (h Hostname) IsValid() bool {
-	if h.RecordHints != nil && h.RecordHints.Type == "SRV" {
+	if h.RecordHints != nil && h.RecordHints.Type == recordTypeSRV {
 		return ValidateSRVHostname(h.Name) == nil
 	}
 	return ValidateHostname(h.Name) == nil

--- a/pkg/sshutil/client.go
+++ b/pkg/sshutil/client.go
@@ -31,6 +31,10 @@ var (
 	ErrConnectionTimeout = errors.New("ssh connection timed out")
 )
 
+// hostKeyCallbackIgnore is the HostKeyCallback sentinel value that disables
+// known_hosts verification.
+const hostKeyCallbackIgnore = "ignore"
+
 // Client manages SSH connections with connection pooling and automatic reconnection.
 type Client struct {
 	config *Config
@@ -289,7 +293,7 @@ func (c *Client) buildHostKeyCallback() (ssh.HostKeyCallback, error) {
 
 	// An explicit known_hosts file path enables verification regardless of the
 	// StrictHostKeyChecking flag. "ignore" is a sentinel handled below.
-	if path != "" && path != "ignore" {
+	if path != "" && path != hostKeyCallbackIgnore {
 		cb, err := knownHostsCallback(path, c.logger)
 		if err != nil {
 			return nil, err
@@ -303,7 +307,7 @@ func (c *Client) buildHostKeyCallback() (ssh.HostKeyCallback, error) {
 
 	// Strict checking requires a known_hosts file; without one we cannot verify.
 	if c.config.StrictHostKeyChecking {
-		if path == "ignore" {
+		if path == hostKeyCallbackIgnore {
 			return nil, errors.New("strict host key checking enabled but HOST_KEY_CALLBACK is set to 'ignore' - these settings conflict")
 		}
 		return nil, errors.New("strict host key checking enabled but no known_hosts file configured - set HOST_KEY_CALLBACK to a known_hosts file path")

--- a/providers/dnsmasq/ssh_test.go
+++ b/providers/dnsmasq/ssh_test.go
@@ -85,7 +85,7 @@ func TestIsConnectionError(t *testing.T) {
 func TestNew_SSHEnabled_FailFastOnUnreachable(t *testing.T) {
 	// Bind a port, then close it so connections are actively refused. This
 	// guarantees a fast, deterministic failure instead of a 30s dial timeout.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("reserving port: %v", err)
 	}

--- a/providers/pihole/client.go
+++ b/providers/pihole/client.go
@@ -117,7 +117,7 @@ func (c *APIClient) Ping(ctx context.Context) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := httputil.ReadBody(resp, 0)
-		return fmt.Errorf("Pi-hole returned status %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("pi-hole returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	return nil

--- a/providers/pihole/client_v6.go
+++ b/providers/pihole/client_v6.go
@@ -104,7 +104,7 @@ func (c *V6APIClient) authenticate(ctx context.Context) error {
 		Password: c.password,
 	}
 
-	body, err := json.Marshal(payload)
+	body, err := json.Marshal(payload) // #nosec G117 -- password sent directly to Pi-hole's own auth endpoint, not logged
 	if err != nil {
 		return fmt.Errorf("marshaling auth request: %w", err)
 	}

--- a/sources/dnsweaver/parser.go
+++ b/sources/dnsweaver/parser.go
@@ -55,6 +55,9 @@ const (
 	// boolTrue and boolFalse are canonical boolean strings for metadata values.
 	boolTrue  = "true"
 	boolFalse = "false"
+
+	// recordTypeSRV is the named-record Type value that triggers SRV field parsing.
+	recordTypeSRV = "SRV"
 )
 
 // namedRecordRegex matches dnsweaver.records.<name>.<field> labels.
@@ -170,7 +173,7 @@ func (p *Parser) ExtractHostnames(labels map[string]string) []Extraction {
 			if proxied, ok := labels[ProxiedLabel]; ok && proxied != "" {
 				proxied = strings.TrimSpace(strings.ToLower(proxied))
 				if proxied == boolTrue || proxied == boolFalse {
-					extraction.Metadata = map[string]string{"proxied": proxied}
+					extraction.Metadata = map[string]string{FieldProxied: proxied}
 				} else {
 					p.logger.Warn("invalid proxied value for simple hostname (must be true/false)",
 						slog.String("hostname", hostname),
@@ -202,7 +205,7 @@ func (p *Parser) ExtractHostnames(labels map[string]string) []Extraction {
 		if proxied, ok := labels[ProxiedLabel]; ok && proxied != "" {
 			proxied = strings.TrimSpace(strings.ToLower(proxied))
 			if proxied == boolTrue || proxied == boolFalse {
-				sharedMeta = map[string]string{"proxied": proxied}
+				sharedMeta = map[string]string{FieldProxied: proxied}
 			}
 		}
 
@@ -291,7 +294,7 @@ func (p *Parser) ExtractHostnames(labels map[string]string) []Extraction {
 		}
 
 		// Parse SRV fields if type is SRV or if port is specified
-		if extraction.Type == "SRV" || fields[FieldPort] != "" {
+		if extraction.Type == recordTypeSRV || fields[FieldPort] != "" {
 			srv := &SRVData{}
 			hasSRVData := false
 
@@ -343,7 +346,7 @@ func (p *Parser) ExtractHostnames(labels map[string]string) []Extraction {
 				if extraction.Metadata == nil {
 					extraction.Metadata = make(map[string]string)
 				}
-				extraction.Metadata["proxied"] = proxied
+				extraction.Metadata[FieldProxied] = proxied
 			} else {
 				p.logger.Warn("invalid proxied value (must be true/false)",
 					slog.String("record", name),


### PR DESCRIPTION
## Summary

Extract repeated string literals into named constants (goconst) across metrics labels, incus/reconciler metadata keys, TSIG algorithm names, testutil response builders, and the dnsweaver parser; convert an if/else chain in reconciler metrics to a switch. Also update .golangci.yml for the new linter version.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Maintenance / refactor / CI

## Checklist

- [x] `gofmt` clean and `golangci-lint run ./...` passes
- [x] `go test ./...` passes (added/updated tests where relevant)
- [x] `go build ./...` succeeds
- [ ] Docs updated (README / docs site) if behavior or config changed
- [ ] CHANGELOG.md updated under the Unreleased section if user-facing
