### PR TITLE
fix(incus): pin server certificate for token enrollment and stateless setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Incus server certificate pinning** (`DNSWEAVER_INCUS_TLS_PIN_SHA256`). Pin
+  the Incus server's leaf certificate to a SHA-256 fingerprint to verify a
+  self-signed server without a CA file and without disabling verification. This
+  fixes remote HTTPS connections against Incus's default certificate, which
+  carries only loopback SANs (`127.0.0.1`, `::1`) and so fails hostname
+  verification against a LAN address. Trust-token enrollment now sets this pin
+  automatically from the fingerprint embedded in the token (persisted as
+  `server.fingerprint` in the cert store) so token onboarding over a remote
+  address works out of the box. The pin is also usable standalone with a
+  pre-provisioned certificate for a fully stateless setup. Thanks to
+  [@jochumdev](https://github.com/jochumdev) for the report and repro.
+  ([GitHub #146](https://github.com/maxfield-allison/dnsweaver/pull/146))
 - **Incus trust-token authentication.** dnsweaver can enroll its own client
   certificate against the Incus API using a one-time trust token instead of a
   pre-provisioned certificate. Set `DNSWEAVER_INCUS_TRUST_TOKEN` and a writable

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -343,6 +343,15 @@ func run() error {
 				incusTLS.CertFile = cc.CertFile
 				incusTLS.KeyFile = cc.KeyFile
 			}
+			// Pin the server's leaf certificate (from the trust token or the
+			// persisted store) so ongoing lister/watcher connections verify
+			// without a CA file, matching the enrollment handshake (#146).
+			if cc.PinnedSHA256 != "" {
+				if incusTLS == nil {
+					incusTLS = &httputil.TLSConfig{}
+				}
+				incusTLS.PinnedSHA256 = cc.PinnedSHA256
+			}
 		}
 
 		baseCfg := incusclient.ClientConfig{

--- a/docs/sources/incus.md
+++ b/docs/sources/incus.md
@@ -128,7 +128,8 @@ DNSWEAVER_INCUS_DOMAIN_SUFFIX=home.example.com
 | `DNSWEAVER_INCUS_CERT_STORE` | No | — | Writable directory where the enrolled client keypair is persisted. Required with `TRUST_TOKEN`. |
 | `DNSWEAVER_INCUS_TLS_SERVER_NAME` | No | — | SNI / verification hostname override. |
 | `DNSWEAVER_INCUS_TLS_MIN_VERSION` | No | `1.2` | Minimum TLS protocol version (`1.2` or `1.3`). |
-| `DNSWEAVER_INCUS_TLS_SKIP_VERIFY` | No | `false` | Skip Incus TLS certificate verification. Prefer `TLS_CA_FILE`. |
+| `DNSWEAVER_INCUS_TLS_SKIP_VERIFY` | No | `false` | Skip Incus TLS certificate verification. Prefer `TLS_CA_FILE` or `TLS_PIN_SHA256`. Logs a warning when enabled. |
+| `DNSWEAVER_INCUS_TLS_PIN_SHA256` | No | — | Pin the Incus server's leaf certificate to this SHA-256 fingerprint (hex, colons optional). Verifies a self-signed server without a CA file. See [Server verification](#server-verification). |
 
 !!! warning "Pick exactly one endpoint"
     Set **either** `DNSWEAVER_INCUS_URL` (remote HTTPS) **or**
@@ -292,13 +293,61 @@ DNSWEAVER_INCUS_TLS_CA_FILE=/run/secrets/incus_server_ca
     access is governed by Unix socket file permissions. Mount the socket into the
     container and ensure the dnsweaver process can read it.
 
+### Server verification
+
+Incus's default server certificate only carries loopback Subject Alternative
+Names (`127.0.0.1`, `::1`). Verifying it by hostname against a LAN address
+therefore fails with `x509: certificate is valid for 127.0.0.1, ::1, not <ip>`.
+There are three ways to make a remote HTTPS connection verify:
+
+1. **CA file** (`DNSWEAVER_INCUS_TLS_CA_FILE`): supply the PEM that issued the
+   server certificate. Standard chain verification applies. Best when you run
+   your own CA.
+2. **Fingerprint pin** (`DNSWEAVER_INCUS_TLS_PIN_SHA256`): pin the server's
+   leaf certificate SHA-256. No CA file needed, still cryptographically
+   anchored. Get the fingerprint from the Incus host with
+   `incus config trust list` or
+   `openssl s_client -connect host:8443 </dev/null | openssl x509 -fingerprint -sha256 -noout`.
+   Trust-token enrollment sets this pin automatically from the token.
+3. **Skip verification** (`DNSWEAVER_INCUS_TLS_SKIP_VERIFY=true`): opt-in,
+   for throwaway dev boxes only. Logs a warning, and leaves the connection open
+   to MITM. Prefer one of the above for anything you keep.
+
+!!! tip "Recommended: pre-provisioned certificate, no persistent state"
+    The stateless default is to generate the client certificate once,
+    out-of-band, and mount it read-only from your platform's secret store
+    (Kubernetes Secret, Docker/Swarm secret, or a mounted file):
+
+    ```bash
+    # once, on the Incus host
+    incus remote generate-certificate    # writes client.crt / client.key
+    incus config trust add-certificate client.crt
+    ```
+
+    ```bash
+    DNSWEAVER_INCUS_URL=https://incus-host:8443
+    DNSWEAVER_INCUS_TLS_CERT_FILE=/run/secrets/incus_client_cert
+    DNSWEAVER_INCUS_TLS_KEY_FILE=/run/secrets/incus_client_key
+    DNSWEAVER_INCUS_TLS_PIN_SHA256=<server leaf fingerprint>   # or TLS_CA_FILE
+    ```
+
+    Nothing is generated at runtime, so the pod needs no writable volume. This
+    works identically on Kubernetes, Docker, and Incus, and is the recommended
+    setup for HA (every replica mounts the same certificate).
+
 ### Trust-Token Authentication
 
 Instead of pre-provisioning a client certificate, dnsweaver can enroll itself
 using an Incus [trust token](https://linuxcontainers.org/incus/docs/main/authentication/#adding-client-certificates-using-tokens).
-On first start it generates a client keypair, registers it with the token, and
-**persists it to a writable cert store** for reuse. Trust tokens are one-time
-use, so the cert store must survive restarts.
+This is the easy opt-in path: hand dnsweaver a token and it does the rest. It
+trades the stateless property for convenience, so it requires a writable cert
+store (see the warning below). If you want to stay stateless, use the
+pre-provisioned certificate approach under [Server verification](#server-verification)
+instead.
+
+On first start dnsweaver generates a client keypair, registers it with the
+token, and **persists it to a writable cert store** for reuse. Trust tokens are
+one-time use, so the cert store must survive restarts.
 
 ```bash
 # On the Incus host: issue a one-time token for dnsweaver
@@ -317,10 +366,15 @@ DNSWEAVER_INCUS_TLS_CA_FILE=/run/secrets/incus_server_ca   # optional
 Behavior:
 
 - **First start:** generates an ECDSA keypair + self-signed client certificate,
-  `POST`s it to `/1.0/certificates` with the token, and writes `client.crt` /
-  `client.key` (mode `0600`) into the cert store.
-- **Subsequent starts:** reuses the persisted certificate; the (now-consumed)
-  token is ignored. Enrollment is idempotent.
+  presents it in the TLS handshake to `/1.0/certificates` with the token, and
+  writes `client.crt` / `client.key` (mode `0600`) into the cert store.
+- **Server pinning:** the trust token embeds the server's certificate
+  fingerprint. dnsweaver pins it automatically for both enrollment and ongoing
+  connections, and persists it as `server.fingerprint` in the cert store. This
+  is why token enrollment works against Incus's loopback-only default
+  certificate with no CA file.
+- **Subsequent starts:** reuses the persisted certificate and pinned
+  fingerprint; the (now-consumed) token is ignored. Enrollment is idempotent.
 - **Restricted to projects:** when `DNSWEAVER_INCUS_PROJECTS` is set, the
   certificate is registered restricted to those projects.
 - **Fallback:** if no token is set, dnsweaver uses

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -483,6 +483,7 @@ func (c *Config) IncusTLS() *httputil.TLSConfig {
 		KeyFile:      g.IncusTLSKeyFile,
 		ServerName:   g.IncusTLSServerName,
 		InsecureSkip: g.IncusTLSSkipVerify,
+		PinnedSHA256: g.IncusTLSPinSHA256,
 	}
 	if g.IncusTLSMinVersion != "" {
 		if parsed, err := httputil.ParseTLSMinVersion(g.IncusTLSMinVersion); err == nil {

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -122,6 +122,7 @@ type GlobalConfig struct {
 	IncusTLSKeyFile    string
 	IncusTLSServerName string
 	IncusTLSSkipVerify bool
+	IncusTLSPinSHA256  string
 	IncusTLSMinVersion string
 
 	// Incus trust-token enrollment (#134). When IncusTrustToken is set and no
@@ -502,6 +503,7 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	cfg.IncusTLSKeyFile = getEnv("DNSWEAVER_INCUS_TLS_KEY_FILE")
 	cfg.IncusTLSServerName = getEnv("DNSWEAVER_INCUS_TLS_SERVER_NAME")
 	cfg.IncusTLSMinVersion = getEnv("DNSWEAVER_INCUS_TLS_MIN_VERSION")
+	cfg.IncusTLSPinSHA256 = getEnv("DNSWEAVER_INCUS_TLS_PIN_SHA256")
 	if v := getEnv("DNSWEAVER_INCUS_TLS_SKIP_VERIFY"); v != "" {
 		cfg.IncusTLSSkipVerify = parseBool(v, false)
 	}

--- a/internal/incus/enroll.go
+++ b/internal/incus/enroll.go
@@ -27,6 +27,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -41,10 +42,12 @@ import (
 	"github.com/maxfield-allison/dnsweaver/pkg/httputil"
 )
 
-// Cert store filenames for the persisted client keypair.
+// Cert store filenames for the persisted client keypair and pinned server
+// fingerprint.
 const (
-	certFileName = "client.crt"
-	keyFileName  = "client.key"
+	certFileName        = "client.crt"
+	keyFileName         = "client.key"
+	fingerprintFileName = "server.fingerprint"
 
 	// defaultCertName is the certificate name registered in the Incus trust
 	// store, and the CommonName of the generated certificate, when unset.
@@ -85,6 +88,12 @@ type EnrollConfig struct {
 type ClientCert struct {
 	CertFile string
 	KeyFile  string
+
+	// PinnedSHA256 is the server leaf certificate fingerprint (hex) the client
+	// should pin for ongoing connections. Populated from the trust token during
+	// enrollment and from the persisted store on reuse. Empty when no pin is
+	// available (e.g. fallback cert/key files, or a token without a fingerprint).
+	PinnedSHA256 string
 }
 
 // certificatesPost is the /1.0/certificates request body. Mirrors the subset of
@@ -125,7 +134,11 @@ func EnsureClientCert(ctx context.Context, cfg EnrollConfig, fallbackCert, fallb
 			logger.Info("using persisted incus client certificate",
 				slog.String("cert_store", cfg.CertStore),
 			)
-			return ClientCert{CertFile: certPath, KeyFile: keyPath}, nil
+			return ClientCert{
+				CertFile:     certPath,
+				KeyFile:      keyPath,
+				PinnedSHA256: loadPersistedFingerprint(cfg.CertStore),
+			}, nil
 		}
 	}
 
@@ -164,6 +177,13 @@ func enroll(ctx context.Context, cfg EnrollConfig, logger *slog.Logger) (ClientC
 		return ClientCert{}, fmt.Errorf("incus: loading generated keypair: %w", err)
 	}
 
+	// The trust token embeds the server's certificate fingerprint. Pinning to
+	// it lets enrollment (and later connections) verify the server without a CA
+	// file and without a blanket InsecureSkip, even though Incus's default
+	// certificate carries only loopback SANs and so fails hostname verification
+	// against a remote address.
+	fingerprint := tokenFingerprint(cfg.Token)
+
 	name := cfg.Name
 	if name == "" {
 		name = defaultCertName
@@ -180,7 +200,7 @@ func enroll(ctx context.Context, cfg EnrollConfig, logger *slog.Logger) (ClientC
 		return ClientCert{}, fmt.Errorf("incus: encoding certificate request: %w", err)
 	}
 
-	client, err := enrollmentClient(cfg.TLS, clientCert)
+	client, err := enrollmentClient(cfg.TLS, clientCert, fingerprint)
 	if err != nil {
 		return ClientCert{}, fmt.Errorf("incus: building enrollment client: %w", err)
 	}
@@ -215,13 +235,22 @@ func enroll(ctx context.Context, cfg EnrollConfig, logger *slog.Logger) (ClientC
 	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
 		return ClientCert{}, fmt.Errorf("incus: writing certificate to cert store: %w", err)
 	}
+	// Persist the pinned fingerprint so restarts (when the one-time token is
+	// already consumed) can still verify the server without a CA file.
+	if fingerprint != "" {
+		fpPath := filepath.Join(cfg.CertStore, fingerprintFileName)
+		if err := os.WriteFile(fpPath, []byte(fingerprint+"\n"), 0o600); err != nil {
+			return ClientCert{}, fmt.Errorf("incus: writing server fingerprint to cert store: %w", err)
+		}
+	}
 
 	logger.Info("enrolled and persisted incus client certificate via trust token",
 		slog.String("name", name),
 		slog.String("cert_store", cfg.CertStore),
 		slog.Bool("restricted", len(cfg.Projects) > 0),
+		slog.Bool("server_pinned", fingerprint != ""),
 	)
-	return ClientCert{CertFile: certPath, KeyFile: keyPath}, nil
+	return ClientCert{CertFile: certPath, KeyFile: keyPath, PinnedSHA256: fingerprint}, nil
 }
 
 // generateClientCert returns a fresh ECDSA P-384 keypair and self-signed X.509
@@ -269,20 +298,25 @@ func generateClientCert(commonName string) (certPEM, keyPEM, certDER []byte, err
 // handshake. Server verification honors the operator's TLS settings (CAFile,
 // ServerName, InsecureSkip) from cfg; any CertFile/KeyFile on cfg is ignored
 // because the enrollment cert is the freshly generated one, not a persisted
-// pair. When no TLS config is supplied a default is used.
-func enrollmentClient(cfg *httputil.TLSConfig, clientCert tls.Certificate) (*http.Client, error) {
-	var tlsConf *tls.Config
+// pair. When pin is non-empty it is applied as a leaf-certificate fingerprint
+// pin so the server verifies without a CA file. When no TLS config is supplied
+// a default is used.
+func enrollmentClient(cfg *httputil.TLSConfig, clientCert tls.Certificate, pin string) (*http.Client, error) {
+	var serverConf httputil.TLSConfig
 	if cfg != nil {
-		serverConf := *cfg
-		// The generated keypair is presented explicitly below; drop any
-		// file-based client cert so Build() doesn't try to load one.
-		serverConf.CertFile = ""
-		serverConf.KeyFile = ""
-		built, err := serverConf.Build()
-		if err != nil {
-			return nil, err
-		}
-		tlsConf = built
+		serverConf = *cfg
+	}
+	// The generated keypair is presented explicitly below; drop any
+	// file-based client cert so Build() doesn't try to load one.
+	serverConf.CertFile = ""
+	serverConf.KeyFile = ""
+	if pin != "" {
+		serverConf.PinnedSHA256 = pin
+	}
+
+	tlsConf, err := serverConf.Build()
+	if err != nil {
+		return nil, err
 	}
 	if tlsConf == nil {
 		tlsConf = &tls.Config{MinVersion: httputil.DefaultTLSMinVersion} //nolint:gosec // DefaultTLSMinVersion is TLS 1.2
@@ -295,6 +329,39 @@ func enrollmentClient(cfg *httputil.TLSConfig, clientCert tls.Certificate) (*htt
 			TLSClientConfig: tlsConf,
 		},
 	}, nil
+}
+
+// tokenFingerprint decodes an Incus trust token and returns the embedded server
+// certificate fingerprint (hex SHA-256). Incus trust tokens are base64-encoded
+// JSON that includes a "fingerprint" field. Returns "" when the token cannot be
+// decoded or carries no fingerprint, in which case enrollment falls back to the
+// operator's CA/ServerName/InsecureSkip settings.
+func tokenFingerprint(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return ""
+	}
+	var payload struct {
+		Fingerprint string `json:"fingerprint"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Fingerprint)
+}
+
+// loadPersistedFingerprint reads a previously persisted server fingerprint from
+// the cert store. Returns "" when absent or unreadable.
+func loadPersistedFingerprint(certStore string) string {
+	data, err := os.ReadFile(filepath.Join(certStore, fingerprintFileName))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 // decodeAPIError extracts a useful message from an Incus error response.

--- a/internal/incus/enroll_test.go
+++ b/internal/incus/enroll_test.go
@@ -2,8 +2,11 @@ package incus
 
 import (
 	"context"
+	"crypto/sha256"
 	gotls "crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"net/http"
@@ -19,6 +22,110 @@ import (
 // self-signed cert used by httptest.NewTLSServer.
 func tlsSkip() *httputil.TLSConfig {
 	return &httputil.TLSConfig{InsecureSkip: true}
+}
+
+// makeToken builds a base64-encoded Incus trust token carrying the given
+// fingerprint, mirroring the real token structure.
+func makeToken(t *testing.T, fingerprint string) string {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"client_name": "dnsweaver",
+		"fingerprint": fingerprint,
+		"secret":      "deadbeef",
+	})
+	if err != nil {
+		t.Fatalf("marshal token: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// certFingerprint returns the hex SHA-256 of a certificate's DER bytes.
+func certFingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestTokenFingerprint(t *testing.T) {
+	fp := "823c4a64cc168708aa49ed9dc0ec755ff414bb91e75049a7eb991cba3d9249fe"
+	if got := tokenFingerprint(makeToken(t, fp)); got != fp {
+		t.Errorf("tokenFingerprint = %q, want %q", got, fp)
+	}
+	if got := tokenFingerprint("not-base64-json"); got != "" {
+		t.Errorf("invalid token = %q, want empty", got)
+	}
+	if got := tokenFingerprint(""); got != "" {
+		t.Errorf("empty token = %q, want empty", got)
+	}
+}
+
+// TestEnsureClientCert_PinnedEnrollment proves enrollment succeeds against a
+// self-signed server WITHOUT InsecureSkip, verified purely by the token's
+// pinned fingerprint, and that the pin is persisted and reused.
+func TestEnsureClientCert_PinnedEnrollment(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"type":"sync","status_code":200,"metadata":{}}`))
+	}))
+	srv.TLS = &gotls.Config{ClientAuth: gotls.RequireAnyClientCert} //nolint:gosec // test server
+	srv.StartTLS()
+	defer srv.Close()
+
+	// Pin the real server certificate via the token. No CA, no InsecureSkip.
+	fp := certFingerprint(srv.Certificate())
+	store := t.TempDir()
+	cc, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL:   srv.URL,
+		Token:     makeToken(t, fp),
+		CertStore: store,
+		TLS:       nil, // no CA, no skip: only the pin can make this pass
+	}, "", "")
+	if err != nil {
+		t.Fatalf("pinned EnsureClientCert: %v", err)
+	}
+	if cc.PinnedSHA256 != fp {
+		t.Errorf("PinnedSHA256 = %q, want %q", cc.PinnedSHA256, fp)
+	}
+	// Fingerprint persisted for restarts.
+	if got := loadPersistedFingerprint(store); got != fp {
+		t.Errorf("persisted fingerprint = %q, want %q", got, fp)
+	}
+	// Reuse path returns the persisted pin without a token.
+	cc2, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL:   srv.URL,
+		CertStore: store,
+	}, "", "")
+	if err != nil {
+		t.Fatalf("reuse EnsureClientCert: %v", err)
+	}
+	if cc2.PinnedSHA256 != fp {
+		t.Errorf("reuse PinnedSHA256 = %q, want %q", cc2.PinnedSHA256, fp)
+	}
+}
+
+// TestEnsureClientCert_PinnedEnrollmentWrongFingerprint proves a mismatched pin
+// rejects the connection (no silent trust).
+func TestEnsureClientCert_PinnedEnrollmentWrongFingerprint(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"type":"sync"}`))
+	}))
+	srv.TLS = &gotls.Config{ClientAuth: gotls.RequireAnyClientCert} //nolint:gosec // test server
+	srv.StartTLS()
+	defer srv.Close()
+
+	store := t.TempDir()
+	_, err := EnsureClientCert(context.Background(), EnrollConfig{
+		BaseURL:   srv.URL,
+		Token:     makeToken(t, "00"+certFingerprint(srv.Certificate())[2:]), // corrupt first byte
+		CertStore: store,
+		TLS:       nil,
+	}, "", "")
+	if err == nil {
+		t.Fatal("expected enrollment to fail on fingerprint mismatch")
+	}
+	if fileExists(filepath.Join(store, certFileName)) {
+		t.Error("certificate must not be persisted on failed enrollment")
+	}
 }
 
 func TestGenerateClientCert(t *testing.T) {

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -2,8 +2,10 @@
 package httputil
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -64,6 +66,15 @@ type TLSConfig struct {
 	// is enabled.
 	InsecureSkip bool
 
+	// PinnedSHA256 pins the server's leaf certificate to a specific SHA-256
+	// fingerprint (hex, colons and case optional). When set, the server's
+	// presented leaf certificate is verified against this fingerprint instead
+	// of the default chain/hostname check. This is used to trust a self-signed
+	// server whose certificate cannot be validated by hostname (e.g. Incus,
+	// whose default certificate only carries loopback SANs) while remaining
+	// cryptographically anchored. An explicit InsecureSkip takes precedence.
+	PinnedSHA256 string
+
 	// MinVersion is the minimum TLS protocol version. Defaults to
 	// DefaultTLSMinVersion (TLS 1.2) when zero. Accepts tls.VersionTLS12
 	// and tls.VersionTLS13.
@@ -78,6 +89,7 @@ func (t TLSConfig) IsZero() bool {
 		t.KeyFile == "" &&
 		t.ServerName == "" &&
 		!t.InsecureSkip &&
+		t.PinnedSHA256 == "" &&
 		t.MinVersion == 0
 }
 
@@ -137,7 +149,39 @@ func (t TLSConfig) Build() (*tls.Config, error) {
 		out.Certificates = []tls.Certificate{cert}
 	}
 
+	// Certificate pinning. When a leaf fingerprint is pinned and the operator
+	// has not explicitly disabled verification, replace the default
+	// chain/hostname check with an exact match against the pinned SHA-256.
+	// This trusts a specific self-signed server (e.g. Incus, whose default
+	// certificate only has loopback SANs) without weakening to a blanket skip.
+	if t.PinnedSHA256 != "" && !t.InsecureSkip {
+		pin := normalizeFingerprint(t.PinnedSHA256)
+		// The default verifier is disabled because it would reject the
+		// self-signed / hostname-mismatched certificate before VerifyConnection
+		// runs; the pin below is the replacement, not a downgrade.
+		out.InsecureSkipVerify = true //nolint:gosec // verification replaced by the certificate pin in VerifyConnection
+		out.VerifyConnection = func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return errors.New("tls: server presented no certificate for pinned verification")
+			}
+			sum := sha256.Sum256(cs.PeerCertificates[0].Raw)
+			got := hex.EncodeToString(sum[:])
+			if !strings.EqualFold(got, pin) {
+				return fmt.Errorf("tls: server certificate SHA-256 %s does not match pinned fingerprint %s", got, pin)
+			}
+			return nil
+		}
+	}
+
 	return out, nil
+}
+
+// normalizeFingerprint lowercases a hex certificate fingerprint and strips
+// colon and whitespace separators so pins may be supplied in any common form
+// ("AA:BB:...", "aabb...", with or without spaces).
+func normalizeFingerprint(fp string) string {
+	replacer := strings.NewReplacer(":", "", " ", "", "\t", "", "\n", "")
+	return strings.ToLower(replacer.Replace(fp))
 }
 
 // permissionHint augments a file-access error with the uid/gid the process is

