### PR TITLE
feat(proxmox): add prefix-based interface matching and fallback for VM IP resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ vendor/
 # Build artifacts
 /bin/
 /dist/
+.gocache/
+.gopath/
 
 # Environment files (may contain secrets)
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- **Proxmox interface selection improvements.** `DNSWEAVER_PROXMOX_ALLOWED_INTERFACES`
+  now matches interface-name prefixes (so `eth` matches `eth0`), per-VM interface
+  tags from `DNSWEAVER_PROXMOX_INTERFACE_TAG_PREFIX` override the allow-list,
+  and if no allowed or tagged interface resolves, dnsweaver falls back to the
+  first non-loopback IPv4 address rather than skipping the VM.
 
 ## [2.6.0] - 2026-07-15
 

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -296,9 +296,11 @@ func run() error {
 			return fmt.Errorf("creating proxmox client: %w", err)
 		}
 		proxmoxLister := proxmoxclient.NewWorkloadListerAdapter(pveClient, proxmoxclient.AdapterConfig{
-			NodeFilter:  cfg.ProxmoxNodeFilter(),
-			TagFilter:   cfg.ProxmoxTagFilter(),
-			StateFilter: cfg.ProxmoxStateFilter(),
+			NodeFilter:          cfg.ProxmoxNodeFilter(),
+			TagFilter:           cfg.ProxmoxTagFilter(),
+			StateFilter:         cfg.ProxmoxStateFilter(),
+			InterfacePreference: cfg.ProxmoxInterfaceTagPrefix(),
+			AllowedInterfaces:   cfg.ProxmoxAllowedInterfaces(),
 		}, logger)
 		listers = append(listers, proxmoxLister)
 		logger.Info("proxmox lister configured",

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -304,6 +304,8 @@ full setup including the required PVE role privileges.
 | `DNSWEAVER_PROXMOX_NODE_FILTER` | No | *(all)* | Restrict discovery to a single PVE node name |
 | `DNSWEAVER_PROXMOX_TAG_FILTER` | No | *(all)* | Only include resources with this tag (prefix match) |
 | `DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX` | No | — | Optional tag prefix in the form `<prefix>+<hostname>` used to override the discovered hostname |
+| `DNSWEAVER_PROXMOX_INTERFACE_TAG_PREFIX` | No | — | Optional tag prefix in the form `<prefix>+<interface>` that selects a specific guest interface for IP resolution. A matching tag overrides the allow-list and is honored even when that interface is not otherwise allowed. |
+| `DNSWEAVER_PROXMOX_ALLOWED_INTERFACES` | No | — | Comma-separated allow-list of guest interface prefixes to consider when resolving IPs. Entries are matched as prefixes (for example `eth` matches `eth0`), and if no entry matches, dnsweaver falls back to the first non-loopback IPv4 address instead of skipping the VM. |
 | `DNSWEAVER_PROXMOX_STATE_FILTER` | No | `running` | Resource status filter (`running`, `stopped`, etc.) |
 | `DNSWEAVER_PROXMOX_DOMAIN_SUFFIX` | No | — | Domain suffix appended to VM names |
 

--- a/docs/sources/proxmox.md
+++ b/docs/sources/proxmox.md
@@ -44,6 +44,8 @@ flowchart LR
 | `DNSWEAVER_PROXMOX_NODE_FILTER` | No | _(all nodes)_ | Restrict discovery to a single PVE node name |
 | `DNSWEAVER_PROXMOX_TAG_FILTER` | No | _(all tags)_ | Only include resources with this tag (prefix match) |
 | `DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX` | No | — | Optional tag prefix in the form `<prefix>+<hostname>` used to override the discovered hostname. The first matching tag wins if multiple tags share the prefix. |
+| `DNSWEAVER_PROXMOX_INTERFACE_TAG_PREFIX` | No | — | Optional tag prefix in the form `<prefix>+<interface>` that selects a specific guest interface for IP resolution. A matching tag overrides the allow-list and can target an interface even if it is not otherwise allowed. |
+| `DNSWEAVER_PROXMOX_ALLOWED_INTERFACES` | No | — | Comma-separated allow-list of guest interface prefixes to consider when resolving IPs (for example `eth,ens`). Prefix matching is used, so `eth` matches `eth0` and `eth1`. If no allow-listed or tagged interface yields a usable IPv4 address, dnsweaver falls back to the first non-loopback IPv4 address instead of skipping the VM. |
 | `DNSWEAVER_PROXMOX_STATE_FILTER` | No | `running` | PVE resource status filter (`running`, `stopped`, etc.) |
 | `DNSWEAVER_PROXMOX_DOMAIN_SUFFIX` | No | — | Domain suffix appended to VM names, e.g. `home.example.com` |
 | `DNSWEAVER_PROXMOX_TARGET_MODE` | No | `guest-ip` | Target resolution mode. `guest-ip` (default) emits an A record per VM IP. `instance` defers record type and target to the matching provider instance — useful for pointing all VMs at a reverse proxy via CNAME. |
@@ -93,6 +95,14 @@ IP resolution differs by resource type:
 | **LXC container** | `net0` config field (`ip=<address>/prefix`) | Reads directly from the PVE API; no agent required |
 
 VMs without a running guest agent are skipped (a debug log entry is emitted). To include VMs, install and enable `qemu-guest-agent` inside the guest.
+
+When interface selection is configured, dnsweaver resolves VM IPs in this order:
+
+1. A matching interface tag from `DNSWEAVER_PROXMOX_INTERFACE_TAG_PREFIX` (if present)
+2. The first interface whose name matches one of the prefixes in `DNSWEAVER_PROXMOX_ALLOWED_INTERFACES` (if configured)
+3. The first non-loopback IPv4 address found on any interface, as a fallback
+
+This keeps the behavior predictable for multi-interface VMs while still avoiding host-only adapters by default when you configure an allow-list.
 
 ## Target Mode
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -351,6 +351,17 @@ func (c *Config) ProxmoxHostnameTagPrefix() string {
 	return c.Global.ProxmoxHostnameTagPrefix
 }
 
+// ProxmoxInterfaceTagPrefix returns the optional tag prefix used to derive an
+// interface name preference from Proxmox tags.
+func (c *Config) ProxmoxInterfaceTagPrefix() string {
+	return c.Global.ProxmoxInterfaceTagPrefix
+}
+
+// ProxmoxAllowedInterfaces returns the optional allow-list of guest interface names.
+func (c *Config) ProxmoxAllowedInterfaces() []string {
+	return c.Global.ProxmoxAllowedInterfaces
+}
+
 // ProxmoxTargetMode returns the configured target resolution mode
 // ("guest-ip" or "instance"). Empty string means use the default.
 func (c *Config) ProxmoxTargetMode() string {

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -85,16 +85,18 @@ type GlobalConfig struct {
 	Source string // traefik, labels, or custom source name
 
 	// Proxmox VE settings
-	ProxmoxURL               string // PVE API base URL (e.g., https://pve-00:8006)
-	ProxmoxTokenID           string // PVE API token ID (e.g., user@pam!dnsweaver)
-	ProxmoxTokenSecret       string // PVE API token secret (UUID); supports _FILE suffix
-	ProxmoxNodeFilter        string // Optional: limit to a specific node (empty = all nodes)
-	ProxmoxTagFilter         string // Optional: prefix match on PVE tags to filter workloads
-	ProxmoxStateFilter       string // Filter by PVE resource status (default: "running")
-	ProxmoxDomainSuffix      string // Domain suffix to append to VM names (e.g., "home.example.com")
-	ProxmoxHostnameTagPrefix string // Optional: tag prefix for hostname override tags (e.g. "dnsweaver")
-	ProxmoxVerifyTLS         bool   // Verify TLS certificate on PVE API endpoint (DEPRECATED in v1.5: prefer ProxmoxTLSSkipVerify)
-	ProxmoxTargetMode        string // Target resolution mode: "guest-ip" (default) or "instance"
+	ProxmoxURL                string   // PVE API base URL (e.g., https://pve-00:8006)
+	ProxmoxTokenID            string   // PVE API token ID (e.g., user@pam!dnsweaver)
+	ProxmoxTokenSecret        string   // PVE API token secret (UUID); supports _FILE suffix
+	ProxmoxNodeFilter         string   // Optional: limit to a specific node (empty = all nodes)
+	ProxmoxTagFilter          string   // Optional: prefix match on PVE tags to filter workloads
+	ProxmoxStateFilter        string   // Filter by PVE resource status (default: "running")
+	ProxmoxDomainSuffix       string   // Domain suffix to append to VM names (e.g., "home.example.com")
+	ProxmoxHostnameTagPrefix  string   // Optional: tag prefix for hostname override tags (e.g. "dnsweaver")
+	ProxmoxInterfaceTagPrefix string   // Optional: tag prefix for interface selection tags (e.g. "dnsweaver")
+	ProxmoxAllowedInterfaces  []string // Optional allow-list of guest interface names for IP resolution
+	ProxmoxVerifyTLS          bool     // Verify TLS certificate on PVE API endpoint (DEPRECATED in v1.5: prefer ProxmoxTLSSkipVerify)
+	ProxmoxTargetMode         string   // Target resolution mode: "guest-ip" (default) or "instance"
 
 	// Unified PVE TLS configuration (v1.5+). Populated from DNSWEAVER_PROXMOX_TLS_*
 	// env vars and consumed by internal/proxmox via httputil.TLSConfig.
@@ -424,6 +426,8 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	cfg.ProxmoxStateFilter = getEnv("DNSWEAVER_PROXMOX_STATE_FILTER")
 	cfg.ProxmoxDomainSuffix = getEnv("DNSWEAVER_PROXMOX_DOMAIN_SUFFIX")
 	cfg.ProxmoxHostnameTagPrefix = getEnv("DNSWEAVER_PROXMOX_HOSTNAME_TAG_PREFIX")
+	cfg.ProxmoxInterfaceTagPrefix = getEnv("DNSWEAVER_PROXMOX_INTERFACE_TAG_PREFIX")
+	cfg.ProxmoxAllowedInterfaces = splitPatterns(getEnv("DNSWEAVER_PROXMOX_ALLOWED_INTERFACES"))
 	cfg.ProxmoxTargetMode = getEnv("DNSWEAVER_PROXMOX_TARGET_MODE")
 	if cfg.ProxmoxTargetMode != "" {
 		switch strings.ToLower(strings.TrimSpace(cfg.ProxmoxTargetMode)) {

--- a/internal/proxmox/adapter.go
+++ b/internal/proxmox/adapter.go
@@ -10,10 +10,12 @@ import (
 )
 
 const (
-	resourceTypeLXC = "lxc"
-	tagLabelValue   = "true"
+	resourceTypeLXC  = "lxc"
+	resourceTypeQEMU = "qemu"
+	tagLabelValue    = "true"
 
-	stateRunning = "running"
+	stateRunning  = "running"
+	ipVersionIPv4 = "ipv4"
 )
 
 // Metadata/log field keys shared between logging and the toWorkload metadata map.
@@ -38,6 +40,14 @@ type AdapterConfig struct {
 	// StateFilter restricts listing to resources in the given state.
 	// Typical values: "running", "stopped". Defaults to "running" if empty.
 	StateFilter string
+
+	// InterfacePreference selects a specific guest interface name to use for IP resolution.
+	// Empty string means no preference and the adapter will use the allow-list below.
+	InterfacePreference string
+
+	// AllowedInterfaces is a list of interface names that are allowed for IP resolution.
+	// If provided, the resolver will only consider those interfaces in order.
+	AllowedInterfaces []string
 }
 
 // WorkloadListerAdapter wraps a Proxmox Client to implement the workload.Lister interface.
@@ -59,9 +69,11 @@ func NewWorkloadListerAdapter(c *Client, cfg AdapterConfig, logger *slog.Logger)
 	return &WorkloadListerAdapter{
 		client: c,
 		cfg: AdapterConfig{
-			NodeFilter:  cfg.NodeFilter,
-			TagFilter:   cfg.TagFilter,
-			StateFilter: stateFilter,
+			NodeFilter:          cfg.NodeFilter,
+			TagFilter:           cfg.TagFilter,
+			StateFilter:         stateFilter,
+			InterfacePreference: cfg.InterfacePreference,
+			AllowedInterfaces:   cfg.AllowedInterfaces,
 		},
 		logger: logger,
 	}
@@ -83,7 +95,8 @@ func (a *WorkloadListerAdapter) ListWorkloads(ctx context.Context) ([]workload.W
 			continue
 		}
 
-		ip, err := ResolveIP(ctx, a.client, r, a.logger)
+		interfacePreference := parseInterfacePreferenceFromTags(r.Tags, a.cfg.InterfacePreference)
+		ip, err := ResolveIPWithInterfacePreferences(ctx, a.client, r, a.logger, interfacePreference, a.cfg.AllowedInterfaces)
 		if err != nil {
 			a.logger.Warn("could not resolve IP for proxmox resource",
 				slog.String(metaKeyNode, r.Node),

--- a/internal/proxmox/ip_resolver.go
+++ b/internal/proxmox/ip_resolver.go
@@ -9,17 +9,11 @@ import (
 	"strings"
 )
 
-const (
-	resourceTypeQEMU = "qemu"
-
-	ipAddressTypeIPv4 = "ipv4"
-)
-
 // ResolveIP returns the primary IPv4 address for a Proxmox resource.
 //
 // For LXC containers (type "lxc"), it reads the net0 config field and parses
 // the ip= component. For QEMU VMs (type "qemu"), it queries the qemu-guest-agent
-// and returns the first non-loopback IPv4 address found on any interface.
+// and returns the first non-loopback IPv4 address found on a selected interface.
 //
 // If the VM has no guest agent running, the function logs a warning and returns
 // an empty string (no error), since this is a common condition in homelabs
@@ -31,7 +25,20 @@ func ResolveIP(ctx context.Context, client *Client, resource ClusterResource, lo
 	case resourceTypeLXC:
 		return resolveLXCIP(ctx, client, resource)
 	case resourceTypeQEMU:
-		return resolveVMIP(ctx, client, resource, logger)
+		return resolveVMIP(ctx, client, resource, logger, "", nil)
+	default:
+		return "", fmt.Errorf("proxmox: unsupported resource type %q", resource.Type)
+	}
+}
+
+// ResolveIPWithInterfacePreferences resolves the primary IPv4 address for a Proxmox resource
+// using the supplied interface preference and allow-list.
+func ResolveIPWithInterfacePreferences(ctx context.Context, client *Client, resource ClusterResource, logger *slog.Logger, interfacePreference string, allowedInterfaces []string) (string, error) {
+	switch resource.Type {
+	case resourceTypeLXC:
+		return resolveLXCIP(ctx, client, resource)
+	case resourceTypeQEMU:
+		return resolveVMIP(ctx, client, resource, logger, interfacePreference, allowedInterfaces)
 	default:
 		return "", fmt.Errorf("proxmox: unsupported resource type %q", resource.Type)
 	}
@@ -79,8 +86,8 @@ func parseLXCNet0IP(net0 string) string {
 }
 
 // resolveVMIP queries the qemu-guest-agent for the VM's network interfaces and
-// returns the first non-loopback IPv4 address found.
-func resolveVMIP(ctx context.Context, client *Client, resource ClusterResource, logger *slog.Logger) (string, error) {
+// returns the first non-loopback IPv4 address found on the preferred interface.
+func resolveVMIP(ctx context.Context, client *Client, resource ClusterResource, logger *slog.Logger, interfacePreference string, allowedInterfaces []string) (string, error) {
 	ifaces, err := client.GetVMAgentNetworks(ctx, resource.Node, resource.VMID)
 	if err != nil {
 		var agentErr *ErrAgentNotRunning
@@ -95,18 +102,77 @@ func resolveVMIP(ctx context.Context, client *Client, resource ClusterResource, 
 		return "", fmt.Errorf("querying guest agent for VM %d on %s: %w", resource.VMID, resource.Node, err)
 	}
 
+	filterByInterface := interfacePreference != "" || len(allowedInterfaces) > 0
+	if filterByInterface {
+		selected := selectInterfaceForIP(ifaces, interfacePreference, allowedInterfaces)
+		if selected != "" {
+			for _, iface := range ifaces {
+				if iface.Name != selected {
+					continue
+				}
+				for _, addr := range iface.IPAddresses {
+					if addr.IPAddressType == ipVersionIPv4 && !isNonRoutableIP(addr.IPAddress) {
+						return addr.IPAddress, nil
+					}
+				}
+				break
+			}
+		}
+	}
+
 	for _, iface := range ifaces {
 		if isLoopback(iface.Name) {
 			continue
 		}
 		for _, addr := range iface.IPAddresses {
-			if addr.IPAddressType == ipAddressTypeIPv4 && !isNonRoutableIP(addr.IPAddress) {
+			if addr.IPAddressType == ipVersionIPv4 && !isNonRoutableIP(addr.IPAddress) {
 				return addr.IPAddress, nil
 			}
 		}
 	}
 
 	return "", nil
+}
+
+func selectInterfaceForIP(ifaces []AgentNetworkInterface, interfacePreference string, allowedInterfaces []string) string {
+	if interfacePreference != "" {
+		for _, iface := range ifaces {
+			if iface.Name == interfacePreference {
+				return iface.Name
+			}
+		}
+		return interfacePreference
+	}
+
+	if len(allowedInterfaces) == 0 {
+		return ""
+	}
+
+	for _, iface := range ifaces {
+		for _, allowed := range allowedInterfaces {
+			if strings.HasPrefix(iface.Name, allowed) {
+				return iface.Name
+			}
+		}
+	}
+	return ""
+}
+
+func parseInterfacePreferenceFromTags(tags string, prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	for _, tag := range strings.Split(tags, ";") {
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			continue
+		}
+		if !strings.HasPrefix(tag, prefix+"+") {
+			continue
+		}
+		return strings.TrimSpace(strings.TrimPrefix(tag, prefix+"+"))
+	}
+	return ""
 }
 
 // isLoopback returns true for known loopback interface names.

--- a/internal/proxmox/ip_resolver_test.go
+++ b/internal/proxmox/ip_resolver_test.go
@@ -62,6 +62,42 @@ func TestIsLoopback(t *testing.T) {
 	}
 }
 
+func TestParseInterfacePreferenceFromTags(t *testing.T) {
+	if got := parseInterfacePreferenceFromTags("dnsweaver+eth1;other:keep", "dnsweaver"); got != "eth1" {
+		t.Fatalf("parseInterfacePreferenceFromTags() = %q, want %q", got, "eth1")
+	}
+	if got := parseInterfacePreferenceFromTags("other;dnsweaver+eth0", "dnsweaver"); got != "eth0" {
+		t.Fatalf("parseInterfacePreferenceFromTags() = %q, want %q", got, "eth0")
+	}
+	if got := parseInterfacePreferenceFromTags("dnsweaver+", "dnsweaver"); got != "" {
+		t.Fatalf("parseInterfacePreferenceFromTags() = %q, want empty", got)
+	}
+	if got := parseInterfacePreferenceFromTags("+eth0", ""); got != "" {
+		t.Fatalf("parseInterfacePreferenceFromTags() = %q, want empty", got)
+	}
+}
+
+func TestSelectInterfaceForIP(t *testing.T) {
+	ifaces := []AgentNetworkInterface{
+		{Name: "lo", IPAddresses: []AgentIPAddress{{IPAddressType: "ipv4", IPAddress: "127.0.0.1"}}},
+		{Name: "eth0", IPAddresses: []AgentIPAddress{{IPAddressType: "ipv4", IPAddress: "10.0.0.10"}}},
+		{Name: "docker0", IPAddresses: []AgentIPAddress{{IPAddressType: "ipv4", IPAddress: "172.17.0.1"}}},
+	}
+
+	if got := selectInterfaceForIP(ifaces, "", []string{"eth0", "docker0"}); got != "eth0" {
+		t.Fatalf("selectInterfaceForIP() = %q, want %q", got, "eth0")
+	}
+	if got := selectInterfaceForIP(ifaces, "docker0", nil); got != "docker0" {
+		t.Fatalf("selectInterfaceForIP() = %q, want %q", got, "docker0")
+	}
+	if got := selectInterfaceForIP(ifaces, "eth1", nil); got != "eth1" {
+		t.Fatalf("selectInterfaceForIP() = %q, want %q", got, "eth1")
+	}
+	if got := selectInterfaceForIP(ifaces, "", []string{"eth"}); got != "eth0" {
+		t.Fatalf("selectInterfaceForIP() = %q, want %q", got, "eth0")
+	}
+}
+
 func TestIsNonRoutableIP(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
<!--
Thanks for contributing to dnsweaver! Please complete the checklist below.
Keep PRs focused — one logical change per pull request.
-->

## Summary

This change improves Proxmox VM IP resolution by limiting what interface is used to determine the IP of the host.  This is done by specifying interface allow-list prefixes, so values like “eth” correctly select interfaces such as “eth0”. It also lets per-VM interface tags override the allow-list and adds a fallback to the first non-loopback IPv4 address when no allowed or tagged interface is available, preventing VMs from being skipped unexpectedly.
## Related issues

<!-- e.g. Closes #123. PRs without a linked issue may be asked for context. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Maintenance / refactor / CI

## Checklist

- [x] `gofmt` clean and `golangci-lint run ./...` passes
- [x] `go test ./...` passes (added/updated tests where relevant)
- [x] `go build ./...` succeeds
- [x] Docs updated (README / docs site) if behavior or config changed
- [x] CHANGELOG.md updated under the Unreleased section if user-facing
