### PR TITLE
fix(reconciler): replace a conflicting CNAME when allowed instead of skipping forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is now read, in numeric order, and `DNSWEAVER_PROXMOX_INTERFACE_TAG_PREFIX`
   and `DNSWEAVER_PROXMOX_ALLOWED_INTERFACES` apply to containers the same way
   they already applied to VMs.
+- **A pre-existing record of a conflicting type blocked the configured record
+  forever.** When a hostname already held a CNAME at the time dnsweaver started
+  managing it (created by hand, or left over from an earlier configuration) and
+  the instance was configured for an A record, or the reverse, the conflict was
+  reported as `skipping due to record type conflict` on every interval and
+  nothing ever changed: the CNAME stayed and the A record was never created.
+  Orphan cleanup could not help because the hostname was still desired, and
+  `DNSWEAVER_ADOPT_EXISTING` was never consulted. The conflicting record is now
+  deleted and replaced when the instance is allowed to delete it: authoritative
+  mode, `DNSWEAVER_ADOPT_EXISTING=true`, or an ownership record showing the
+  stale record is dnsweaver's own. Additive mode never deletes, so it still
+  skips. When the record cannot be replaced the warning is logged once rather
+  than every interval, and names the setting that would let dnsweaver resolve
+  it. Dry-run reports what would be replaced; a failed delete marks the action
+  failed and nothing is created on top of the leftover record.
+  ([GitHub #171](https://github.com/maxfield-allison/dnsweaver/issues/171))
 
 ### Added
 - **Dual-stack support for the Proxmox source.** `DNSWEAVER_PROXMOX_IP_VERSION`

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -37,7 +37,7 @@ dnsweaver --config /etc/dnsweaver/config.yml
 | `DNSWEAVER_CLEANUP_ORPHANS` | `true` | Delete DNS records when workloads are removed |
 | `DNSWEAVER_CLEANUP_ON_STOP` | `true` | Delete DNS records when containers stop |
 | `DNSWEAVER_OWNERSHIP_TRACKING` | `true` | Use TXT records to track record ownership |
-| `DNSWEAVER_ADOPT_EXISTING` | `false` | Adopt existing DNS records by creating ownership TXT |
+| `DNSWEAVER_ADOPT_EXISTING` | `false` | Adopt existing DNS records by creating ownership TXT; also replaces a pre-existing record of a conflicting type (for example a CNAME where an A is configured) instead of skipping it |
 | `DNSWEAVER_DEFAULT_TTL` | `300` | Default TTL for DNS records (seconds) |
 | `DNSWEAVER_RECONCILE_INTERVAL` | `60s` | Periodic reconciliation interval |
 | `DNSWEAVER_SHUTDOWN_TIMEOUT` | `30s` | Graceful shutdown timeout for in-flight updates |

--- a/docs/configuration/modes.md
+++ b/docs/configuration/modes.md
@@ -65,6 +65,8 @@ Only records with matching TXT ownership records are deleted when containers sto
     - "*.apps.internal.example.com"  # Only use on dedicated subdomains
 ```
 
+**Conflicting record types:** a pre-existing record whose type cannot coexist with the configured one (for example a CNAME where an A record is configured, or the reverse) is deleted and replaced by the configured record. In managed mode the same record is replaced only when `DNSWEAVER_ADOPT_EXISTING=true` or when dnsweaver already owns the hostname; otherwise it is skipped and a warning is logged once. Additive mode never replaces it.
+
 **When to use:**
 
 - Dedicated zones exclusively for container DNS
@@ -142,7 +144,7 @@ These global settings interact with operational modes:
 | `DNSWEAVER_CLEANUP_ORPHANS` | If `false`, disables deletion globally (overrides managed/authoritative) |
 | `DNSWEAVER_CLEANUP_ON_STOP` | If `false`, only delete records when containers are removed, not stopped |
 | `DNSWEAVER_OWNERSHIP_TRACKING` | If `false`, dnsweaver can't distinguish its own records from others |
-| `DNSWEAVER_ADOPT_EXISTING` | If `true`, dnsweaver claims ownership of pre-existing records |
+| `DNSWEAVER_ADOPT_EXISTING` | If `true`, dnsweaver claims ownership of pre-existing records, and replaces a pre-existing record of a conflicting type (for example a CNAME where an A is configured) instead of skipping it. Managed mode without it skips the record and logs once; additive mode never replaces it |
 
 ## Choosing the Right Mode
 

--- a/internal/reconciler/actions.go
+++ b/internal/reconciler/actions.go
@@ -4,6 +4,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -18,7 +19,8 @@ import (
 //     reports it would write different state for it (provider.RecordComparer,
 //     e.g. Cloudflare proxied) → update in place
 //  3. If exists with different target (same type) → delete old, create new
-//  4. If exists with a type that cannot coexist (CNAME) → log warning, skip
+//  4. If exists with a type that cannot coexist (CNAME) → replace when allowed
+//     (see canReplaceConflicting), else warn once and skip
 //
 // When hostname has RecordHints, they override provider defaults:
 // - RecordHints.Provider: route directly to named provider instead of domain matching
@@ -44,8 +46,7 @@ func (r *Reconciler) ensureRecord(ctx context.Context, hostname *source.Hostname
 			return actions
 		}
 		// Route to explicit provider, bypassing domain matching
-		action := r.ensureRecordForProvider(ctx, hostname, inst, cache)
-		return append(actions, action)
+		return append(actions, r.ensureRecordForProvider(ctx, hostname, inst, cache)...)
 	}
 
 	// Standard domain-based matching (with optional metadata-filter scoping
@@ -105,7 +106,7 @@ func (r *Reconciler) ensureRecord(ctx context.Context, hostname *source.Hostname
 	}
 
 	for _, inst := range writers {
-		actions = append(actions, r.ensureRecordForProvider(ctx, hostname, inst, cache))
+		actions = append(actions, r.ensureRecordForProvider(ctx, hostname, inst, cache)...)
 	}
 	return actions
 }
@@ -138,29 +139,20 @@ func isSelfReferential(hostname, target string, recordType provider.RecordType) 
 	return source.NormalizeHostname(hostname) == source.NormalizeHostname(target)
 }
 
-// warnSelfReferentialOnce reports a self-referential CNAME at warn level the
-// first time it is seen for a provider/hostname pair and at debug level after
-// that. The condition is a configuration problem that cannot resolve on its own,
-// so repeating the warning every interval is pure noise (issue #165).
-func (r *Reconciler) warnSelfReferentialOnce(hostname, providerName, target string) {
-	key := providerName + "|" + hostname
-
+// warnOnce logs msg at warn level the first time key is seen and at debug
+// level after that. It is for conditions that cannot resolve on their own, where
+// repeating the warning every interval is pure noise (issue #165).
+func (r *Reconciler) warnOnce(key, msg string, attrs ...any) {
 	r.mu.Lock()
-	_, seen := r.warnedSelfCNAME[key]
+	_, seen := r.warnedOnce[key]
 	if !seen {
-		if r.warnedSelfCNAME == nil {
-			r.warnedSelfCNAME = make(map[string]struct{})
+		if r.warnedOnce == nil {
+			r.warnedOnce = make(map[string]struct{})
 		}
-		r.warnedSelfCNAME[key] = struct{}{}
+		r.warnedOnce[key] = struct{}{}
 	}
 	r.mu.Unlock()
 
-	const msg = "skipping self-referential CNAME (target is the hostname itself)"
-	attrs := []any{
-		slog.String("hostname", hostname),
-		slog.String("provider", providerName),
-		slog.String("target", target),
-	}
 	if seen {
 		r.logger.Debug(msg, attrs...)
 		return
@@ -168,9 +160,102 @@ func (r *Reconciler) warnSelfReferentialOnce(hostname, providerName, target stri
 	r.logger.Warn(msg, attrs...)
 }
 
+// warnSelfReferentialOnce reports a self-referential CNAME once per
+// provider/hostname pair.
+func (r *Reconciler) warnSelfReferentialOnce(hostname, providerName, target string) {
+	r.warnOnce("self-cname|"+providerName+"|"+hostname,
+		"skipping self-referential CNAME (target is the hostname itself)",
+		slog.String("hostname", hostname),
+		slog.String("provider", providerName),
+		slog.String("target", target),
+	)
+}
+
+// warnTypeConflictOnce reports a type conflict dnsweaver is not allowed to
+// resolve, once per provider/hostname pair, with the setting that would let it.
+func (r *Reconciler) warnTypeConflictOnce(hostname string, inst *provider.ProviderInstance, desiredType string, existingTypes []string) {
+	msg := "skipping due to record type conflict; set DNSWEAVER_ADOPT_EXISTING=true or use authoritative mode to let dnsweaver replace the existing record(s)"
+	if !inst.Mode.AllowsDelete() {
+		msg = "skipping due to record type conflict; additive mode never deletes, so the existing record(s) must be removed by hand"
+	}
+	r.warnOnce("type-conflict|"+inst.Name()+"|"+hostname, msg,
+		slog.String("hostname", hostname),
+		slog.String("provider", inst.Name()),
+		slog.String("mode", string(inst.Mode)),
+		slog.String("desired_type", desiredType),
+		slog.Any("existing_types", existingTypes),
+	)
+}
+
+// canReplaceConflicting reports whether inst may delete records of another
+// type that occupy hostname so the desired record can take their place.
+// Additive mode never deletes. Authoritative mode owns everything in scope and
+// ADOPT_EXISTING is the operator saying pre-existing records are dnsweaver's to
+// manage; otherwise only a record this instance already owns (left over from
+// an earlier configuration) is replaced (issue #171).
+func (r *Reconciler) canReplaceConflicting(inst *provider.ProviderInstance, hostname string, cache *recordCache) bool {
+	switch {
+	case !inst.Mode.AllowsDelete():
+		return false
+	case !inst.Mode.RequiresOwnership(), r.config.AdoptExisting:
+		return true
+	}
+	return cache != nil && cache.hasOwnershipRecord(inst.Name(), hostname, r.config.InstanceID)
+}
+
+// replaceConflictingRecords deletes the records at hostname whose type cannot
+// coexist with the desired record, returning a delete action per record removed
+// (or that would be removed, in dry-run). It stops at the first failure and
+// returns the error, leaving the remaining records in place: creating on top of
+// a half-cleared name would fail anyway, and the caller must not try.
+func (r *Reconciler) replaceConflictingRecords(ctx context.Context, hostname string, inst *provider.ProviderInstance, conflicting []provider.Record) ([]Action, error) {
+	actions := make([]Action, 0, len(conflicting))
+	for _, rec := range conflicting {
+		action := Action{
+			Type:       ActionDelete,
+			Provider:   inst.Name(),
+			Hostname:   hostname,
+			RecordType: string(rec.Type),
+			Target:     rec.Target,
+		}
+		attrs := []any{
+			slog.String("hostname", hostname),
+			slog.String("provider", inst.Name()),
+			slog.String("type", string(rec.Type)),
+			slog.String("target", rec.Target),
+		}
+
+		if r.isDryRun() {
+			action.Status = StatusSuccess
+			r.logger.Info("would replace conflicting record (dry-run)", attrs...)
+			actions = append(actions, action)
+			continue
+		}
+
+		var err error
+		if rec.Type == provider.RecordTypeSRV {
+			err = inst.DeleteSRVRecord(ctx, hostname, rec.Target, rec.SRV)
+		} else {
+			err = inst.DeleteRecordByTarget(ctx, hostname, rec.Type, rec.Target)
+		}
+		// A record that vanished between List and Delete is the outcome we wanted.
+		if err != nil && !errors.Is(err, provider.ErrNotFound) {
+			r.logger.Error("failed to replace conflicting record", append(attrs, slog.String("error", err.Error()))...)
+			return actions, fmt.Errorf("replacing conflicting %s record %s: %w", rec.Type, rec.Target, err)
+		}
+
+		action.Status = StatusSuccess
+		r.logger.Info("replaced conflicting record", attrs...)
+		actions = append(actions, action)
+	}
+	return actions, nil
+}
+
 // ensureRecordForProvider handles record creation for a single provider with List+Compare logic.
 // When hostname has RecordHints, they override provider instance defaults.
-func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *source.Hostname, inst *provider.ProviderInstance, cache *recordCache) Action {
+// It returns a delete action for each conflicting record it replaced, followed
+// by the action for the desired record itself.
+func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *source.Hostname, inst *provider.ProviderInstance, cache *recordCache) []Action {
 	// Determine effective record type, target, and TTL
 	// RecordHints override provider defaults when present
 	recordType := inst.RecordType
@@ -247,20 +332,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 		action.Status = StatusSkipped
 		action.Error = errSelfReferentialCNAME
 		r.warnSelfReferentialOnce(hostname.Name, inst.Name(), target)
-		return action
-	}
-
-	if r.isDryRun() {
-		action.Status = StatusSuccess
-		r.logger.Info("would create record (dry-run)",
-			slog.String("hostname", hostname.Name),
-			slog.String("provider", inst.Name()),
-			slog.String("type", string(recordType)),
-			slog.String("target", target),
-			slog.Bool("ownership_tracking", r.config.OwnershipTracking),
-			slog.Bool("has_hints", hostname.HasRecordHints()),
-		)
-		return action
+		return []Action{action}
 	}
 
 	// Step 1: Get existing records from cache (or fetch if cache unavailable)
@@ -304,23 +376,44 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 		}
 	}
 
-	// Step 3: Handle type conflicts (CNAME vs everything else)
+	// Step 3: Handle type conflicts (CNAME vs everything else). A conflicting
+	// record is replaced when this instance may delete it; otherwise the desired
+	// record can never be created and the hostname is skipped (issue #171).
+	var replaced []Action
 	if len(conflictingTypeRecords) > 0 {
 		conflictTypes := make([]string, 0, len(conflictingTypeRecords))
 		for _, rec := range conflictingTypeRecords {
 			conflictTypes = append(conflictTypes, string(rec.Type))
 		}
-		action.Type = ActionSkip
-		action.Status = StatusSkipped
-		action.Error = fmt.Sprintf("type conflict: existing %v record(s) conflict with %s",
-			conflictTypes, recordType)
-		r.logger.Warn("skipping due to record type conflict",
+		if !r.canReplaceConflicting(inst, hostname.Name, cache) {
+			action.Type = ActionSkip
+			action.Status = StatusSkipped
+			action.Error = fmt.Sprintf("type conflict: existing %v record(s) conflict with %s",
+				conflictTypes, recordType)
+			r.warnTypeConflictOnce(hostname.Name, inst, string(recordType), conflictTypes)
+			return []Action{action}
+		}
+
+		var err error
+		replaced, err = r.replaceConflictingRecords(ctx, hostname.Name, inst, conflictingTypeRecords)
+		if err != nil {
+			action.Status = StatusFailed
+			action.Error = err.Error()
+			return append(replaced, action)
+		}
+	}
+
+	if r.isDryRun() {
+		action.Status = StatusSuccess
+		r.logger.Info("would create record (dry-run)",
 			slog.String("hostname", hostname.Name),
 			slog.String("provider", inst.Name()),
-			slog.String("desired_type", string(recordType)),
-			slog.Any("existing_types", conflictTypes),
+			slog.String("type", string(recordType)),
+			slog.String("target", target),
+			slog.Bool("ownership_tracking", r.config.OwnershipTracking),
+			slog.Bool("has_hints", hostname.HasRecordHints()),
 		)
-		return action
+		return append(replaced, action)
 	}
 
 	// Step 4: Check if record with correct target already exists
@@ -401,7 +494,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 					slog.String("target", target),
 				)
 			}
-			return action
+			return append(replaced, action)
 		}
 	}
 
@@ -438,7 +531,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 				slog.String("provider", inst.Name()),
 				slog.String("error", err.Error()),
 			)
-			return action
+			return append(replaced, action)
 		}
 
 		action.Type = ActionUpdate
@@ -450,7 +543,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 			slog.String("target", target),
 		)
 		r.ensureOwnershipRecord(ctx, hostname.Name, inst, metadata, cache)
-		return action
+		return append(replaced, action)
 	}
 
 	// Step 6: Create the record (no existing records)
@@ -496,7 +589,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 		r.ensureOwnershipRecord(ctx, hostname.Name, inst, metadata, cache)
 	}
 
-	return action
+	return append(replaced, action)
 }
 
 // ensureOwnershipRecord creates the ownership TXT record if tracking is enabled.

--- a/internal/reconciler/conflict_test.go
+++ b/internal/reconciler/conflict_test.go
@@ -1,0 +1,268 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+)
+
+// newConflictReconciler wires one mock instance in the given mode holding the
+// supplied pre-existing records, returning the reconciler, a warm cache and the
+// mock. cfg replaces the default reconciler config.
+func newConflictReconciler(t *testing.T, logger *slog.Logger, mode provider.OperationalMode, recordType provider.RecordType, target string, cfg Config, existing ...provider.Record) (*Reconciler, *recordCache, *testMockProvider) {
+	t.Helper()
+
+	mock := newTestMockProvider("test-dns")
+	for _, rec := range existing {
+		mock.AddRecord(rec)
+	}
+
+	providers := provider.NewRegistry(logger)
+	providers.RegisterFactory("mock", func(_ provider.FactoryConfig) (provider.Provider, error) {
+		return mock, nil
+	})
+	if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+		Name:       "test-dns",
+		TypeName:   "mock",
+		RecordType: recordType,
+		Target:     target,
+		TTL:        300,
+		Mode:       mode,
+		Domains:    []string{"*.example.com"},
+	}); err != nil {
+		t.Fatalf("CreateInstance failed: %v", err)
+	}
+
+	r := &Reconciler{
+		providers:      providers,
+		config:         cfg,
+		logger:         logger,
+		knownHostnames: make(map[string]struct{}),
+	}
+	r.syncAtomics()
+
+	return r, newRecordCache(context.Background(), providers, logger), mock
+}
+
+// A hostname that already carries a record of an incompatible type (a CNAME
+// where an A is wanted, or the reverse) used to be skipped forever. It is now
+// replaced when the instance may delete it: authoritative mode, ADOPT_EXISTING,
+// or an ownership record showing the conflicting record is dnsweaver's own.
+// Additive mode never deletes, and the skip warns once (issue #171).
+func TestEnsureRecord_TypeConflictPolicy(t *testing.T) {
+	existingCNAME := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeCNAME, Target: "proxy.example.com", TTL: 300}
+	existingA := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.99", TTL: 300}
+	existingHTTPS := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeHTTPS, Target: ".", TTL: 300}
+	ownership := provider.Record{Hostname: "_dnsweaver.app.example.com", Type: provider.RecordTypeTXT, Target: "heritage=dnsweaver"}
+
+	type step struct {
+		typ    ActionType
+		status ActionStatus
+	}
+	replaced := []step{{ActionDelete, StatusSuccess}, {ActionCreate, StatusSuccess}}
+	skipped := []step{{ActionSkip, StatusSkipped}}
+
+	tests := []struct {
+		name        string
+		mode        provider.OperationalMode
+		adopt       bool
+		dryRun      bool
+		desiredType provider.RecordType
+		target      string
+		existing    []provider.Record
+		deleteErr   func(provider.Record) error
+		want        []step
+		wantErr     string
+		wantDeleted int // records the mock actually removed
+		wantCreated int // non-TXT records the mock actually created
+	}{
+		{
+			name:        "unowned CNAME, managed, adopt off: skipped",
+			mode:        provider.ModeManaged,
+			desiredType: provider.RecordTypeA,
+			target:      "10.0.0.1",
+			existing:    []provider.Record{existingCNAME},
+			want:        skipped,
+			wantErr:     "conflict",
+		},
+		{
+			name:        "unowned CNAME, managed, adopt on: replaced",
+			mode:        provider.ModeManaged,
+			adopt:       true,
+			desiredType: provider.RecordTypeA,
+			target:      "10.0.0.1",
+			existing:    []provider.Record{existingCNAME},
+			want:        replaced,
+			wantDeleted: 1,
+			wantCreated: 1,
+		},
+		{
+			name:        "unowned CNAME, authoritative: replaced",
+			mode:        provider.ModeAuthoritative,
+			desiredType: provider.RecordTypeA,
+			target:      "10.0.0.1",
+			existing:    []provider.Record{existingCNAME},
+			want:        replaced,
+			wantDeleted: 1,
+			wantCreated: 1,
+		},
+		{
+			name:        "owned CNAME, managed, adopt off: replaced",
+			mode:        provider.ModeManaged,
+			desiredType: provider.RecordTypeA,
+			target:      "10.0.0.1",
+			existing:    []provider.Record{existingCNAME, ownership},
+			want:        replaced,
+			wantDeleted: 1,
+			wantCreated: 1,
+		},
+		{
+			name:        "additive never deletes, even with adopt on",
+			mode:        provider.ModeAdditive,
+			adopt:       true,
+			desiredType: provider.RecordTypeA,
+			target:      "10.0.0.1",
+			existing:    []provider.Record{existingCNAME, ownership},
+			want:        skipped,
+			wantErr:     "conflict",
+		},
+		{
+			name:        "dry-run reports the replacement without touching the provider",
+			mode:        provider.ModeAuthoritative,
+			dryRun:      true,
+			desiredType: provider.RecordTypeA,
+			target:      "10.0.0.1",
+			existing:    []provider.Record{existingCNAME},
+			want:        replaced,
+		},
+		{
+			name:        "desired CNAME over existing A, adopt off: skipped",
+			mode:        provider.ModeManaged,
+			desiredType: provider.RecordTypeCNAME,
+			target:      "proxy.example.com",
+			existing:    []provider.Record{existingA},
+			want:        skipped,
+			wantErr:     "conflict",
+		},
+		{
+			name:        "desired CNAME over existing A, adopt on: replaced",
+			mode:        provider.ModeManaged,
+			adopt:       true,
+			desiredType: provider.RecordTypeCNAME,
+			target:      "proxy.example.com",
+			existing:    []provider.Record{existingA},
+			want:        replaced,
+			wantDeleted: 1,
+			wantCreated: 1,
+		},
+		{
+			name:        "desired CNAME over owned A and companion HTTPS: both replaced",
+			mode:        provider.ModeManaged,
+			desiredType: provider.RecordTypeCNAME,
+			target:      "proxy.example.com",
+			existing:    []provider.Record{existingA, existingHTTPS, ownership},
+			want:        []step{{ActionDelete, StatusSuccess}, {ActionDelete, StatusSuccess}, {ActionCreate, StatusSuccess}},
+			wantDeleted: 2,
+			wantCreated: 1,
+		},
+		{
+			name:        "delete failure fails the action and creates nothing",
+			mode:        provider.ModeManaged,
+			adopt:       true,
+			desiredType: provider.RecordTypeA,
+			target:      "10.0.0.1",
+			existing:    []provider.Record{existingCNAME},
+			deleteErr:   func(provider.Record) error { return errors.New("api down") },
+			want:        []step{{ActionCreate, StatusFailed}},
+			wantErr:     "api down",
+		},
+		{
+			name:        "a failure part-way through keeps the deletes that succeeded and stops",
+			mode:        provider.ModeAuthoritative,
+			desiredType: provider.RecordTypeCNAME,
+			target:      "proxy.example.com",
+			existing:    []provider.Record{existingA, existingHTTPS},
+			deleteErr: func(rec provider.Record) error {
+				if rec.Type == provider.RecordTypeHTTPS {
+					return errors.New("api down")
+				}
+				return nil
+			},
+			want:        []step{{ActionDelete, StatusSuccess}, {ActionCreate, StatusFailed}},
+			wantErr:     "api down",
+			wantDeleted: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.AdoptExisting = tt.adopt
+			cfg.DryRun = tt.dryRun
+			r, cache, mock := newConflictReconciler(t, quietLogger(), tt.mode, tt.desiredType, tt.target, cfg, tt.existing...)
+			if tt.deleteErr != nil {
+				mock.deleteFn = func(_ context.Context, rec provider.Record) error { return tt.deleteErr(rec) }
+			}
+
+			actions := r.ensureRecord(context.Background(), &source.Hostname{Name: "app.example.com", Source: "test"}, cache)
+
+			if len(actions) != len(tt.want) {
+				t.Fatalf("expected %d action(s), got %d: %v", len(tt.want), len(actions), actions)
+			}
+			for i, want := range tt.want {
+				if actions[i].Type != want.typ || actions[i].Status != want.status {
+					t.Errorf("action %d: expected %s/%s, got %s/%s (%s)", i, want.typ, want.status, actions[i].Type, actions[i].Status, actions[i].Error)
+				}
+			}
+			last := actions[len(actions)-1]
+			if tt.wantErr != "" && !containsHelper(last.Error, tt.wantErr) {
+				t.Errorf("expected final action error to mention %q, got %q", tt.wantErr, last.Error)
+			}
+			if tt.wantErr == "" && last.Error != "" {
+				t.Errorf("expected no error on the final action, got %q", last.Error)
+			}
+
+			if got := len(mock.GetDeleted()); got != tt.wantDeleted {
+				t.Errorf("expected %d record(s) deleted, got %d: %v", tt.wantDeleted, got, mock.GetDeleted())
+			}
+			created := mock.GetCreatedDNSRecords()
+			if len(created) != tt.wantCreated {
+				t.Fatalf("expected %d record(s) created, got %d: %v", tt.wantCreated, len(created), created)
+			}
+			for _, rec := range created {
+				if rec.Type != tt.desiredType || rec.Target != tt.target {
+					t.Errorf("expected created record %s -> %s, got %s -> %s", tt.desiredType, tt.target, rec.Type, rec.Target)
+				}
+			}
+		})
+	}
+}
+
+// A conflict dnsweaver may not resolve is a standing condition, so the warning
+// is logged once per provider/hostname and at debug level afterwards.
+func TestEnsureRecord_TypeConflictWarnsOnce(t *testing.T) {
+	var warnings int
+	logger := slog.New(&countingHandler{level: slog.LevelWarn, count: &warnings})
+	r, cache, _ := newConflictReconciler(t, logger, provider.ModeManaged, provider.RecordTypeA, "10.0.0.1", DefaultConfig(),
+		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeCNAME, Target: "proxy.example.com", TTL: 300},
+	)
+
+	for range 3 {
+		actions := r.ensureRecord(context.Background(), &source.Hostname{Name: "app.example.com", Source: "test"}, cache)
+		if len(actions) != 1 || actions[0].Type != ActionSkip {
+			t.Fatalf("expected a single skip action, got %v", actions)
+		}
+	}
+	if warnings != 1 {
+		t.Errorf("expected 1 warn-level log across repeated passes, got %d", warnings)
+	}
+
+	r.ensureRecord(context.Background(), &source.Hostname{Name: "other.example.com", Source: "test"}, cache)
+	if warnings != 1 {
+		t.Errorf("a hostname with no conflict must not warn, got %d total", warnings)
+	}
+}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -95,17 +95,19 @@ type Reconciler struct {
 	enabled atomic.Bool
 	dryRun  atomic.Bool
 
-	// mu protects knownHostnames, recoveredMetadata, and warnedSelfCNAME during
+	// mu protects knownHostnames, recoveredMetadata, and warnedOnce during
 	// concurrent access
 	mu sync.RWMutex
 	// knownHostnames tracks hostnames discovered in the last reconciliation.
 	// Used for orphan detection.
 	knownHostnames map[string]struct{}
 
-	// warnedSelfCNAME tracks "provider|hostname" pairs already reported as
-	// self-referential CNAMEs, so the warning is logged once rather than on
-	// every reconciliation interval. Populated lazily.
-	warnedSelfCNAME map[string]struct{}
+	// warnedOnce tracks conditions already reported at warn level, keyed by
+	// "<reason>|<provider>|<hostname>", so a problem that cannot resolve on its
+	// own (a self-referential CNAME, a type conflict dnsweaver may not replace)
+	// is logged once rather than on every reconciliation interval. Populated
+	// lazily; see warnOnce.
+	warnedOnce map[string]struct{}
 
 	// hostnameProviders tracks which provider(s) each hostname was routed to
 	// in the previous reconciliation. Used by orphan cleanup to delete records


### PR DESCRIPTION
Closes #171.

A hostname that already held a CNAME (made by hand, or left over from an earlier config) where an A was configured, or the reverse, was skipped with `skipping due to record type conflict` on every interval and never converged. Two things made that permanent: the conflict check in `ensureRecordForProvider` ran before anything that could adopt or replace, so `DNSWEAVER_ADOPT_EXISTING` never got a look at it; and orphan cleanup only considers hostnames that are no longer desired, so authoritative mode never cleared the stale record either.

## Changes

**Replace when the instance may delete.** `canReplaceConflicting` says yes for authoritative mode, for `DNSWEAVER_ADOPT_EXISTING=true`, and for a hostname this instance already owns (the CNAME is dnsweaver's own from a previous configuration). Additive mode never deletes, so it never replaces. No new setting; the existing ones now reach this path, which is what their docs already claimed.

**Delete then create, with the failure case handled.** `replaceConflictingRecords` deletes each conflicting record through the same calls orphan cleanup uses, tolerates a record that vanished between list and delete, and stops at the first real failure: the action is marked failed and nothing is created on top of a half-cleared name. Replaced records come back as delete actions, so `DeletedCount()` and the metrics line up with orphan cleanup.

**Warn once, and say what would fix it.** When replacement isn't allowed the skip is unchanged, but the warning fires once per provider/hostname (debug after that) and names the setting that would let dnsweaver take over. The #165 warn-once helper is generalised into `warnOnce` for this.

**Dry-run sees conflicts.** The dry-run early return moved below the conflict check so `would replace conflicting record (dry-run)` is reported; the read is the same list the cache already does in dry-run.

Docs: `modes.md` and `environment.md` now describe the conflict behaviour under `ADOPT_EXISTING` and authoritative mode. CHANGELOG entry under Unreleased.

## Tests

`internal/reconciler/conflict_test.go`: table over unowned CNAME skip (managed, adopt off), adopt on, authoritative, owned CNAME with adopt off, additive with adopt on, dry-run (no provider calls, would-replace delete action), CNAME desired over existing A, owned A plus companion HTTPS both replaced before a CNAME, delete failure fails the action with no create, and a part-way failure that keeps the successful delete and stops. Plus a warn-once test across three passes. `go test ./... -race`, `go vet`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
