### PR TITLE
fix(httputil): CR/LF log sanitizer barrier (CodeQL #5/#6) + .trivyignore refresh

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,11 +1,25 @@
 # Trivy CVE Ignore List for dnsweaver
 # https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#by-finding-ids
+#
+# All entries below are Docker Engine / Moby *daemon-side* vulnerabilities in
+# github.com/docker/docker v28.5.2 (the latest v28 release). dnsweaver imports
+# the Docker SDK as a read-only client (it lists container/service state and
+# watches events) and never runs a daemon, so these daemon-side code paths are
+# unreachable. govulncheck's call-graph analysis confirms this — it does not
+# report these as reachable. A stable fix exists only in github.com/moby/moby/v2
+# (pre-release beta as of this writing), which requires a full import-path
+# migration; there is nothing to bump to in the +incompatible v28.x module.
+# Review by: 2026-11-01 or when github.com/moby/moby/v2 reaches a stable release.
 
-# CVE-2026-34040: Docker Engine AuthZ plugin bypass in github.com/docker/docker v28.5.2
-# Fix available in v29.3.1 (github.com/moby/moby/v2), but:
-#   1. Only beta releases on Go proxy (v2.0.0-beta.0 through beta.8)
-#   2. Requires Go 1.25.5+ and full import path migration to moby/moby/v2
-#   3. CVE is a daemon-side AuthZ plugin bypass — dnsweaver is a client-only consumer
-#      that uses the Docker SDK to read container/service state (no AuthZ interaction)
-# Review by: 2026-07-01 or when moby/moby/v2 reaches stable release
+# CVE-2026-34040: Docker Engine AuthZ plugin bypass (oversized request bodies).
 CVE-2026-34040
+
+# CVE-2026-41567: Moby/Docker Engine arbitrary code execution via a malicious
+# container image and compressed layers. Daemon-side; unreachable from a
+# read-only SDK client. No fix in the v28.x github.com/docker/docker module.
+CVE-2026-41567
+
+# CVE-2026-42306: Moby host file overwrite via a race condition in container
+# archive handling. Daemon-side; unreachable from a read-only SDK client. No fix
+# in the v28.x github.com/docker/docker module.
+CVE-2026-42306

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -299,9 +299,19 @@ func sanitizeURL(u *url.URL) string {
 	return stripControlChars(sanitized.String())
 }
 
-// stripControlChars removes ASCII control characters (including CR and LF) from
-// s so that untrusted URL content cannot forge or split log entries.
+// stripControlChars removes ASCII control characters from s so that untrusted
+// URL content cannot forge or split log entries.
+//
+// CR and LF (the actual log-forging vectors for CWE-117) are removed first via
+// explicit replacements; this is the canonical newline barrier that static
+// analyzers recognize as neutralizing log injection. The subsequent pass then
+// drops any remaining control characters (tab, NUL, DEL, etc.) for good measure.
 func stripControlChars(s string) string {
+	// Remove carriage returns and line feeds explicitly. These are what allow
+	// forging a new log line; neutralizing them is the CWE-117 barrier.
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	// Drop any other control characters that could corrupt log output.
 	return strings.Map(func(r rune) rune {
 		if r < 0x20 || r == 0x7f {
 			return -1

--- a/pkg/httputil/client_test.go
+++ b/pkg/httputil/client_test.go
@@ -340,6 +340,11 @@ func TestSanitizeURL_StripsControlChars(t *testing.T) {
 			break
 		}
 	}
+
+	// Explicitly assert the CR/LF log-forging vectors are gone (CWE-117).
+	if strings.ContainsAny(result, "\r\n") {
+		t.Errorf("sanitized URL must not contain CR or LF, got %q", result)
+	}
 }
 
 func TestTLSConfig_PinnedSHA256(t *testing.T) {


### PR DESCRIPTION
## Summary

Security housekeeping, two related changes.

### 1. CodeQL log-injection (CWE-117) — alerts #5/#6

Closes the two open code-scanning alerts on the debug logs in `userAgentTransport.RoundTrip` ([pkg/httputil/client.go](https://github.com/maxfield-allison/dnsweaver/blob/main/pkg/httputil/client.go)).

The logged URL already passed through `sanitizeURL()` -> `stripControlChars()`, which removed all control characters including CR/LF. But the stripping used `strings.Map`, which CodeQL's taint tracking doesn't recognize as a newline barrier — so the sanitizer was invisible to the analyzer and the alert persisted.

- `stripControlChars` now removes CR and LF explicitly via `strings.ReplaceAll` first (the canonical CWE-117 barrier that static analyzers recognize), then keeps the `strings.Map` pass for any other control characters.
- No behavior change for callers — output is identical, just expressed legibly for CodeQL.
- Strengthened `TestSanitizeURL_StripsControlChars` to explicitly assert CR/LF are absent.

### 2. `.trivyignore` refresh

- Bumped the lapsed review date (`2026-07-01` -> `2026-11-01`; `moby/moby/v2` is still pre-release, so the acceptance stands).
- Documented two additional daemon-side `docker/docker` CVEs that a local `trivy image` scan surfaces (CVE-2026-41567 malicious-image RCE, CVE-2026-42306 host-file-overwrite race). Both are Docker Engine/Moby daemon vulns with no fix in the v28.x module; dnsweaver uses the SDK as a read-only client and runs no daemon, so the paths are unreachable (govulncheck agrees). The GitLab trivy gate already passes them via `--ignore-unfixed`; listing them makes the acceptance explicit.

## Context

Part of a security sweep: govulncheck (source) and trivy (image) were both run. Findings are limited to the known, unreachable, no-upstream-fix `docker/docker` daemon CVEs already accepted by CI policy. The Alpine 3.23.5 base image scans clean (0 vulns).

## Validation

`go build`, `go vet`, `go test ./pkg/httputil/` pass; local trivy gate (`trivy fs --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore`) exits 0.