### PR TITLE
fix(httputil): strip control characters from sanitized URLs (CodeQL log-injection #5/#6)

### DIFF
--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -271,8 +271,10 @@ var sensitiveQueryParams = map[string]bool{
 	"apikey":   true,
 }
 
-// sanitizeURL returns a URL string with sensitive query parameters redacted.
-// This prevents credentials from appearing in debug logs.
+// sanitizeURL returns a URL string with sensitive query parameters redacted
+// and control characters neutralized. This prevents credentials from appearing
+// in debug logs and blocks log injection/forging via CR/LF or other control
+// characters embedded in a URL.
 func sanitizeURL(u *url.URL) string {
 	if u == nil {
 		return ""
@@ -288,13 +290,24 @@ func sanitizeURL(u *url.URL) string {
 	}
 
 	if !redacted {
-		return u.String()
+		return stripControlChars(u.String())
 	}
 
 	// Rebuild URL with redacted query
 	sanitized := *u
 	sanitized.RawQuery = query.Encode()
-	return sanitized.String()
+	return stripControlChars(sanitized.String())
+}
+
+// stripControlChars removes ASCII control characters (including CR and LF) from
+// s so that untrusted URL content cannot forge or split log entries.
+func stripControlChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 // RoundTrip implements http.RoundTripper.

--- a/pkg/httputil/client_test.go
+++ b/pkg/httputil/client_test.go
@@ -328,6 +328,20 @@ func TestSanitizeURL_NilURL(t *testing.T) {
 	}
 }
 
+func TestSanitizeURL_StripsControlChars(t *testing.T) {
+	// A URL carrying CR/LF (and other control chars) must not be able to forge
+	// or split a log line once written out.
+	u, _ := url.Parse("http://example.com/api?zone=te%0d%0aFORGED+LOG+ENTRY%00st")
+	result := sanitizeURL(u)
+
+	for _, r := range result {
+		if r < 0x20 || r == 0x7f {
+			t.Errorf("sanitized URL should not contain control characters, got %q", result)
+			break
+		}
+	}
+}
+
 func TestTLSConfig_PinnedSHA256(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

Fixes CodeQL `go/log-injection` alerts **#5** and **#6** (Medium) in `pkg/httputil/client.go`.

`sanitizeURL` already redacts sensitive query parameters (`token`, `apikey`, ...) before URLs are written to debug logs, but it passed the rest of the URL string through unchanged. A URL carrying CR/LF or other ASCII control characters could therefore forge or split a log entry when the request/response is logged in `userAgentTransport.RoundTrip`.

## Change

- Neutralize the vector at the source: `sanitizeURL` now runs its result through a new `stripControlChars` helper that removes ASCII control characters (`< 0x20` and `0x7f`), including CR and LF.
- Added `TestSanitizeURL_StripsControlChars` covering a URL with embedded `%0d%0a` and `%00`.

## Validation

- `gofmt -l` clean
- `go build ./pkg/httputil/` ✅
- `go vet ./pkg/httputil/` ✅
- `go test ./pkg/httputil/` ✅ (all `TestSanitizeURL_*` pass)

Once merged to `main`, CodeQL alerts #5 and #6 will auto-close on the next scan.