### PR TITLE
fix: make image health checks honor the configured port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
           cache: true
       - name: go build
         run: go build ./...
+      - name: Build container image
+        run: docker build --build-arg VERSION=ci -t dnsweaver:healthcheck-test .
+      - name: Test container healthcheck
+        run: ./scripts/test-image-healthcheck.sh dnsweaver:healthcheck-test
 
   govulncheck:
     name: Vulnerability Scan

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -277,6 +277,7 @@ docker:build:amd64:
   script:
     - source build.env
     - docker build --pull --platform linux/amd64 --build-arg VERSION=$CI_COMMIT_SHORT_SHA --build-arg CACHE_BUST=$CI_PIPELINE_ID -t $IMAGE:$TAG-amd64 -t $IMAGE:sha-$CI_COMMIT_SHORT_SHA-amd64 .
+    - ./scripts/test-image-healthcheck.sh $IMAGE:$TAG-amd64
     - docker push $IMAGE:$TAG-amd64 && docker push $IMAGE:sha-$CI_COMMIT_SHORT_SHA-amd64
   artifacts:
     reports: { dotenv: build.env }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Container health checks now follow the configured server port.** The
+  official image no longer forces `DNSWEAVER_HEALTH_PORT=8080`, so
+  `server.port` in YAML works inside the container. Its built-in healthcheck
+  resolves the same YAML and environment precedence as the server, including
+  configs passed with `--config`, and probes the effective port without adding
+  `wget` or `curl` to the runtime image.
+  ([GitHub #187](https://github.com/maxfield-allison/dnsweaver/issues/187))
+
 ## [2.8.0] - 2026-08-23
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,12 +89,9 @@ COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 # Ensure binary and entrypoint are executable
 RUN chmod +x /usr/local/bin/dnsweaver /usr/local/bin/entrypoint.sh
 
-# Default environment variable (can be overridden)
-ENV DNSWEAVER_HEALTH_PORT="8080"
-
-# Health check (using busybox nc — no wget needed)
+# Health check (resolves the effective port from config)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD ["/bin/sh", "-c", "echo -e 'GET /health HTTP/1.0\r\nHost: localhost\r\n\r\n' | nc localhost 8080 | grep -q '200 OK' || exit 1"]
+    CMD ["/usr/local/bin/dnsweaver", "--healthcheck"]
 
 # Note: container starts as root so the entrypoint can detect the docker
 # socket GID and add the dnsweaver user to the matching group. The entrypoint

--- a/cmd/dnsweaver/healthcheck.go
+++ b/cmd/dnsweaver/healthcheck.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/maxfield-allison/dnsweaver/internal/config"
+	"github.com/maxfield-allison/dnsweaver/internal/health"
+)
+
+const (
+	healthcheckTimeout        = 4 * time.Second
+	processOneCommandLinePath = "/proc/1/cmdline"
+)
+
+func runHealthcheck() error {
+	configPath := config.GetConfigFilePath()
+	if configPath == "" {
+		configPath = processOneConfigPath()
+	}
+
+	port, err := config.ResolveHealthPort(configPath)
+	if err != nil {
+		return fmt.Errorf("resolving health port: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), healthcheckTimeout)
+	defer cancel()
+
+	return health.Probe(ctx, port)
+}
+
+// processOneConfigPath recovers a --config argument used to launch the main
+// container process. Docker healthcheck commands are separate processes, so
+// they do not otherwise inherit the main process's command-line flags.
+func processOneConfigPath() string {
+	commandLine, err := os.ReadFile(processOneCommandLinePath)
+	if err != nil {
+		return ""
+	}
+
+	return configPathFromArgs(strings.Split(string(commandLine), "\x00"))
+}
+
+func configPathFromArgs(args []string) string {
+	for i, arg := range args {
+		switch arg {
+		case "--config", "-config":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		default:
+			for _, prefix := range []string{"--config=", "-config="} {
+				if path, ok := strings.CutPrefix(arg, prefix); ok {
+					return path
+				}
+			}
+		}
+	}
+
+	return ""
+}

--- a/cmd/dnsweaver/healthcheck_test.go
+++ b/cmd/dnsweaver/healthcheck_test.go
@@ -1,0 +1,43 @@
+package main
+
+import "testing"
+
+func TestConfigPathFromArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "long flag",
+			args: []string{"/usr/local/bin/dnsweaver", "--config", "/etc/dnsweaver/config.yml"},
+			want: "/etc/dnsweaver/config.yml",
+		},
+		{
+			name: "long flag with equals",
+			args: []string{"/usr/local/bin/dnsweaver", "--config=/etc/dnsweaver/config.yml"},
+			want: "/etc/dnsweaver/config.yml",
+		},
+		{
+			name: "single-dash flag",
+			args: []string{"/usr/local/bin/dnsweaver", "-config", "/etc/dnsweaver/config.yml"},
+			want: "/etc/dnsweaver/config.yml",
+		},
+		{
+			name: "missing value",
+			args: []string{"/usr/local/bin/dnsweaver", "--config"},
+		},
+		{
+			name: "no config flag",
+			args: []string{"/usr/local/bin/dnsweaver"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := configPathFromArgs(tc.args); got != tc.want {
+				t.Errorf("configPathFromArgs() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/dnsweaver/main.go
+++ b/cmd/dnsweaver/main.go
@@ -45,6 +45,7 @@ func main() {
 	configPath := flag.String("config", "", "Path to YAML configuration file")
 	showVersion := flag.Bool("version", false, "Show version and exit")
 	validateOnly := flag.Bool("validate", false, "Validate configuration and exit")
+	healthcheckOnly := flag.Bool("healthcheck", false, "Probe the running health endpoint and exit")
 	flag.Parse()
 
 	if *showVersion {
@@ -59,6 +60,14 @@ func main() {
 			slog.Error("failed to set DNSWEAVER_CONFIG", slog.String("error", err.Error()))
 			os.Exit(1)
 		}
+	}
+
+	if *healthcheckOnly {
+		if err := runHealthcheck(); err != nil {
+			fmt.Fprintf(os.Stderr, "Health check failed: %s\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	// Surface environment variables with a misspelled DNSWEAVER prefix (e.g.

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -184,7 +184,7 @@ services:
   dnsweaver:
     image: maxamill/dnsweaver:latest
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "/usr/local/bin/dnsweaver", "--healthcheck"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/deployment/swarm.md
+++ b/docs/deployment/swarm.md
@@ -136,7 +136,7 @@ services:
     secrets:
       - dns_token
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "/usr/local/bin/dnsweaver", "--healthcheck"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/examples/docker-stack-testing.example.yml
+++ b/docs/examples/docker-stack-testing.example.yml
@@ -52,7 +52,7 @@ services:
         protocol: tcp
         mode: ingress
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "/usr/local/bin/dnsweaver", "--healthcheck"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -263,7 +263,7 @@ Add to your Docker Compose or Swarm deployment:
 
 ```yaml
 healthcheck:
-  test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+  test: ["CMD", "/usr/local/bin/dnsweaver", "--healthcheck"]
   interval: 30s
   timeout: 10s
   retries: 3

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -368,17 +368,10 @@ func loadGlobalConfig() (*GlobalConfig, []*ConfigError) {
 	}
 
 	// Parse HEALTH_PORT
-	if portStr := getEnv("DNSWEAVER_HEALTH_PORT"); portStr != "" {
-		port, err := strconv.Atoi(portStr)
-		if err != nil {
-			errs = append(errs, configErrFull("DNSWEAVER_HEALTH_PORT", fmt.Sprintf("invalid integer %q", portStr), "Must be a valid TCP port number", "DNSWEAVER_HEALTH_PORT=8080"))
-		} else if port < 1 || port > 65535 {
-			errs = append(errs, configErrFull("DNSWEAVER_HEALTH_PORT", fmt.Sprintf("must be between 1 and 65535, got %d", port), "Choose an unprivileged port (1024-65535)", "DNSWEAVER_HEALTH_PORT=8080"))
-		} else {
-			cfg.HealthPort = port
-		}
-	} else {
-		cfg.HealthPort = DefaultHealthPort
+	var healthPortErr *ConfigError
+	cfg.HealthPort, healthPortErr = healthPortFromEnvironment(DefaultHealthPort)
+	if healthPortErr != nil {
+		errs = append(errs, healthPortErr)
 	}
 
 	// Parse INSTANCE_ID

--- a/internal/config/health.go
+++ b/internal/config/health.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ResolveHealthPort returns the port used by the health and metrics server.
+// It follows the same precedence as Load: environment, config file, defaults.
+// Only the server port is resolved so container health checks do not need to
+// read provider credentials or validate unrelated configuration on every run.
+func ResolveHealthPort(configPath string) (int, error) {
+	port := DefaultHealthPort
+
+	if configPath != "" {
+		fileCfg, err := LoadFile(configPath)
+		if err != nil {
+			return 0, err
+		}
+		port = fileCfg.ToGlobalConfig().HealthPort
+	}
+
+	port, configErr := healthPortFromEnvironment(port)
+	if configErr != nil {
+		return 0, configErr
+	}
+
+	return port, nil
+}
+
+func healthPortFromEnvironment(fallback int) (int, *ConfigError) {
+	portStr := getEnv("DNSWEAVER_HEALTH_PORT")
+	if portStr == "" {
+		return fallback, nil
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fallback, configErrFull(
+			"DNSWEAVER_HEALTH_PORT",
+			fmt.Sprintf("invalid integer %q", portStr),
+			"Must be a valid TCP port number",
+			"DNSWEAVER_HEALTH_PORT=8080",
+		)
+	}
+	if port < 1 || port > 65535 {
+		return fallback, configErrFull(
+			"DNSWEAVER_HEALTH_PORT",
+			fmt.Sprintf("must be between 1 and 65535, got %d", port),
+			"Choose an unprivileged port (1024-65535)",
+			"DNSWEAVER_HEALTH_PORT=8080",
+		)
+	}
+
+	return port, nil
+}

--- a/internal/config/health.go
+++ b/internal/config/health.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strconv"
+
+	"gopkg.in/yaml.v3"
 )
 
 // ResolveHealthPort returns the port used by the health and metrics server.
@@ -13,11 +16,11 @@ func ResolveHealthPort(configPath string) (int, error) {
 	port := DefaultHealthPort
 
 	if configPath != "" {
-		fileCfg, err := LoadFile(configPath)
+		filePort, err := healthPortFromFile(configPath)
 		if err != nil {
 			return 0, err
 		}
-		port = fileCfg.ToGlobalConfig().HealthPort
+		port = filePort
 	}
 
 	port, configErr := healthPortFromEnvironment(port)
@@ -26,6 +29,25 @@ func ResolveHealthPort(configPath string) (int, error) {
 	}
 
 	return port, nil
+}
+
+func healthPortFromFile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("reading config file: %w", err)
+	}
+
+	var fileCfg struct {
+		Server *FileServerConfig `yaml:"server,omitempty"`
+	}
+	if err := yaml.Unmarshal(data, &fileCfg); err != nil {
+		return 0, fmt.Errorf("parsing YAML config: %w", err)
+	}
+
+	if fileCfg.Server != nil && fileCfg.Server.Port > 0 && fileCfg.Server.Port <= 65535 {
+		return fileCfg.Server.Port, nil
+	}
+	return DefaultHealthPort, nil
 }
 
 func healthPortFromEnvironment(fallback int) (int, *ConfigError) {

--- a/internal/config/health_test.go
+++ b/internal/config/health_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveHealthPort(t *testing.T) {
+	t.Run("compiled default", func(t *testing.T) {
+		t.Setenv("DNSWEAVER_HEALTH_PORT", "")
+
+		port, err := ResolveHealthPort("")
+		if err != nil {
+			t.Fatalf("ResolveHealthPort() error = %v", err)
+		}
+		if port != DefaultHealthPort {
+			t.Errorf("ResolveHealthPort() = %d, want %d", port, DefaultHealthPort)
+		}
+	})
+
+	t.Run("YAML value", func(t *testing.T) {
+		t.Setenv("DNSWEAVER_HEALTH_PORT", "")
+		path := writeHealthConfig(t, "server:\n  port: 18080\n")
+
+		port, err := ResolveHealthPort(path)
+		if err != nil {
+			t.Fatalf("ResolveHealthPort() error = %v", err)
+		}
+		if port != 18080 {
+			t.Errorf("ResolveHealthPort() = %d, want 18080", port)
+		}
+	})
+
+	t.Run("environment overrides YAML", func(t *testing.T) {
+		t.Setenv("DNSWEAVER_HEALTH_PORT", "19090")
+		path := writeHealthConfig(t, "server:\n  port: 18080\n")
+
+		port, err := ResolveHealthPort(path)
+		if err != nil {
+			t.Fatalf("ResolveHealthPort() error = %v", err)
+		}
+		if port != 19090 {
+			t.Errorf("ResolveHealthPort() = %d, want 19090", port)
+		}
+	})
+
+	t.Run("invalid environment value", func(t *testing.T) {
+		t.Setenv("DNSWEAVER_HEALTH_PORT", "not-a-port")
+
+		_, err := ResolveHealthPort("")
+		if err == nil {
+			t.Fatal("ResolveHealthPort() error = nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "DNSWEAVER_HEALTH_PORT") {
+			t.Errorf("ResolveHealthPort() error = %q, want field name", err)
+		}
+	})
+
+	t.Run("missing YAML file", func(t *testing.T) {
+		t.Setenv("DNSWEAVER_HEALTH_PORT", "")
+
+		_, err := ResolveHealthPort(filepath.Join(t.TempDir(), "missing.yml"))
+		if err == nil {
+			t.Fatal("ResolveHealthPort() error = nil, want an error")
+		}
+	})
+}
+
+func writeHealthConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -251,12 +251,10 @@ func mergeGlobalConfig(base *GlobalConfig) (*GlobalConfig, []*ConfigError) {
 		}
 	}
 
-	if v := getEnv("DNSWEAVER_HEALTH_PORT"); v != "" {
-		if port, err := parseIntEnv(v); err == nil && port >= 1 && port <= 65535 {
-			cfg.HealthPort = port
-		} else {
-			errs = append(errs, configErrFull("DNSWEAVER_HEALTH_PORT", fmt.Sprintf("invalid value %q", v), "Must be a valid TCP port (1-65535)", "DNSWEAVER_HEALTH_PORT=8080"))
-		}
+	var healthPortErr *ConfigError
+	cfg.HealthPort, healthPortErr = healthPortFromEnvironment(cfg.HealthPort)
+	if healthPortErr != nil {
+		errs = append(errs, healthPortErr)
 	}
 
 	// Note: DNSWEAVER_SOURCE (singular) is deprecated. Source list is

--- a/internal/health/probe.go
+++ b/internal/health/probe.go
@@ -1,0 +1,30 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Probe checks the local liveness endpoint on port.
+func Probe(ctx context.Context, port int) error {
+	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating health request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("probing %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("probing %s: received %s", url, resp.Status)
+	}
+
+	return nil
+}

--- a/internal/health/probe_test.go
+++ b/internal/health/probe_test.go
@@ -1,0 +1,81 @@
+package health
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestProbe(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{name: "healthy", statusCode: http.StatusOK},
+		{name: "unhealthy status", statusCode: http.StatusServiceUnavailable, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer server.Close()
+
+			port := serverPort(t, server.Listener.Addr())
+			err := Probe(context.Background(), port)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Probe() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestProbeConnectionFailure(t *testing.T) {
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := serverPort(t, listener.Addr())
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	err = Probe(context.Background(), port)
+	if err == nil {
+		t.Fatal("Probe() error = nil, want a connection error")
+	}
+}
+
+func serverPort(t *testing.T, addr net.Addr) int {
+	t.Helper()
+
+	_, portString, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("Atoi(%q): %v", portString, err)
+	}
+	return port
+}
+
+func TestProbeErrorIncludesEndpoint(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := Probe(ctx, 18080)
+	if err == nil {
+		t.Fatal("Probe() error = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "127.0.0.1:18080/health") {
+		t.Errorf("Probe() error = %q, want endpoint", err)
+	}
+}

--- a/scripts/test-image-healthcheck.sh
+++ b/scripts/test-image-healthcheck.sh
@@ -49,6 +49,9 @@ docker run --detach \
     --mount "type=bind,source=$config_path,target=/etc/dnsweaver/config.yml,readonly" \
     "$image" --config /etc/dnsweaver/config.yml >/dev/null
 wait_for_healthy "$container_yaml"
+docker exec \
+    --env DNSWEAVER_HEALTH_PORT=18080 \
+    "$container_yaml" /usr/local/bin/dnsweaver --healthcheck
 
 # An environment override must take precedence over the YAML port for both.
 docker run --detach \
@@ -58,3 +61,6 @@ docker run --detach \
     --env DNSWEAVER_HEALTH_PORT=18081 \
     "$image" >/dev/null
 wait_for_healthy "$container_env"
+docker exec \
+    --env DNSWEAVER_HEALTH_PORT=18081 \
+    "$container_env" /usr/local/bin/dnsweaver --healthcheck

--- a/scripts/test-image-healthcheck.sh
+++ b/scripts/test-image-healthcheck.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+image=dnsweaver:healthcheck-test
+if [ "$#" -gt 0 ]; then
+    image=$1
+fi
+config_path="$repo_root/testdata/image-healthcheck-config.yml"
+container_prefix="dnsweaver-healthcheck-$$"
+container_yaml="$container_prefix-yaml"
+container_env="$container_prefix-env"
+
+cleanup() {
+    docker rm -f "$container_yaml" "$container_env" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+wait_for_healthy() {
+    container_name=$1
+    attempts=0
+
+    while [ "$attempts" -lt 30 ]; do
+        status=$(docker inspect --format '{{.State.Health.Status}}' "$container_name")
+        case "$status" in
+            healthy)
+                return 0
+                ;;
+            unhealthy)
+                docker inspect --format '{{json .State.Health.Log}}' "$container_name"
+                docker logs "$container_name"
+                return 1
+                ;;
+        esac
+
+        attempts=$((attempts + 1))
+        sleep 2
+    done
+
+    docker inspect --format '{{json .State.Health}}' "$container_name"
+    docker logs "$container_name"
+    return 1
+}
+
+# YAML selected through the CLI must drive both the server and image healthcheck.
+docker run --detach \
+    --name "$container_yaml" \
+    --mount "type=bind,source=$config_path,target=/etc/dnsweaver/config.yml,readonly" \
+    "$image" --config /etc/dnsweaver/config.yml >/dev/null
+wait_for_healthy "$container_yaml"
+
+# An environment override must take precedence over the YAML port for both.
+docker run --detach \
+    --name "$container_env" \
+    --mount "type=bind,source=$config_path,target=/etc/dnsweaver/config.yml,readonly" \
+    --env DNSWEAVER_CONFIG=/etc/dnsweaver/config.yml \
+    --env DNSWEAVER_HEALTH_PORT=18081 \
+    "$image" >/dev/null
+wait_for_healthy "$container_env"

--- a/testdata/image-healthcheck-config.yml
+++ b/testdata/image-healthcheck-config.yml
@@ -1,0 +1,24 @@
+platform: none
+
+server:
+  port: 18080
+
+sources:
+  - name: traefik
+    file_discovery:
+      paths:
+        - /tmp
+      pattern: "*.yml"
+      poll_interval: 60s
+      watch_method: poll
+
+providers:
+  - name: test
+    type: webhook
+    domains:
+      - "*.example.com"
+    target: 192.0.2.1
+    config:
+      url: http://127.0.0.1:9
+      timeout: 1s
+      retries: "0"


### PR DESCRIPTION
## Summary

The image healthcheck now uses `DNSWEAVER_HEALTH_PORT` when it is set. Otherwise it reads `server.port` from YAML, then falls back to the compiled default of 8080.

- Removes the Dockerfile's `DNSWEAVER_HEALTH_PORT=8080` default so it no longer overrides YAML configuration.
- Adds `dnsweaver --healthcheck`. It reads only `server.port`, then probes `http://127.0.0.1:<port>/health` with a four-second timeout.
- Recovers the config path from `/proc/1/cmdline` when the container's main process was started with `--config`.
- Replaces the `wget` healthchecks in the Docker Compose, Swarm, testing, and observability examples with the binary command.

The Helm chart already derives its container port and named probes from `config.server.port`, so it does not need a template change. Removing the image ENV lets that existing wiring work.

Both the GitHub Build job and GitLab amd64 image build now run `scripts/test-image-healthcheck.sh`. The script starts the real image with a YAML port of 18080 and an environment override of 18081. It waits for both containers to become healthy and probes the expected ports directly.

## Related issues

Closes #187

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [x] Maintenance / refactor / CI

## Verification

- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run --config .golangci.yml --timeout 5m` (0 issues)
- `scripts/test-image-healthcheck.sh`
- `helm template` with `config.server.port=18080`, confirming the config, container port, and named probes stay aligned

## Checklist

- [x] `gofmt` clean and `golangci-lint` passes
- [x] `go test ./...` passes (added/updated tests where relevant)
- [x] `go build ./...` succeeds
- [x] Docs updated (README / docs site) if behavior or config changed
- [x] CHANGELOG.md updated under the Unreleased section if user-facing
