### PR TITLE
fix(reconciler): allow coexisting record types; only CNAME conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Coexisting record types were rejected as conflicts, stalling reconciliation.**
+  Any existing record whose type differed from the desired one was treated as a
+  conflict, so dnsweaver logged `skipping due to record type conflict` and made
+  no changes. DNS only forbids one combination — a CNAME cannot share a name
+  with any other record (RFC 1034 §3.6.2, RFC 2181 §10.1) — and that is now the
+  only case that skips. A + AAAA dual-stack instances, SRV records, and HTTPS
+  records may coexist as they do in real zones. This most often hit single
+  Technitium instances on default settings: the companion HTTPS record dnsweaver
+  creates itself was seen as a conflict on the next pass, so target changes
+  stopped being applied after the first successful create, and deleting one
+  record never restored it.
+  ([GitHub #165](https://github.com/maxfield-allison/dnsweaver/issues/165))
+- **Technitium no longer attempts a companion HTTPS record for CNAME instances.**
+  A CNAME is exclusive, so Technitium rejected the companion and dnsweaver
+  logged a warning on every reconcile. Companions are now created for A and AAAA
+  records only; hostnames fronted by a CNAME inherit the HTTPS record of the
+  name they point at. Companions written by earlier releases are still deleted
+  when their CNAME is removed.
+  ([GitHub #165](https://github.com/maxfield-allison/dnsweaver/issues/165))
+- **Self-referential CNAMEs are skipped instead of retried.** When the configured
+  target is itself a discovered hostname — a reverse proxy with a router rule of
+  its own — dnsweaver tried to create a CNAME pointing at its own name once per
+  interval. It is now skipped with a single warning naming the hostname.
+  ([GitHub #165](https://github.com/maxfield-allison/dnsweaver/issues/165))
+
 ## [2.7.2] - 2026-08-07
 
 ### Changed

--- a/docs/deployment/split-horizon.md
+++ b/docs/deployment/split-horizon.md
@@ -60,7 +60,7 @@ When container `app.example.com` starts:
 - External DNS → `CNAME` record → `tunnel.example.com`
 
 !!! tip "Companion HTTPS Records"
-    When using Technitium for internal DNS, dnsweaver automatically creates companion HTTPS (SVCB) records alongside A/CNAME records. This prevents ECH (Encrypted Client Hello) fallback errors that commonly occur in split-horizon setups where external DNS (e.g., Cloudflare) provides HTTPS records but internal DNS doesn't. See [Technitium — Companion HTTPS Records](../providers/technitium.md#companion-https-records) for details.
+    When using Technitium for internal DNS, dnsweaver automatically creates companion HTTPS (SVCB) records alongside A/AAAA records. This prevents ECH (Encrypted Client Hello) fallback errors that commonly occur in split-horizon setups where external DNS (e.g., Cloudflare) provides HTTPS records but internal DNS doesn't. See [Technitium — Companion HTTPS Records](../providers/technitium.md#companion-https-records) for details.
 
 ## Internal-Only Services
 

--- a/docs/providers/technitium.md
+++ b/docs/providers/technitium.md
@@ -190,7 +190,9 @@ but emits a deprecation warning and will be removed in a future major release.
 
 ## Companion HTTPS Records
 
-By default, dnsweaver automatically creates companion HTTPS (SVCB Type 65) records whenever it creates an A, AAAA, or CNAME record in Technitium. This prevents **ECH (Encrypted Client Hello) fallback errors** that commonly affect split-horizon DNS environments.
+By default, dnsweaver automatically creates companion HTTPS (SVCB Type 65) records whenever it creates an A or AAAA record in Technitium. This prevents **ECH (Encrypted Client Hello) fallback errors** that commonly affect split-horizon DNS environments.
+
+Instances configured with `RECORD_TYPE=CNAME` get no companion record: a CNAME is exclusive and cannot share a name with any other record type, so Technitium rejects the companion outright. Those hostnames inherit the HTTPS record of the name their CNAME points at.
 
 ### Why This Exists
 
@@ -200,7 +202,7 @@ The companion HTTPS record tells browsers "this host speaks HTTP/2 over TLS" wit
 
 ### What Gets Created
 
-For each A/AAAA/CNAME record, dnsweaver creates:
+For each A/AAAA record, dnsweaver creates:
 
 ```
 app.example.com  300  IN  HTTPS  1 . alpn="h2"

--- a/internal/reconciler/actions.go
+++ b/internal/reconciler/actions.go
@@ -16,7 +16,7 @@ import (
 // 1. Check if record exists for hostname
 // 2. If exists with same target → skip (idempotent)
 // 3. If exists with different target (same type) → delete old, create new
-// 4. If exists with different type → log warning, skip (don't delete manual records)
+// 4. If exists with a type that cannot coexist (CNAME) → log warning, skip
 //
 // When hostname has RecordHints, they override provider defaults:
 // - RecordHints.Provider: route directly to named provider instead of domain matching
@@ -108,6 +108,64 @@ func (r *Reconciler) ensureRecord(ctx context.Context, hostname *source.Hostname
 	return actions
 }
 
+// typesConflict reports whether a record of type desired can be created at a
+// name that already holds a record of type existing.
+//
+// DNS only forbids one combination: a CNAME is exclusive and cannot share an
+// owner name with any other data (RFC 1034 §3.6.2, RFC 2181 §10.1). Every other
+// pairing is legal and common in practice — A + AAAA for dual-stack, either of
+// them alongside an HTTPS/SVCB record, SRV alongside address records. Treating
+// those as conflicts made dnsweaver skip its own hostnames forever once a second
+// record type appeared, including the companion HTTPS record the Technitium
+// provider creates itself (issue #165).
+//
+// Callers handle the same-type case before reaching here; TXT ownership markers
+// are filtered out upstream and never reach this comparison.
+func typesConflict(desired, existing provider.RecordType) bool {
+	return desired == provider.RecordTypeCNAME || existing == provider.RecordTypeCNAME
+}
+
+// isSelfReferential reports whether target names the record's own hostname,
+// which would create a CNAME pointing at itself (a resolution loop). This
+// happens when the configured TARGET is itself a discovered hostname — e.g. a
+// reverse proxy that also has a router rule of its own.
+func isSelfReferential(hostname, target string, recordType provider.RecordType) bool {
+	if recordType != provider.RecordTypeCNAME {
+		return false
+	}
+	return source.NormalizeHostname(hostname) == source.NormalizeHostname(target)
+}
+
+// warnSelfReferentialOnce reports a self-referential CNAME at warn level the
+// first time it is seen for a provider/hostname pair and at debug level after
+// that. The condition is a configuration problem that cannot resolve on its own,
+// so repeating the warning every interval is pure noise (issue #165).
+func (r *Reconciler) warnSelfReferentialOnce(hostname, providerName, target string) {
+	key := providerName + "|" + hostname
+
+	r.mu.Lock()
+	_, seen := r.warnedSelfCNAME[key]
+	if !seen {
+		if r.warnedSelfCNAME == nil {
+			r.warnedSelfCNAME = make(map[string]struct{})
+		}
+		r.warnedSelfCNAME[key] = struct{}{}
+	}
+	r.mu.Unlock()
+
+	const msg = "skipping self-referential CNAME (target is the hostname itself)"
+	attrs := []any{
+		slog.String("hostname", hostname),
+		slog.String("provider", providerName),
+		slog.String("target", target),
+	}
+	if seen {
+		r.logger.Debug(msg, attrs...)
+		return
+	}
+	r.logger.Warn(msg, attrs...)
+}
+
 // ensureRecordForProvider handles record creation for a single provider with List+Compare logic.
 // When hostname has RecordHints, they override provider instance defaults.
 func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *source.Hostname, inst *provider.ProviderInstance, cache *recordCache) Action {
@@ -164,6 +222,16 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 		Target:     target,
 	}
 
+	// A CNAME pointing at its own name is a resolution loop; no provider will
+	// accept it and retrying every interval only produces noise.
+	if isSelfReferential(hostname.Name, target, recordType) {
+		action.Type = ActionSkip
+		action.Status = StatusSkipped
+		action.Error = errSelfReferentialCNAME
+		r.warnSelfReferentialOnce(hostname.Name, inst.Name(), target)
+		return action
+	}
+
 	if r.isDryRun() {
 		action.Status = StatusSuccess
 		r.logger.Info("would create record (dry-run)",
@@ -202,18 +270,23 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 	}
 
 	// Step 2: Analyze existing records
+	// Records of a different type only conflict when DNS itself forbids the
+	// coexistence — see typesConflict. Types that may legally share a name
+	// (A + AAAA + HTTPS + SRV) are ignored here: they belong to another
+	// instance, another address family, or to our own companion HTTPS record.
 	var sameTypeRecords []provider.Record
 	var conflictingTypeRecords []provider.Record
 
 	for _, existing := range existingRecords {
-		if existing.Type == recordType {
+		switch {
+		case existing.Type == recordType:
 			sameTypeRecords = append(sameTypeRecords, existing)
-		} else {
+		case typesConflict(recordType, existing.Type):
 			conflictingTypeRecords = append(conflictingTypeRecords, existing)
 		}
 	}
 
-	// Step 3: Handle type conflicts (A vs CNAME)
+	// Step 3: Handle type conflicts (CNAME vs everything else)
 	if len(conflictingTypeRecords) > 0 {
 		conflictTypes := make([]string, 0, len(conflictingTypeRecords))
 		for _, rec := range conflictingTypeRecords {

--- a/internal/reconciler/coexistence_test.go
+++ b/internal/reconciler/coexistence_test.go
@@ -1,0 +1,232 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+)
+
+// newCoexistenceReconciler wires a single mock instance holding the supplied
+// pre-existing records, returning the reconciler and a warm cache.
+func newCoexistenceReconciler(t *testing.T, recordType provider.RecordType, target string, existing ...provider.Record) (*Reconciler, *recordCache, *testMockProvider) {
+	t.Helper()
+
+	mock := newTestMockProvider("test-dns")
+	for _, rec := range existing {
+		mock.AddRecord(rec)
+	}
+
+	logger := quietLogger()
+	providers := provider.NewRegistry(logger)
+	providers.RegisterFactory("mock", func(cfg provider.FactoryConfig) (provider.Provider, error) {
+		return mock, nil
+	})
+	if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+		Name:       "test-dns",
+		TypeName:   "mock",
+		RecordType: recordType,
+		Target:     target,
+		TTL:        300,
+		Domains:    []string{"*.example.com"},
+	}); err != nil {
+		t.Fatalf("CreateInstance failed: %v", err)
+	}
+
+	r := &Reconciler{
+		providers:      providers,
+		config:         DefaultConfig(),
+		logger:         logger,
+		knownHostnames: make(map[string]struct{}),
+	}
+	r.syncAtomics()
+
+	return r, newRecordCache(context.Background(), providers, logger), mock
+}
+
+func TestTypesConflict(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  provider.RecordType
+		existing provider.RecordType
+		want     bool
+	}{
+		{"A alongside AAAA", provider.RecordTypeA, provider.RecordTypeAAAA, false},
+		{"AAAA alongside A", provider.RecordTypeAAAA, provider.RecordTypeA, false},
+		{"A alongside companion HTTPS", provider.RecordTypeA, provider.RecordTypeHTTPS, false},
+		{"AAAA alongside companion HTTPS", provider.RecordTypeAAAA, provider.RecordTypeHTTPS, false},
+		{"SRV alongside A", provider.RecordTypeSRV, provider.RecordTypeA, false},
+		{"HTTPS alongside A", provider.RecordTypeHTTPS, provider.RecordTypeA, false},
+		{"A blocked by existing CNAME", provider.RecordTypeA, provider.RecordTypeCNAME, true},
+		{"AAAA blocked by existing CNAME", provider.RecordTypeAAAA, provider.RecordTypeCNAME, true},
+		{"HTTPS blocked by existing CNAME", provider.RecordTypeHTTPS, provider.RecordTypeCNAME, true},
+		{"CNAME blocked by existing A", provider.RecordTypeCNAME, provider.RecordTypeA, true},
+		{"CNAME blocked by existing HTTPS", provider.RecordTypeCNAME, provider.RecordTypeHTTPS, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := typesConflict(tt.desired, tt.existing); got != tt.want {
+				t.Errorf("typesConflict(%s, %s) = %v, want %v", tt.desired, tt.existing, got, tt.want)
+			}
+		})
+	}
+}
+
+// The Technitium provider creates a companion HTTPS record next to every A/AAAA
+// record it writes. That record must not block later reconciles of the address
+// record it accompanies — issue #165, where the stale target was never updated
+// and a WARN was logged on every interval.
+func TestEnsureRecord_CompanionHTTPSDoesNotBlockUpdate(t *testing.T) {
+	r, cache, mock := newCoexistenceReconciler(t, provider.RecordTypeA, "10.0.0.1",
+		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.99", TTL: 300},
+		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeHTTPS, Target: ".", TTL: 300},
+	)
+
+	actions := r.ensureRecord(context.Background(), &source.Hostname{Name: "app.example.com", Source: "test"}, cache)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if actions[0].Type != ActionUpdate || actions[0].Status != StatusSuccess {
+		t.Fatalf("expected a successful update, got %v/%v (%s)", actions[0].Type, actions[0].Status, actions[0].Error)
+	}
+
+	for _, deleted := range mock.GetDeleted() {
+		if deleted.Type == provider.RecordTypeHTTPS {
+			t.Error("companion HTTPS record must not be deleted while updating the A record")
+		}
+	}
+}
+
+// Dual-stack: an AAAA instance and an A instance share every hostname, and
+// neither may treat the other's record as a conflict.
+func TestEnsureRecord_DualStackCoexists(t *testing.T) {
+	r, cache, _ := newCoexistenceReconciler(t, provider.RecordTypeAAAA, "2001:db8::1",
+		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1", TTL: 300},
+		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeHTTPS, Target: ".", TTL: 300},
+	)
+
+	actions := r.ensureRecord(context.Background(), &source.Hostname{Name: "app.example.com", Source: "test"}, cache)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if actions[0].Type != ActionCreate || actions[0].Status != StatusSuccess {
+		t.Fatalf("expected the AAAA record to be created, got %v/%v (%s)", actions[0].Type, actions[0].Status, actions[0].Error)
+	}
+}
+
+// An existing CNAME still blocks address records: that conflict is real.
+func TestEnsureRecord_ExistingCNAMEStillConflicts(t *testing.T) {
+	r, cache, _ := newCoexistenceReconciler(t, provider.RecordTypeA, "10.0.0.1",
+		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeCNAME, Target: "proxy.example.com", TTL: 300},
+	)
+
+	actions := r.ensureRecord(context.Background(), &source.Hostname{Name: "app.example.com", Source: "test"}, cache)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if actions[0].Type != ActionSkip || !containsHelper(actions[0].Error, "conflict") {
+		t.Fatalf("expected a conflict skip, got %v (%s)", actions[0].Type, actions[0].Error)
+	}
+}
+
+// A desired CNAME is exclusive, so any pre-existing record blocks it — including
+// an HTTPS record left behind by an older dnsweaver release.
+func TestEnsureRecord_DesiredCNAMEConflictsWithHTTPS(t *testing.T) {
+	r, cache, _ := newCoexistenceReconciler(t, provider.RecordTypeCNAME, "proxy.example.com",
+		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeHTTPS, Target: ".", TTL: 300},
+	)
+
+	actions := r.ensureRecord(context.Background(), &source.Hostname{Name: "app.example.com", Source: "test"}, cache)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if actions[0].Type != ActionSkip || !containsHelper(actions[0].Error, "conflict") {
+		t.Fatalf("expected a conflict skip, got %v (%s)", actions[0].Type, actions[0].Error)
+	}
+}
+
+// A CNAME whose target is the hostname itself is a resolution loop; it must be
+// skipped rather than retried against the provider every interval.
+func TestEnsureRecord_SkipsSelfReferentialCNAME(t *testing.T) {
+	r, cache, mock := newCoexistenceReconciler(t, provider.RecordTypeCNAME, "proxy.example.com")
+
+	actions := r.ensureRecord(context.Background(), &source.Hostname{Name: "proxy.example.com", Source: "test"}, cache)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if actions[0].Type != ActionSkip || actions[0].Error != errSelfReferentialCNAME {
+		t.Fatalf("expected a self-referential skip, got %v (%s)", actions[0].Type, actions[0].Error)
+	}
+	if len(mock.GetCreated()) != 0 {
+		t.Error("no record should be created for a self-referential CNAME")
+	}
+}
+
+func TestIsSelfReferential(t *testing.T) {
+	tests := []struct {
+		name       string
+		hostname   string
+		target     string
+		recordType provider.RecordType
+		want       bool
+	}{
+		{"identical CNAME", "proxy.example.com", "proxy.example.com", provider.RecordTypeCNAME, true},
+		{"case and trailing dot", "Proxy.Example.com", "proxy.example.com.", provider.RecordTypeCNAME, true},
+		{"different target", "app.example.com", "proxy.example.com", provider.RecordTypeCNAME, false},
+		{"A record with matching target is not a loop", "proxy.example.com", "proxy.example.com", provider.RecordTypeA, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSelfReferential(tt.hostname, tt.target, tt.recordType); got != tt.want {
+				t.Errorf("isSelfReferential(%q, %q, %s) = %v, want %v", tt.hostname, tt.target, tt.recordType, got, tt.want)
+			}
+		})
+	}
+}
+
+// The self-referential warning must not repeat on every interval — the whole
+// point of the skip is to stop the per-cycle noise (issue #165).
+func TestWarnSelfReferentialOnce(t *testing.T) {
+	var warnings int
+	r := &Reconciler{
+		logger: slog.New(&countingHandler{level: slog.LevelWarn, count: &warnings}),
+		config: DefaultConfig(),
+	}
+
+	for range 5 {
+		r.warnSelfReferentialOnce("proxy.example.com", "test-dns", "proxy.example.com")
+	}
+	if warnings != 1 {
+		t.Errorf("expected 1 warn-level log for a repeated hostname, got %d", warnings)
+	}
+
+	r.warnSelfReferentialOnce("other.example.com", "test-dns", "other.example.com")
+	if warnings != 2 {
+		t.Errorf("expected a warning for a second hostname, got %d total", warnings)
+	}
+}
+
+// countingHandler counts records at or above the configured level.
+type countingHandler struct {
+	level slog.Level
+	count *int
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *countingHandler) Handle(_ context.Context, rec slog.Record) error {
+	if rec.Level >= h.level {
+		*h.count++
+	}
+	return nil
+}
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(string) slog.Handler      { return h }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -18,9 +18,10 @@ import (
 
 // Common error messages used in reconciliation actions.
 const (
-	errRecordAlreadyExists = "record already exists"
-	errRecordTypeConflict  = "record type conflict"
-	errNoMatchingProvider  = "no matching provider"
+	errRecordAlreadyExists  = "record already exists"
+	errRecordTypeConflict   = "record type conflict"
+	errNoMatchingProvider   = "no matching provider"
+	errSelfReferentialCNAME = "self-referential CNAME (target equals hostname)"
 )
 
 // Reconciliation-level outcome labels used for the reconciliations_total metric.
@@ -94,11 +95,17 @@ type Reconciler struct {
 	enabled atomic.Bool
 	dryRun  atomic.Bool
 
-	// mu protects knownHostnames and recoveredMetadata during concurrent access
+	// mu protects knownHostnames, recoveredMetadata, and warnedSelfCNAME during
+	// concurrent access
 	mu sync.RWMutex
 	// knownHostnames tracks hostnames discovered in the last reconciliation.
 	// Used for orphan detection.
 	knownHostnames map[string]struct{}
+
+	// warnedSelfCNAME tracks "provider|hostname" pairs already reported as
+	// self-referential CNAMEs, so the warning is logged once rather than on
+	// every reconciliation interval. Populated lazily.
+	warnedSelfCNAME map[string]struct{}
 
 	// hostnameProviders tracks which provider(s) each hostname was routed to
 	// in the previous reconciliation. Used by orphan cleanup to delete records

--- a/providers/technitium/companion.go
+++ b/providers/technitium/companion.go
@@ -19,14 +19,28 @@ const companionHTTPSSvcPriority = 1
 const companionHTTPSTargetName = "."
 
 // needsCompanionHTTPS returns true if the given record type should trigger
-// companion HTTPS record creation (A, AAAA, or CNAME).
+// companion HTTPS record creation (A or AAAA).
+//
+// CNAME is deliberately excluded: a CNAME is exclusive and cannot share an
+// owner name with an HTTPS record (RFC 1034 §3.6.2, RFC 2181 §10.1). Technitium
+// rejects the companion outright in that case, so attempting it only produced a
+// warning on every reconcile (issue #165). Hosts fronted by a CNAME inherit the
+// HTTPS record of the name they point at.
 func needsCompanionHTTPS(recordType provider.RecordType) bool {
 	switch recordType {
-	case provider.RecordTypeA, provider.RecordTypeAAAA, provider.RecordTypeCNAME:
+	case provider.RecordTypeA, provider.RecordTypeAAAA:
 		return true
 	default:
 		return false
 	}
+}
+
+// hadCompanionHTTPS returns true if a record of the given type may have a
+// companion HTTPS record left over from an earlier dnsweaver release, which
+// created companions for CNAME records too. Deletion stays broader than
+// creation so those leftovers are still cleaned up when the record is removed.
+func hadCompanionHTTPS(recordType provider.RecordType) bool {
+	return needsCompanionHTTPS(recordType) || recordType == provider.RecordTypeCNAME
 }
 
 // createCompanionHTTPS creates a companion HTTPS record for the given hostname.
@@ -38,7 +52,7 @@ func needsCompanionHTTPS(recordType provider.RecordType) bool {
 //
 // Skips creation if:
 //   - Auto HTTPS records are disabled
-//   - The record type doesn't need a companion (not A/AAAA/CNAME)
+//   - The record type doesn't need a companion (not A/AAAA)
 //   - An HTTPS record already exists for the hostname (avoids overwriting manual records)
 func (p *Provider) createCompanionHTTPS(ctx context.Context, hostname string, recordType provider.RecordType, ttl int) error {
 	if !p.autoHTTPSRecords {
@@ -90,7 +104,7 @@ func (p *Provider) deleteCompanionHTTPS(ctx context.Context, hostname string, re
 	if !p.autoHTTPSRecords {
 		return nil
 	}
-	if !needsCompanionHTTPS(recordType) {
+	if !hadCompanionHTTPS(recordType) {
 		return nil
 	}
 

--- a/providers/technitium/companion_test.go
+++ b/providers/technitium/companion_test.go
@@ -47,3 +47,49 @@ func TestCompanionLifecycle(t *testing.T) {
 		t.Fatalf("deleteCompanionHTTPS failed: %v", err)
 	}
 }
+
+// A CNAME cannot share a name with an HTTPS record, so no companion is created
+// for one (issue #165) — but a companion written by an older release is still
+// removed when the CNAME goes away.
+func TestCompanionSkippedForCNAME(t *testing.T) {
+	var addCalls, deleteCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/zones/records/get":
+			_, _ = w.Write([]byte(`{"status":"ok","response":{"zone":{"name":"zone"},"name":"app.example.com","records":[]}}`))
+		case "/api/zones/records/add":
+			addCalls++
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case "/api/zones/records/delete":
+			deleteCalls++
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL, Token: "token", Zone: "zone", TTL: 300, AutoHTTPSRecords: true, AutoHTTPSALPN: "h2"}
+	p, err := New("inst", cfg)
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+	p.client = NewClient(server.URL, "token")
+
+	ctx := context.Background()
+	if err := p.createCompanionHTTPS(ctx, "app.example.com", provider.RecordTypeCNAME, 300); err != nil {
+		t.Fatalf("createCompanionHTTPS failed: %v", err)
+	}
+	if addCalls != 0 {
+		t.Errorf("expected no companion creation for a CNAME, got %d add call(s)", addCalls)
+	}
+
+	if err := p.deleteCompanionHTTPS(ctx, "app.example.com", provider.RecordTypeCNAME); err != nil {
+		t.Fatalf("deleteCompanionHTTPS failed: %v", err)
+	}
+	if deleteCalls != 1 {
+		t.Errorf("expected leftover companion cleanup for a CNAME, got %d delete call(s)", deleteCalls)
+	}
+}

--- a/providers/technitium/provider.go
+++ b/providers/technitium/provider.go
@@ -17,7 +17,7 @@ type Provider struct {
 	url              string // Technitium API URL (recorded for Identity reporting)
 	zone             string
 	ttl              int
-	autoHTTPSRecords bool   // Create companion HTTPS records for A/CNAME records
+	autoHTTPSRecords bool   // Create companion HTTPS records for A/AAAA records
 	autoHTTPSALPN    string // ALPN value for companion HTTPS records (e.g., "h2")
 	client           *Client
 	logger           *slog.Logger
@@ -278,7 +278,7 @@ func (p *Provider) Create(ctx context.Context, record provider.Record) error {
 		slog.Int("ttl", ttl),
 	)
 
-	// Auto-create companion HTTPS record for A/AAAA/CNAME records when enabled.
+	// Auto-create companion HTTPS record for A/AAAA records when enabled.
 	// This prevents ECH fallback errors in split-horizon DNS environments.
 	if err := p.createCompanionHTTPS(ctx, record.Hostname, record.Type, ttl); err != nil {
 		p.logger.Warn("companion HTTPS record creation failed (non-fatal)",
@@ -335,7 +335,7 @@ func (p *Provider) Delete(ctx context.Context, record provider.Record) error {
 		slog.String("target", record.Target),
 	)
 
-	// Auto-delete companion HTTPS record when an A/AAAA/CNAME record is removed.
+	// Auto-delete companion HTTPS record when an A/AAAA record is removed.
 	// Uses best-effort: companion may already be gone or manually deleted.
 	if err := p.deleteCompanionHTTPS(ctx, record.Hostname, record.Type); err != nil {
 		p.logger.Warn("companion HTTPS record deletion failed (non-fatal)",


### PR DESCRIPTION
Fixes #165.

`ensureRecordForProvider` treated *any* existing record of a different type as a conflict, and that check runs before the "record already exists" check. DNS only forbids one combination: a CNAME can't share a name with any other record ([RFC 1034 §3.6.2](https://datatracker.ietf.org/doc/html/rfc1034#section-3.6.2), [RFC 2181 §10.1](https://datatracker.ietf.org/doc/html/rfc2181#section-10.1)). A + AAAA, SRV, and HTTPS coexist legally.

This needed no multi-instance setup to trigger. The Technitium provider creates a companion HTTPS record next to every address record it writes, with `AUTO_HTTPS_RECORDS` on by default, so a single Technitium instance poisoned itself on the second pass: target changes stopped applying after the first successful create, and a manually deleted record was never restored.

## Changes

**`typesConflict(desired, existing)`** — conflict only when either side is a CNAME. Coexisting types are ignored: not deleted, not counted toward an exact match, not blocking.

**Companion HTTPS is A/AAAA only** — a CNAME can't coexist with an HTTPS record, so Technitium rejected the companion and logged a warning on every reconcile. Deletion stays broader (`hadCompanionHTTPS`) so companions written by earlier releases are still cleaned up when their CNAME is removed.

**Self-referential CNAMEs are skipped** — when the configured target is itself a discovered hostname, dnsweaver retried an impossible create every interval. Now skipped, warned once per provider/hostname via `warnSelfReferentialOnce`, debug thereafter.

Docs in `technitium.md` and `split-horizon.md` claimed companion HTTPS support for CNAME records, which never worked; corrected.

## Tests

`internal/reconciler/coexistence_test.go` — 11-case table for `typesConflict`, companion-HTTPS-blocks-update repro, dual-stack coexistence, both directions of genuine CNAME conflict, self-referential skip, warn-once. `providers/technitium/companion_test.go` — `TestCompanionSkippedForCNAME` asserts zero add calls and one delete call for a CNAME.

Verified end to end against a live Technitium server on a throwaway zone, released build vs this branch: the released build reproduces the reporter's log line every cycle and never applies a target change; this branch applies it, recreates a manually deleted record, coexists A + AAAA + HTTPS across two instances, leaves companions untouched, and stays quiet at steady state. A CNAME instance aimed at a name holding A/AAAA/HTTPS still refuses to clobber it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
