### PR TITLE
chore(release): v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-08-23
+
 ### Fixed
 - **Changing the Cloudflare proxied state did not reach existing records.** A
   `dnsweaver.proxied` label (or `dnsweaver.dev/proxied` annotation) was honored
@@ -1547,7 +1549,10 @@ release workflow.
 - GitLab CI/CD pipeline with GitHub release automation
 - Docker Hub and GitHub Container Registry publishing
 
-[Unreleased]: https://github.com/maxfield-allison/dnsweaver/compare/v2.7.1...HEAD
+[Unreleased]: https://github.com/maxfield-allison/dnsweaver/compare/v2.8.0...HEAD
+[2.8.0]: https://github.com/maxfield-allison/dnsweaver/compare/v2.7.3...v2.8.0
+[2.7.3]: https://github.com/maxfield-allison/dnsweaver/compare/v2.7.2...v2.7.3
+[2.7.2]: https://github.com/maxfield-allison/dnsweaver/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/maxfield-allison/dnsweaver/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/maxfield-allison/dnsweaver/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/maxfield-allison/dnsweaver/compare/v2.5.0...v2.6.0


### PR DESCRIPTION
Moves the Unreleased section under a v2.8.0 header dated today and fixes the compare links at the bottom (the Unreleased link still pointed at v2.7.1, and the 2.7.x releases had no links at all).

Minor bump rather than patch: the Proxmox work that landed in #172 adds `DNSWEAVER_PROXMOX_IP_VERSION` (dual-stack) and pool labels. Also in this release: #170 (#173), #171 (#175), Proxmox DHCP and multi-NIC LXC resolution (#172), and the Go 1.26.6 / x/mod security bumps.

Tag v2.8.0 follows once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)