### PR TITLE
fix(config): honor TARGET_MODE in provider validation (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dynamic target modes were rejected at startup.** A provider instance
+  configured with `DNSWEAVER_{NAME}_TARGET_MODE` (`public` or `interface:<name>`)
+  but no static `DNSWEAVER_{NAME}_TARGET` failed provider initialization with
+  `target: required but not set`. Config loading accepted the mode, but the
+  target mode was dropped before provider validation, which still required a
+  literal target — so the feature's primary use case (resolve the target
+  dynamically, no static IP) never started. The target mode now flows through to
+  provider validation, which treats `TARGET` as an optional fallback whenever a
+  mode is set. A static fallback, when provided, is still checked against the
+  record type. ([GitHub #130](https://github.com/maxfield-allison/dnsweaver/issues/130))
+
 ## [2.7.0] - 2026-07-28
 
 ### Added

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -342,6 +342,7 @@ func TestProviderInstanceConfig_ToProviderConfig(t *testing.T) {
 		TypeName:       "technitium",
 		RecordType:     provider.RecordTypeA,
 		Target:         "10.0.0.1",
+		TargetMode:     "public",
 		TTL:            300,
 		Domains:        []string{"*.example.com"},
 		ExcludeDomains: []string{"admin.example.com"},
@@ -361,6 +362,9 @@ func TestProviderInstanceConfig_ToProviderConfig(t *testing.T) {
 	}
 	if provCfg.Target != cfg.Target {
 		t.Errorf("Target = %q, want %q", provCfg.Target, cfg.Target)
+	}
+	if provCfg.TargetMode != cfg.TargetMode {
+		t.Errorf("TargetMode = %q, want %q", provCfg.TargetMode, cfg.TargetMode)
 	}
 	if provCfg.TTL != cfg.TTL {
 		t.Errorf("TTL = %d, want %d", provCfg.TTL, cfg.TTL)

--- a/internal/config/instance.go
+++ b/internal/config/instance.go
@@ -73,6 +73,7 @@ func (c *ProviderInstanceConfig) ToProviderConfig() provider.ProviderInstanceCon
 		TypeName:            c.TypeName,
 		RecordType:          c.RecordType,
 		Target:              c.Target,
+		TargetMode:          c.TargetMode,
 		TTL:                 c.TTL,
 		Mode:                c.Mode,
 		Domains:             c.Domains,

--- a/pkg/provider/instance.go
+++ b/pkg/provider/instance.go
@@ -551,6 +551,13 @@ type ProviderInstanceConfig struct {
 	// Target is the IP or hostname target for records.
 	Target string
 
+	// TargetMode, when non-empty, signals that Target is resolved dynamically
+	// at runtime (DNSWEAVER_{NAME}_TARGET_MODE, e.g. "public" or
+	// "interface:<name>"). In that case Target is optional and acts only as a
+	// fallback until the first successful resolution, so Validate does not
+	// require it. Empty means Target is used verbatim and is required.
+	TargetMode string
+
 	// TTL is the record TTL in seconds.
 	TTL int
 
@@ -592,19 +599,27 @@ func (c *ProviderInstanceConfig) Validate() error {
 	if c.RecordType != RecordTypeA && c.RecordType != RecordTypeAAAA && c.RecordType != RecordTypeCNAME {
 		return ErrConfigInvalid("record_type", string(c.RecordType), "must be A, AAAA, or CNAME")
 	}
-	if c.Target == "" {
-		return ErrConfigMissing("target")
-	}
 
-	// Validate target matches record type
-	if c.RecordType == RecordTypeCNAME && isIPAddress(c.Target) {
-		return ErrConfigInvalid("target", c.Target, "CNAME records cannot point to IP addresses; use record_type=A or AAAA for IP targets")
-	}
-	if c.RecordType == RecordTypeA && !isIPv4Address(c.Target) {
-		return ErrConfigInvalid("target", c.Target, "A records must point to IPv4 addresses; use record_type=AAAA for IPv6 or CNAME for hostnames")
-	}
-	if c.RecordType == RecordTypeAAAA && !isIPv6Address(c.Target) {
-		return ErrConfigInvalid("target", c.Target, "AAAA records must point to IPv6 addresses; use record_type=A for IPv4 or CNAME for hostnames")
+	// Target is required unless a dynamic TargetMode is configured, in which
+	// case it is resolved at runtime and Target (when set) is only a fallback.
+	// When a fallback Target is provided alongside a mode we still type-check
+	// it below; when it is empty the runtime resolver is family-aware and
+	// validates its own output, so there is nothing to check here.
+	if c.Target == "" {
+		if c.TargetMode == "" {
+			return ErrConfigMissing("target")
+		}
+	} else {
+		// Validate target matches record type.
+		if c.RecordType == RecordTypeCNAME && isIPAddress(c.Target) {
+			return ErrConfigInvalid("target", c.Target, "CNAME records cannot point to IP addresses; use record_type=A or AAAA for IP targets")
+		}
+		if c.RecordType == RecordTypeA && !isIPv4Address(c.Target) {
+			return ErrConfigInvalid("target", c.Target, "A records must point to IPv4 addresses; use record_type=AAAA for IPv6 or CNAME for hostnames")
+		}
+		if c.RecordType == RecordTypeAAAA && !isIPv6Address(c.Target) {
+			return ErrConfigInvalid("target", c.Target, "AAAA records must point to IPv6 addresses; use record_type=A for IPv4 or CNAME for hostnames")
+		}
 	}
 
 	if c.TTL < 1 {

--- a/pkg/provider/instance_test.go
+++ b/pkg/provider/instance_test.go
@@ -248,6 +248,65 @@ func TestProviderInstanceConfig_Validate_Complete(t *testing.T) {
 	}
 }
 
+func TestProviderInstanceConfig_Validate_TargetMode_NoTarget(t *testing.T) {
+	// Regression for #130: when a dynamic TARGET_MODE is set, TARGET is
+	// resolved at runtime and must not be required at validation time.
+	cfg := ProviderInstanceConfig{
+		Name:       "cloudflare",
+		TypeName:   "cloudflare",
+		RecordType: RecordTypeA,
+		Target:     "", // resolved dynamically via TargetMode
+		TargetMode: "public",
+		TTL:        300,
+		Domains:    []string{"*.example.com"},
+		ProviderConfig: map[string]string{
+			"zone_id": "abc123",
+		},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected valid config with TargetMode and no Target, got error: %v", err)
+	}
+}
+
+func TestProviderInstanceConfig_Validate_TargetMode_WithFallback(t *testing.T) {
+	// A static fallback Target alongside a mode is still type-checked.
+	valid := ProviderInstanceConfig{
+		Name:           "cloudflare",
+		TypeName:       "cloudflare",
+		RecordType:     RecordTypeA,
+		Target:         "203.0.113.10", // valid IPv4 fallback
+		TargetMode:     "public",
+		TTL:            300,
+		Domains:        []string{"*.example.com"},
+		ProviderConfig: map[string]string{"zone_id": "abc123"},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Errorf("expected valid config with fallback Target, got error: %v", err)
+	}
+
+	invalid := valid
+	invalid.Target = "not-an-ip" // fallback must still match record type
+	if err := invalid.Validate(); err == nil {
+		t.Error("expected error for non-IPv4 fallback Target on an A record, got nil")
+	}
+}
+
+func TestProviderInstanceConfig_Validate_NoTargetNoMode(t *testing.T) {
+	// Without a mode, TARGET remains required.
+	cfg := ProviderInstanceConfig{
+		Name:           "cloudflare",
+		TypeName:       "cloudflare",
+		RecordType:     RecordTypeA,
+		TTL:            300,
+		Domains:        []string{"*.example.com"},
+		ProviderConfig: map[string]string{"zone_id": "abc123"},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected 'target required' error when neither Target nor TargetMode is set, got nil")
+	}
+}
+
 func TestProviderInstanceConfig_Validate_CNAME_Complete(t *testing.T) {
 	// Test a complete valid CNAME configuration
 	cfg := ProviderInstanceConfig{


### PR DESCRIPTION
## Summary

Fixes #130. A provider instance configured with a dynamic target mode but **no** static target — the feature's main use case — failed to start.

Reported on [#130](https://github.com/maxfield-allison/dnsweaver/issues/130#issuecomment-5104583432):

```
error="initializing providers: invalid provider config cloudflare: ... target: required but not set"
```

with:

```yaml
- DNSWEAVER_CLOUDFLARE_TARGET_MODE=public
# no DNSWEAVER_CLOUDFLARE_TARGET
```

## Root cause

Two validation layers, only one was target-mode-aware:

1. `internal/config` validation already treats `TARGET` as optional when `TARGET_MODE` is set → config load passes.
2. `ToProviderConfig()` then built a `provider.ProviderInstanceConfig` that **had no `TargetMode` field**, so the mode was silently dropped. `provider.ProviderInstanceConfig.Validate()` (run during `InitializeProvider`) still hard-required a literal `Target` → **fatal**.

Provider initialization runs *before* the dynamic target refresher resolves anything (the refresher resolves post-registration and applies via `SetDynamicTarget`), so requiring a literal target at validation time made `public` / `interface:<name>` unusable without also hardcoding the very IP the feature exists to avoid.

## Change

- Added a `TargetMode` field to `provider.ProviderInstanceConfig` and pass it through in `ToProviderConfig()`.
- `Validate()` now treats `Target` as an optional fallback whenever `TargetMode` is set. A static fallback, when provided, is still type-checked against the record type. With no mode set, `Target` remains required (unchanged behavior).

## Tests

- `TestProviderInstanceConfig_Validate_TargetMode_NoTarget` — mode set, empty target → valid (the regression).
- `TestProviderInstanceConfig_Validate_TargetMode_WithFallback` — typed fallback accepted; bad fallback still rejected.
- `TestProviderInstanceConfig_Validate_NoTargetNoMode` — unchanged "target required" path.
- Extended `TestProviderInstanceConfig_ToProviderConfig` to assert `TargetMode` passthrough.

Validated: `gofmt` clean, `go build`, `go test -race ./pkg/provider/ ./internal/config/` all pass.