### PR TITLE
feat(config): warn on misspelled DNSWEAVER_ environment prefixes (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 - **Proxmox interface selection improvements.** `DNSWEAVER_PROXMOX_ALLOWED_INTERFACES`
   now matches interface-name prefixes (so `eth` matches `eth0`), per-VM interface
   tags from `DNSWEAVER_PROXMOX_INTERFACE_TAG_PREFIX` override the allow-list,
   and if no allowed or tagged interface resolves, dnsweaver falls back to the
   first non-loopback IPv4 address rather than skipping the VM.
+- **Misspelled environment-prefix detection.** On startup dnsweaver scans the
+  environment for variables whose prefix closely resembles `DNSWEAVER_` but is
+  misspelled (for example `DNSWEVAER_CLOUDFLARE_TARGET_MODE`, with the `V` and
+  `A` transposed) and logs a warning naming the corrected variable. Such
+  variables were previously ignored silently and typically surfaced later as a
+  confusing "required but not set" error for the value the user believed they
+  had set. Only close misspellings of the prefix are flagged, so unrelated
+  environment variables and correctly prefixed keys are never reported.
+  ([GitHub #154](https://github.com/maxfield-allison/dnsweaver/issues/154))
+
+### Fixed
+- **Log injection via URLs in debug logs.** `sanitizeURL`, used when the HTTP
+  transport logs request and response URLs at debug level, redacted sensitive
+  query parameters but passed the rest of the URL through unchanged. A URL
+  carrying CR/LF or other control characters could forge or split a log entry.
+  The sanitizer now strips ASCII control characters from its output, resolving
+  the CodeQL `go/log-injection` alerts.
+  ([GitHub #155](https://github.com/maxfield-allison/dnsweaver/pull/155))
+
+### Changed
+- **Dependencies.** Bumped `prometheus/client_golang` to 1.24.1, `k8s.io/api`
+  and `k8s.io/client-go` to 0.36.3, and the `actions/setup-go` and
+  `actions/setup-python` CI actions to v7.
+  ([GitHub #153](https://github.com/maxfield-allison/dnsweaver/pull/153),
+  [#150](https://github.com/maxfield-allison/dnsweaver/pull/150),
+  [#151](https://github.com/maxfield-allison/dnsweaver/pull/151))
 
 ## [2.6.0] - 2026-07-15
 

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -61,6 +61,12 @@ func main() {
 		}
 	}
 
+	// Surface environment variables with a misspelled DNSWEAVER prefix (e.g.
+	// DNSWEVAER_...) before loading config. Such variables are silently ignored
+	// and otherwise show up only as a confusing "required but not set" error for
+	// the value the user thought they had set.
+	config.WarnOnMisspelledEnvPrefixes(slog.Default())
+
 	// Also check DNSWEAVER_VALIDATE_ONLY env var for container-based validation
 	if parseBoolEnv("DNSWEAVER_VALIDATE_ONLY") {
 		validateOnly = boolPtr(true)

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -324,3 +324,25 @@ See the individual provider documentation for complete settings:
 - [Webhook](../providers/webhook.md)
 
 For Kubernetes source configuration, see [Kubernetes Source](../sources/kubernetes.md).
+
+## Troubleshooting
+
+### Misspelled `DNSWEAVER_` prefix
+
+Every dnsweaver variable begins with the exact prefix `DNSWEAVER_`. A variable
+whose prefix is misspelled (for example `DNSWEVAER_CLOUDFLARE_TARGET_MODE`, with
+the `V` and `A` transposed) is not recognized and is silently ignored, which
+usually surfaces later as a confusing "required but not set" error for the value
+you thought you had set.
+
+On startup dnsweaver scans the environment for prefixes that closely resemble
+`DNSWEAVER_` but are misspelled and logs a warning with the corrected name:
+
+```
+WARN environment variable has a misspelled DNSWEAVER prefix and will be ignored
+     variable=DNSWEVAER_CLOUDFLARE_TARGET_MODE
+     did_you_mean=DNSWEAVER_CLOUDFLARE_TARGET_MODE
+```
+
+If you see this warning, fix the spelling of the variable name. Correctly
+prefixed but otherwise unknown variables are not flagged.

--- a/internal/config/envcheck.go
+++ b/internal/config/envcheck.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// canonicalEnvPrefix is the correct first segment of every dnsweaver
+// environment variable (the part before the first underscore). All config keys
+// take the form DNSWEAVER_... — see DECISIONS.md.
+const canonicalEnvPrefix = "DNSWEAVER"
+
+// maxPrefixTypoDistance is the largest Levenshtein distance from
+// canonicalEnvPrefix that is still treated as an obvious misspelling. Two edits
+// covers the common cases (a transposition, a dropped letter, a doubled letter)
+// while staying far away from any unrelated environment variable.
+const maxPrefixTypoDistance = 2
+
+// WarnOnMisspelledEnvPrefixes scans the process environment for variables whose
+// first underscore-delimited segment closely resembles the DNSWEAVER prefix but
+// is misspelled (for example DNSWEVAER_CLOUDFLARE_TARGET_MODE instead of
+// DNSWEAVER_CLOUDFLARE_TARGET_MODE).
+//
+// Such a variable is silently ignored during config loading, which typically
+// surfaces later as a confusing "required but not set" error for the value the
+// user believed they had provided. Emitting a warning here makes the typo
+// obvious and points at the intended variable name.
+//
+// Only segments within a small edit distance of the canonical prefix are
+// reported, so ordinary environment variables (PATH, HOME, DOCKER_HOST, ...)
+// are never flagged. A nil logger falls back to slog.Default().
+func WarnOnMisspelledEnvPrefixes(logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	for _, env := range os.Environ() {
+		name, _, ok := strings.Cut(env, "=")
+		if !ok {
+			continue
+		}
+
+		segment, rest, ok := strings.Cut(name, "_")
+		if !ok || rest == "" {
+			// No underscore, or nothing after it: not a DNSWEAVER_<KEY> shape.
+			continue
+		}
+		if segment == canonicalEnvPrefix {
+			// Correctly prefixed — either consumed or an as-yet-unknown key,
+			// neither of which this check is responsible for.
+			continue
+		}
+		if !looksLikePrefixTypo(segment) {
+			continue
+		}
+
+		logger.Warn("environment variable has a misspelled DNSWEAVER prefix and will be ignored",
+			slog.String("variable", name),
+			slog.String("did_you_mean", canonicalEnvPrefix+"_"+rest),
+		)
+	}
+}
+
+// looksLikePrefixTypo reports whether segment is almost certainly a misspelling
+// of canonicalEnvPrefix: an all-uppercase-letter token of roughly the same
+// length that is within maxPrefixTypoDistance edits, but not an exact match.
+//
+// The length window and letter-only guard make unrelated prefixes such as
+// DOCKER, K8S or KUBERNETES cheap to reject before computing edit distance.
+func looksLikePrefixTypo(segment string) bool {
+	if segment == "" || segment == canonicalEnvPrefix {
+		return false
+	}
+	if len(segment) < len(canonicalEnvPrefix)-maxPrefixTypoDistance ||
+		len(segment) > len(canonicalEnvPrefix)+maxPrefixTypoDistance {
+		return false
+	}
+	for i := 0; i < len(segment); i++ {
+		if c := segment[i]; c < 'A' || c > 'Z' {
+			return false
+		}
+	}
+	return levenshtein(segment, canonicalEnvPrefix) <= maxPrefixTypoDistance
+}
+
+// levenshtein returns the edit distance between two ASCII strings using the
+// standard two-row dynamic programming formulation.
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}

--- a/internal/config/envcheck_test.go
+++ b/internal/config/envcheck_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLooksLikePrefixTypo(t *testing.T) {
+	tests := []struct {
+		segment string
+		want    bool
+	}{
+		// Genuine misspellings of DNSWEAVER (distance 1-2).
+		{"DNSWEVAER", true},  // transposed A/V (the #130 typo)
+		{"DNSWEAER", true},   // dropped V
+		{"DNSWAEVER", true},  // transposed A/E
+		{"DNSWEAVR", true},   // dropped E
+		{"DNSWEAVERR", true}, // doubled R
+
+		// Exact prefix is not a typo.
+		{"DNSWEAVER", false},
+
+		// Unrelated prefixes.
+		{"DOCKER", false},
+		{"KUBERNETES", false},
+		{"PATH", false},
+		{"HOME", false},
+		{"", false},
+
+		// Right length but not letters-only, or too far away.
+		{"DNSWEAVE1", false},
+		{"COMPLETELY", false},
+	}
+
+	for _, tt := range tests {
+		if got := looksLikePrefixTypo(tt.segment); got != tt.want {
+			t.Errorf("looksLikePrefixTypo(%q) = %v, want %v", tt.segment, got, tt.want)
+		}
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"abc", "abc", 0},
+		{"DNSWEAVER", "DNSWEVAER", 2},
+		{"DNSWEAVER", "DNSWEAER", 1},
+		{"kitten", "sitting", 3},
+	}
+	for _, tt := range tests {
+		if got := levenshtein(tt.a, tt.b); got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+// captureWarnings runs WarnOnMisspelledEnvPrefixes against a JSON logger backed
+// by a buffer and returns the decoded log records.
+func captureWarnings(t *testing.T) []map[string]any {
+	t.Helper()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	WarnOnMisspelledEnvPrefixes(logger)
+
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("failed to decode log line %q: %v", line, err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
+func TestWarnOnMisspelledEnvPrefixes_FlagsMisspelledPrefix(t *testing.T) {
+	// The exact scenario reported in issue #130.
+	t.Setenv("DNSWEVAER_CLOUDFLARE_TARGET_MODE", "public")
+
+	records := captureWarnings(t)
+
+	var found bool
+	for _, rec := range records {
+		if rec["variable"] == "DNSWEVAER_CLOUDFLARE_TARGET_MODE" {
+			found = true
+			if got, want := rec["did_you_mean"], "DNSWEAVER_CLOUDFLARE_TARGET_MODE"; got != want {
+				t.Errorf("did_you_mean = %v, want %v", got, want)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning for the misspelled prefix, got records: %v", records)
+	}
+}
+
+func TestWarnOnMisspelledEnvPrefixes_IgnoresValidAndUnrelated(t *testing.T) {
+	t.Setenv("DNSWEAVER_CLOUDFLARE_TARGET_MODE", "public") // correct prefix
+	t.Setenv("DOCKER_HOST", "unix:///var/run/docker.sock") // unrelated
+	t.Setenv("DNSWEAVER_INSTANCES", "cloudflare")          // correct prefix
+
+	for _, rec := range captureWarnings(t) {
+		if v, ok := rec["variable"].(string); ok && strings.HasPrefix(v, "DNSWEAVER_") {
+			t.Errorf("correctly prefixed variable %q should not be flagged", v)
+		}
+		if rec["variable"] == "DOCKER_HOST" {
+			t.Errorf("unrelated variable DOCKER_HOST should not be flagged")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #154 (follow-up from #130).

A `DNSWEAVER_` variable whose **prefix** is misspelled — e.g. `DNSWEVAER_CLOUDFLARE_TARGET_MODE` (the `V` and `A` transposed, the exact case reported in #130) — is silently ignored during config loading. It then typically surfaces as a confusing downstream error like `DNSWEAVER_CLOUDFLARE_TARGET: required but not set`, pointing at the wrong thing.

## Change

- New `config.WarnOnMisspelledEnvPrefixes` scans `os.Environ()` for a first underscore-delimited segment that is within a small Levenshtein distance (≤2) of `DNSWEAVER` but not an exact match, and logs a warning naming the corrected variable:
  ```
  WARN environment variable has a misspelled DNSWEAVER prefix and will be ignored
       variable=DNSWEVAER_CLOUDFLARE_TARGET_MODE
       did_you_mean=DNSWEAVER_CLOUDFLARE_TARGET_MODE
  ```
- A length window and a letters-only guard reject unrelated prefixes (`PATH`, `HOME`, `DOCKER`, `KUBERNETES`, ...) cheaply before computing edit distance.
- Correctly prefixed but otherwise unknown keys are intentionally **not** flagged (no fragile central key registry to maintain, so no false positives on new/valid keys).
- Wired into `main()` **before** `config.Load()` so it surfaces even when the resulting config error is fatal (the #130 scenario).
- Documented under a new Troubleshooting section in `docs/configuration/environment.md`.
- CHANGELOG updated (also records the already-merged log-injection fix #155 and the dependency bumps for this release).

## Why not "warn on any unknown `DNSWEAVER_` var"

The original #130 bug was a *misspelled prefix*, which by definition is not `DNSWEAVER_`-prefixed, so an unknown-key check would never have caught it. There is also no central registry of valid keys (per-instance keys are dynamic, `DNSWEAVER_<NAME>_<KEY>`), so an unknown-key check would be prone to false positives. Prefix near-miss detection targets the actual failure mode with essentially zero false-positive risk.

## Validation

- `gofmt -l` clean
- `go build ./cmd/dnsweaver/ ./internal/config/` ✅
- `go vet ./internal/config/` ✅
- `go test -race ./internal/config/` ✅ — new tests: `TestLooksLikePrefixTypo`, `TestLevenshtein`, `TestWarnOnMisspelledEnvPrefixes_FlagsMisspelledPrefix`, `TestWarnOnMisspelledEnvPrefixes_IgnoresValidAndUnrelated`