### PR TITLE
fix(reconciler)+feat(cloudflare): hint-precedence collisions + non-routable proxy auto-disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Cloudflare auto-disables proxying for non-routable targets.** An A/AAAA
+  record whose target is a private or otherwise non-routable IP (RFC1918,
+  loopback, link-local, IPv4 CGNAT `100.64.0.0/10`, IPv6 ULA `fc00::/7`, the
+  unspecified address) can never be proxied by Cloudflare — it rejects such
+  records with error `9003`. dnsweaver now detects this and creates the record
+  unproxied instead of failing, logging a warning that names the target. An
+  explicit per-record `proxied=true` on such a target is still demoted (it could
+  only ever error), with a louder warning noting the override. CNAME targets are
+  left untouched, since their routability can't be determined without a runtime
+  lookup. This makes the `proxied` label unnecessary for internal records.
+  ([GitHub #161](https://github.com/maxfield-allison/dnsweaver/issues/161))
+
 ### Fixed
 - **Source collision could drop a per-record `proxied` override.** When one
   workload exposed the same hostname via both a Traefik router rule and a native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Source collision could drop a per-record `proxied` override.** When one
+  workload exposed the same hostname via both a Traefik router rule and a native
+  `dnsweaver.records.<name>.*` label, deduplication kept whichever source was
+  listed first in `DNSWEAVER_SOURCES` rather than the more specific declaration.
+  Because the Traefik source carries no per-record hints, a native
+  `proxied=false` override (and its target) was silently discarded whenever
+  Traefik was registered first, causing the provider default to apply — e.g. a
+  Cloudflare `9003` error for a proxied record pointing at a private IP.
+  Hostname collisions on a single workload are now resolved by explicit hint
+  precedence: a candidate carrying record hints wins over one without,
+  regardless of source ordering, and instance-selection metadata from the losing
+  candidate is preserved. Same-workload multi-source declarations are no longer
+  counted or warned as cross-workload duplicates.
+  ([GitHub #159](https://github.com/maxfield-allison/dnsweaver/issues/159))
+
 ## [2.7.1] - 2026-07-28
 
 ### Fixed

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/maxfield-allison/dnsweaver/pkg/provider"
 	"github.com/maxfield-allison/dnsweaver/pkg/source"
 	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+	dnsweaversrc "github.com/maxfield-allison/dnsweaver/sources/dnsweaver"
 	"github.com/maxfield-allison/dnsweaver/sources/traefik"
 )
 
@@ -389,6 +390,90 @@ func TestReconcile_DuplicateHostnameAcrossWorkloads(t *testing.T) {
 	created := mockProvider.GetCreatedDNSRecords()
 	if len(created) != 1 {
 		t.Errorf("expected 1 DNS record (not 2), got %d", len(created))
+	}
+}
+
+// TestReconcile_SourceCollision_NativeHintsWinRegardlessOfOrder verifies that
+// when a single workload declares the same hostname via both a Traefik router
+// rule (which carries no per-record hints) and a native dnsweaver record (which
+// carries an explicit proxied=false hint), the explicit hint always wins — no
+// matter which source is registered first. Regression test for issue #159.
+func TestReconcile_SourceCollision_NativeHintsWinRegardlessOfOrder(t *testing.T) {
+	registerOrders := []struct {
+		name  string
+		first string // which source is registered first
+	}{
+		{name: "traefik_first", first: "traefik"},
+		{name: "dnsweaver_first", first: "dnsweaver"},
+	}
+
+	for _, tc := range registerOrders {
+		t.Run(tc.name, func(t *testing.T) {
+			// One container exposes the same hostname via a Traefik rule AND a
+			// native dnsweaver record that overrides proxied to false with a
+			// non-proxiable target.
+			dockerMock := newTestMockWorkloadLister(workload.PlatformDocker)
+			dockerMock.AddWorkload("zerobyte", map[string]string{
+				"traefik.http.routers.zerobyte.rule": "Host(`app.example.com`)",
+				"dnsweaver.records.primary.hostname": "app.example.com",
+				"dnsweaver.records.primary.proxied":  "false",
+				"dnsweaver.records.primary.target":   "192.0.2.144",
+			})
+
+			logger := quietLogger()
+
+			sources := source.NewRegistry(logger)
+			if tc.first == "traefik" {
+				sources.Register(traefik.New(traefik.WithLogger(logger)))
+				sources.Register(dnsweaversrc.New(dnsweaversrc.WithLogger(logger)))
+			} else {
+				sources.Register(dnsweaversrc.New(dnsweaversrc.WithLogger(logger)))
+				sources.Register(traefik.New(traefik.WithLogger(logger)))
+			}
+
+			mockProvider := newTestMockProvider("test-dns")
+			providers := provider.NewRegistry(logger)
+			providers.RegisterFactory("mock", func(_ provider.FactoryConfig) (provider.Provider, error) {
+				return mockProvider, nil
+			})
+			_ = providers.CreateInstance(provider.ProviderInstanceConfig{
+				Name:       "test-dns",
+				TypeName:   "mock",
+				RecordType: provider.RecordTypeA,
+				Target:     "10.0.0.1",
+				TTL:        300,
+				Domains:    []string{"*.example.com"},
+			})
+
+			r := New([]workload.Lister{dockerMock}, sources, providers,
+				WithConfig(DefaultConfig()),
+				WithLogger(logger),
+			)
+
+			result, err := r.Reconcile(context.Background())
+			if err != nil {
+				t.Fatalf("Reconcile returned error: %v", err)
+			}
+
+			// The collision is on a single workload, so it must not be counted
+			// as a cross-workload duplicate.
+			if result.HostnamesDuplicate != 0 {
+				t.Errorf("HostnamesDuplicate = %d, want 0 (same-workload multi-source is not a duplicate)", result.HostnamesDuplicate)
+			}
+
+			created := mockProvider.GetCreatedDNSRecords()
+			if len(created) != 1 {
+				t.Fatalf("expected exactly 1 DNS record, got %d", len(created))
+			}
+
+			rec := created[0]
+			if rec.Metadata["proxied"] != "false" {
+				t.Errorf("explicit per-record proxied override was dropped: Metadata[proxied] = %q, want %q", rec.Metadata["proxied"], "false")
+			}
+			if rec.Target != "192.0.2.144" {
+				t.Errorf("native record target was not applied: Target = %q, want %q", rec.Target, "192.0.2.144")
+			}
+		})
 	}
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -318,18 +318,41 @@ func (r *Reconciler) extractHostnames(ctx context.Context, workloads []workload.
 			hostname := &hostnames[i]
 			// Use normalized (lowercase) name as key for case-insensitive comparison (RFC 1035)
 			normalizedName := hostname.NormalizedName()
-			if existingWorkload, exists := hostnameOrigins[normalizedName]; exists {
-				// Duplicate hostname detected
+			existingWorkload, exists := hostnameOrigins[normalizedName]
+			if !exists {
+				hostnameOrigins[normalizedName] = w.Name
+				discoveredHostnames[normalizedName] = hostname
+				continue
+			}
+
+			// A hostname collision. Resolve it by explicit precedence rather than
+			// by source-registration order: a candidate carrying per-record hints
+			// (e.g. native dnsweaver labels with proxied=false) wins over one that
+			// carries none (e.g. a Traefik router rule), so the more specific
+			// declaration is never silently dropped. See issue #159.
+			winner := mergeDuplicateHostname(discoveredHostnames[normalizedName], hostname)
+			discoveredHostnames[normalizedName] = winner
+
+			if existingWorkload != w.Name {
+				// Genuine cross-workload collision: two different workloads claim
+				// the same hostname. This usually signals a misconfiguration.
 				r.logger.Warn("duplicate hostname found in multiple workloads",
 					slog.String("hostname", hostname.Name),
 					slog.String("first_workload", existingWorkload),
 					slog.String("duplicate_workload", w.Name),
+					slog.String("selected_source", winner.Source),
 				)
 				result.HostnamesDuplicate++
-				// First workload wins - don't update hostnameOrigins
 			} else {
-				hostnameOrigins[normalizedName] = w.Name
-				discoveredHostnames[normalizedName] = hostname
+				// The same workload declared this hostname via multiple sources
+				// (e.g. a Traefik rule and a native dnsweaver record). This is a
+				// supported pattern, not an error — hint precedence decides which
+				// declaration wins.
+				r.logger.Debug("hostname declared by multiple sources on one workload; applying hint precedence",
+					slog.String("hostname", hostname.Name),
+					slog.String("workload", w.Name),
+					slog.String("selected_source", winner.Source),
+				)
 			}
 		}
 	}
@@ -358,13 +381,56 @@ func (r *Reconciler) extractHostnames(ctx context.Context, workloads []workload.
 			hostname := &fileHostnames[i]
 			// Use normalized (lowercase) name as key for case-insensitive comparison (RFC 1035)
 			normalizedName := hostname.NormalizedName()
-			if _, exists := discoveredHostnames[normalizedName]; !exists {
+			if existing, exists := discoveredHostnames[normalizedName]; !exists {
 				discoveredHostnames[normalizedName] = hostname
+			} else {
+				// Apply the same hint precedence as workload extraction so a
+				// file-declared record with explicit hints is not shadowed by a
+				// hint-less label collision (and vice versa). See issue #159.
+				discoveredHostnames[normalizedName] = mergeDuplicateHostname(existing, hostname)
 			}
 		}
 	}
 
 	return discoveredHostnames
+}
+
+// mergeDuplicateHostname resolves a collision between an already-selected
+// hostname and a newly discovered duplicate of the same (normalized) name.
+//
+// Precedence is explicit and independent of source registration order: the
+// candidate carrying per-record hints (RecordHints, e.g. a native dnsweaver
+// record with proxied=false) wins over one without (e.g. a Traefik router rule
+// that only yields a bare hostname). When neither or both carry hints, the
+// existing selection is kept for determinism. Instance-selection metadata from
+// the losing candidate is preserved on the winner so provider-instance
+// filtering (e.g. Traefik entrypoints) still applies. See issue #159.
+func mergeDuplicateHostname(existing, candidate *source.Hostname) *source.Hostname {
+	winner, loser := existing, candidate
+	if existing.RecordHints == nil && candidate.RecordHints != nil {
+		winner, loser = candidate, existing
+	}
+	winner.Metadata = mergeInstanceMetadata(winner.Metadata, loser.Metadata)
+	return winner
+}
+
+// mergeInstanceMetadata returns the union of two instance-selection metadata
+// maps. The winner's existing keys take precedence; the loser only fills gaps.
+// The winner map is returned (possibly newly allocated); neither input's
+// existing values are overwritten.
+func mergeInstanceMetadata(winner, loser map[string]string) map[string]string {
+	if len(loser) == 0 {
+		return winner
+	}
+	if winner == nil {
+		winner = make(map[string]string, len(loser))
+	}
+	for k, v := range loser {
+		if _, ok := winner[k]; !ok {
+			winner[k] = v
+		}
+	}
+	return winner
 }
 
 // ReconcileHostname performs reconciliation for a single hostname.

--- a/providers/cloudflare/provider.go
+++ b/providers/cloudflare/provider.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/maxfield-allison/dnsweaver/pkg/provider"
@@ -464,23 +466,80 @@ var _ provider.Updater = (*Provider)(nil)
 // resolveProxied determines the effective proxied state for a record.
 // Priority order:
 //  1. TXT/SRV records are never proxied (Cloudflare limitation)
-//  2. Per-record Metadata["proxied"] override (if present)
-//  3. Provider-level config default (p.proxied)
+//  2. Per-record Metadata["proxied"] override, else provider-level default
+//  3. A/AAAA records whose target is a non-routable IP are forced unproxied,
+//     because Cloudflare rejects proxying such targets with error 9003. This
+//     overrides both the default and an explicit proxied=true (a louder
+//     warning is logged in the explicit case).
 func (p *Provider) resolveProxied(record provider.Record) bool {
 	// TXT and SRV records cannot be proxied by Cloudflare
 	if record.Type == provider.RecordTypeTXT || record.Type == provider.RecordTypeSRV {
 		return false
 	}
 
-	// Check per-record metadata override
+	// Determine the requested proxied state and whether it was set explicitly
+	// via a per-record hint (vs inherited from the provider default).
+	proxied := p.proxied
+	explicit := false
 	if record.Metadata != nil {
 		if v, ok := record.Metadata["proxied"]; ok {
-			return parseBool(v)
+			proxied = parseBool(v)
+			explicit = true
 		}
 	}
 
-	// Fall back to provider-level default
-	return p.proxied
+	// Cloudflare cannot proxy a non-routable target; honoring proxied=true here
+	// can only ever produce a 9003 API error. Demote to unproxied and explain.
+	if proxied && isNonRoutableTarget(record) {
+		if explicit {
+			p.logger.Warn("overriding explicit proxied=true: Cloudflare cannot proxy a non-routable target; creating record unproxied",
+				slog.String("provider", p.name),
+				slog.String("hostname", record.Hostname),
+				slog.String("type", string(record.Type)),
+				slog.String("target", record.Target),
+			)
+		} else {
+			p.logger.Warn("auto-disabling Cloudflare proxy: target is not publicly routable",
+				slog.String("provider", p.name),
+				slog.String("hostname", record.Hostname),
+				slog.String("type", string(record.Type)),
+				slog.String("target", record.Target),
+			)
+		}
+		return false
+	}
+
+	return proxied
+}
+
+// isNonRoutableTarget reports whether the record's target is a literal IP that
+// Cloudflare cannot proxy. Only A and AAAA records are considered; CNAME
+// targets are hostnames and are left to the explicit hint / provider default,
+// since deciding their routability would require runtime DNS lookups.
+//
+// "Non-routable" here is Cloudflare-specific: RFC1918, loopback, link-local,
+// the unspecified address, IPv6 ULA (fc00::/7), and IPv4 CGNAT
+// (100.64.0.0/10, RFC 6598). CGNAT is intentionally included because it is not
+// publicly reachable, even though other parts of dnsweaver (e.g. the Incus IP
+// resolver) deliberately keep CGNAT for Tailscale targets — different context,
+// different call.
+func isNonRoutableTarget(record provider.Record) bool {
+	if record.Type != provider.RecordTypeA && record.Type != provider.RecordTypeAAAA {
+		return false
+	}
+	ip := net.ParseIP(strings.TrimSpace(record.Target))
+	if ip == nil {
+		return false
+	}
+	// IsPrivate covers IPv4 RFC1918 and IPv6 ULA (fc00::/7).
+	if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+		return true
+	}
+	// IPv4 CGNAT 100.64.0.0/10 (RFC 6598) is not covered by IsPrivate().
+	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+		return true
+	}
+	return false
 }
 
 // proxiedMetadata returns a Metadata map with the proxied state.

--- a/providers/cloudflare/provider_test.go
+++ b/providers/cloudflare/provider_test.go
@@ -3,6 +3,8 @@ package cloudflare
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -321,7 +323,7 @@ func TestProvider_Create_WithProxied(t *testing.T) {
 	record := provider.Record{
 		Hostname: "proxy.example.com",
 		Type:     provider.RecordTypeA,
-		Target:   "10.0.0.1",
+		Target:   "203.0.113.10",
 	}
 
 	err := p.Create(context.Background(), record)
@@ -605,7 +607,7 @@ func TestProvider_Create_WithMetadataProxiedOverride(t *testing.T) {
 	record := provider.Record{
 		Hostname: "override.example.com",
 		Type:     provider.RecordTypeA,
-		Target:   "10.0.0.1",
+		Target:   "203.0.113.10",
 		TTL:      300,
 		Metadata: map[string]string{"proxied": "true"},
 	}
@@ -722,5 +724,140 @@ func TestProvider_List_PopulatesProxiedMetadata(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// newResolveProxiedProvider builds a minimal provider for resolveProxied unit
+// tests, with a given provider-level default and a discarding logger.
+func newResolveProxiedProvider(defaultProxied bool) *Provider {
+	return &Provider{
+		name:    "test-cf",
+		proxied: defaultProxied,
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestResolveProxied_NonRoutableTargetsDemoted(t *testing.T) {
+	// A/AAAA records whose target cannot be proxied by Cloudflare should be
+	// forced unproxied regardless of the provider default or an explicit hint.
+	nonRoutable := []struct {
+		name   string
+		typ    provider.RecordType
+		target string
+	}{
+		{"rfc1918_10", provider.RecordTypeA, "10.0.0.1"},
+		{"rfc1918_172", provider.RecordTypeA, "172.16.5.9"},
+		{"rfc1918_192", provider.RecordTypeA, "192.168.0.144"},
+		{"loopback_v4", provider.RecordTypeA, "127.0.0.1"},
+		{"linklocal_v4", provider.RecordTypeA, "169.254.1.1"},
+		{"unspecified_v4", provider.RecordTypeA, "0.0.0.0"},
+		{"cgnat_low", provider.RecordTypeA, "100.64.0.1"},
+		{"cgnat_high", provider.RecordTypeA, "100.127.255.254"},
+		{"ula_v6", provider.RecordTypeAAAA, "fd00::1"},
+		{"loopback_v6", provider.RecordTypeAAAA, "::1"},
+		{"linklocal_v6", provider.RecordTypeAAAA, "fe80::1"},
+	}
+
+	for _, tc := range nonRoutable {
+		t.Run(tc.name+"_default_true", func(t *testing.T) {
+			p := newResolveProxiedProvider(true)
+			rec := provider.Record{Hostname: "app.example.com", Type: tc.typ, Target: tc.target}
+			if p.resolveProxied(rec) {
+				t.Errorf("resolveProxied(%s %s) = true, want false (non-routable, default on)", tc.typ, tc.target)
+			}
+		})
+		t.Run(tc.name+"_explicit_true", func(t *testing.T) {
+			p := newResolveProxiedProvider(false)
+			rec := provider.Record{
+				Hostname: "app.example.com",
+				Type:     tc.typ,
+				Target:   tc.target,
+				Metadata: map[string]string{"proxied": "true"},
+			}
+			if p.resolveProxied(rec) {
+				t.Errorf("resolveProxied(%s %s, explicit true) = true, want false (non-routable overrides explicit)", tc.typ, tc.target)
+			}
+		})
+	}
+}
+
+func TestResolveProxied_RoutableAndOtherTypesUnchanged(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultProxied bool
+		record         provider.Record
+		want           bool
+	}{
+		{
+			name:           "public_v4_default_true",
+			defaultProxied: true,
+			record:         provider.Record{Type: provider.RecordTypeA, Target: "1.1.1.1"},
+			want:           true,
+		},
+		{
+			name:           "public_v4_default_false",
+			defaultProxied: false,
+			record:         provider.Record{Type: provider.RecordTypeA, Target: "1.1.1.1"},
+			want:           false,
+		},
+		{
+			name:           "public_v4_explicit_true",
+			defaultProxied: false,
+			record:         provider.Record{Type: provider.RecordTypeA, Target: "8.8.8.8", Metadata: map[string]string{"proxied": "true"}},
+			want:           true,
+		},
+		{
+			name:           "public_v6_default_true",
+			defaultProxied: true,
+			record:         provider.Record{Type: provider.RecordTypeAAAA, Target: "2606:4700:4700::1111"},
+			want:           true,
+		},
+		{
+			// CNAME targets are names, not IPs — never inferred, honor default/hint.
+			name:           "cname_private_looking_default_true",
+			defaultProxied: true,
+			record:         provider.Record{Type: provider.RecordTypeCNAME, Target: "internal.example.com"},
+			want:           true,
+		},
+		{
+			name:           "cname_explicit_false",
+			defaultProxied: true,
+			record:         provider.Record{Type: provider.RecordTypeCNAME, Target: "internal.example.com", Metadata: map[string]string{"proxied": "false"}},
+			want:           false,
+		},
+		{
+			// A record with a non-IP target (shouldn't happen, but must not panic).
+			name:           "a_record_non_ip_target",
+			defaultProxied: true,
+			record:         provider.Record{Type: provider.RecordTypeA, Target: "not-an-ip"},
+			want:           true,
+		},
+		{
+			name:           "txt_never_proxied",
+			defaultProxied: true,
+			record:         provider.Record{Type: provider.RecordTypeTXT, Target: "some text"},
+			want:           false,
+		},
+		{
+			name:           "srv_never_proxied",
+			defaultProxied: true,
+			record:         provider.Record{Type: provider.RecordTypeSRV, Target: "srv.example.com"},
+			want:           false,
+		},
+		{
+			name:           "explicit_false_public_target",
+			defaultProxied: true,
+			record:         provider.Record{Type: provider.RecordTypeA, Target: "1.1.1.1", Metadata: map[string]string{"proxied": "false"}},
+			want:           false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newResolveProxiedProvider(tc.defaultProxied)
+			if got := p.resolveProxied(tc.record); got != tc.want {
+				t.Errorf("resolveProxied() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #159, closes #161. Two related changes shipping in one release.

### 1. Reconciler: resolve source collisions by hint precedence (#159)

When one workload declared the same hostname via both a Traefik router rule and a native `dnsweaver.records.<name>.*` label, `extractHostnames()` deduplicated by `DNSWEAVER_SOURCES` registration order ("first source wins"). The Traefik source emits only a bare hostname with no `RecordHints`, so whenever it was registered first it shadowed the native record and the explicit per-record `proxied=false` (and target) override was silently dropped. The provider default (`proxied=true`) then applied, producing a Cloudflare `9003` error for a proxied record pointing at a private IP.

- Collisions on a single hostname are now resolved by **explicit hint precedence** instead of source-registration order: a candidate carrying `RecordHints` beats one without, regardless of `DNSWEAVER_SOURCES` ordering.
- Instance-selection `Metadata` from the losing candidate (e.g. Traefik entrypoints) is merged onto the winner so provider-instance filtering still works.
- A same-workload multi-source collision is a supported pattern and is no longer counted or warned as a cross-workload duplicate. Genuine cross-workload collisions still warn and increment `HostnamesDuplicate`.
- The same precedence is applied in the file-discovery merge path.

### 2. Cloudflare: auto-disable proxying for non-routable A/AAAA targets (#161)

Cloudflare rejects a proxied record whose target is a non-routable IP with error `9003`, so `proxied=true` on such a target can only ever fail. After #159, the user's explicit `proxied: false` works — but they shouldn't have to set it at all.

- `resolveProxied()` now detects A/AAAA records whose target is non-routable (RFC1918, loopback, link-local, IPv4 CGNAT `100.64.0.0/10`, IPv6 ULA `fc00::/7`, unspecified) and creates them unproxied, logging a warning naming the target. Default on, no flag.
- An explicit per-record `proxied=true` on a non-routable target is still demoted (it could only `9003` otherwise) but logs a **louder** warning noting the override, rather than silently flipping a deliberately-set value.
- CNAME is left untouched — the target is a name, not an IP, so routability can't be determined without a runtime lookup.
- Lives entirely in the Cloudflare provider; the reconciler stays provider-agnostic. The non-routable set deliberately includes CGNAT (not publicly routable), unlike the Incus IP resolver which keeps CGNAT for Tailscale targets.

## Tests

- `TestReconcile_SourceCollision_NativeHintsWinRegardlessOfOrder` runs both source orderings and asserts the record keeps `proxied=false` + the native target either way, and that the collision isn't counted as a duplicate.
- Table-driven `resolveProxied` tests cover each private/loopback/link-local/CGNAT/ULA class (v4 + v6) for both default-on and explicit-true, plus routable, CNAME, non-IP, TXT, and SRV cases.
- Two existing proxied-plumbing tests updated to use a public target so their `proxied=true` intent still holds.
- Full local suite green (`go build ./...`, `go vet`, `go test ./...`); `golangci-lint` clean.