--- a/pkg/httputil/client_test.go
+++ b/pkg/httputil/client_test.go
@@ -2,7 +2,9 @@ package httputil
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -323,5 +325,65 @@ func TestSanitizeURL_NilURL(t *testing.T) {
 	result := sanitizeURL(nil)
 	if result != "" {
 		t.Errorf("nil URL should return empty string, got %q", result)
+	}
+}
+
+func TestTLSConfig_PinnedSHA256(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sum := sha256.Sum256(srv.Certificate().Raw)
+	goodPin := hex.EncodeToString(sum[:])
+
+	get := func(cfg *tls.Config) error {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: cfg}}
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		return resp.Body.Close()
+	}
+
+	// Correct pin: connection succeeds against the self-signed server with no
+	// CA and no InsecureSkip.
+	okCfg, err := TLSConfig{PinnedSHA256: goodPin}.Build()
+	if err != nil {
+		t.Fatalf("Build with pin: %v", err)
+	}
+	if err := get(okCfg); err != nil {
+		t.Fatalf("pinned request failed: %v", err)
+	}
+
+	// Colon-separated, uppercase pin normalizes to the same result.
+	mixedCfg, err := TLSConfig{PinnedSHA256: strings.ToUpper(goodPin)}.Build()
+	if err != nil {
+		t.Fatalf("Build with upper pin: %v", err)
+	}
+	if err := get(mixedCfg); err != nil {
+		t.Fatalf("uppercase pin request failed: %v", err)
+	}
+
+	// Wrong pin: connection is rejected.
+	badCfg, err := TLSConfig{PinnedSHA256: "00" + goodPin[2:]}.Build()
+	if err != nil {
+		t.Fatalf("Build with bad pin: %v", err)
+	}
+	if err := get(badCfg); err == nil {
+		t.Fatal("expected wrong pin to reject the connection")
+	}
+
+	// Explicit InsecureSkip takes precedence over the pin.
+	skipCfg, err := TLSConfig{InsecureSkip: true, PinnedSHA256: "00" + goodPin[2:]}.Build()
+	if err != nil {
+		t.Fatalf("Build skip+pin: %v", err)
+	}
+	if skipCfg.VerifyConnection != nil {
+		t.Error("explicit InsecureSkip should bypass pin (no VerifyConnection)")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes remote HTTPS connections to the Incus API, including trust-token enrollment over a LAN address, by pinning the server's leaf certificate instead of disabling verification. This is the alternative to #146 discussed in that thread.

## The bug

Incus's default server certificate carries only loopback SANs (`127.0.0.1`, `::1`). Verifying it by hostname against a remote address fails:

```
tls: failed to verify certificate: x509: certificate is valid for 127.0.0.1, ::1, not 10.1.20.40
```

So token enrollment (#134) over a remote URL was broken unless the operator supplied a CA file and a matching `TLS_SERVER_NAME`.

## Approach

Instead of a blanket `InsecureSkip` (which would disable verification for the lister and watcher too, and override operators who configured TLS on purpose), pin the server's leaf certificate:

- **`httputil.TLSConfig.PinnedSHA256`**: when set, server verification checks the presented leaf against the pinned SHA-256 via `VerifyConnection` rather than the default chain/hostname check. An explicit `InsecureSkip` still wins. Fingerprints accepted with or without colons, any case.
- **Trust-token enrollment**: the token already embeds the server's fingerprint. dnsweaver pins it for the enrollment handshake and for ongoing connections, and persists it as `server.fingerprint` in the cert store so tokenless restarts stay verified. No CA file or skip needed.
- **`DNSWEAVER_INCUS_TLS_PIN_SHA256`**: a standalone knob so a pre-provisioned certificate can verify a self-signed Incus server with no CA file and **no persistent state**, which is a fully stateless secret-mounted setup that works the same on Kubernetes, Docker, and Incus.

## State model

- **Easy opt-in path**: trust token + writable cert store. Persists the keypair and fingerprint. One mounted volume.
- **Stateless default (recommended)**: pre-provisioned cert mounted from a platform secret + `PIN_SHA256` (or a CA file). Nothing written at runtime. Same setup everywhere, and the right shape for HA replicas.

Docs now document server verification (CA vs pin vs skip), recommend the stateless path as the default, and frame token enrollment as the convenience path.

## Testing

- Unit: SHA-256 pin accept/reject/normalization; `InsecureSkip` precedence; token fingerprint parsing; pinned enrollment against a self-signed test server with no skip; mismatched-pin rejection; persisted-fingerprint reuse.
- `golangci-lint`, `go test -race ./...`, `go build ./...` green.
- End-to-end against Incus 7.2 over a raw IP with no CA:
  1. Fresh token enrollment: pins from the token, persists `server.fingerprint`, connects and reconciles.
  2. Tokenless restart: verifies using only the persisted fingerprint, reconciles.
  3. Stateless pre-provisioned cert + `PIN_SHA256`, no token, no cert store: connects and reconciles, nothing written.

Closes #146
