### PR TITLE
fix: make release image jobs portable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
   GOFLAGS: "-mod=readonly"
   BINARY_NAME: "dnsweaver"
   REGISTRY: "registry.probablyfine.dev"
-  IMAGE: "registry.probablyfine.dev/root/dnsweaver"
+  IMAGE: "$CI_REGISTRY_IMAGE"
   # Deploy target - set these as CI/CD variables or override here
   # DEPLOY_HOST: "swarm-manager.example.com"
   # DEPLOY_USER: "deploy"
@@ -34,7 +34,7 @@ workflow:
 .rules-docker: &rules-docker
   - if: $CI_COMMIT_TAG
   - if: $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "develop"
-    changes: &docker-files ["{**/*.go,go.mod,go.sum,Dockerfile,.dockerignore}"]
+    changes: &docker-files ["{**/*.go,go.mod,go.sum,Dockerfile,.dockerignore,.gitlab-ci.yml,scripts/test-image-healthcheck.sh,testdata/image-healthcheck-config.yml}"]
   - if: $CI_COMMIT_BRANCH =~ /^(feature|bugfix|hotfix|fix)\//
     changes: *docker-files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+
+- **GitLab image jobs now use the current project registry path and work with
+  host-socket Docker runners.** Image names come from `CI_REGISTRY_IMAGE`, and
+  the built-image healthcheck test copies its fixture through the Docker API
+  instead of requiring the daemon to see the CI job's filesystem path.
+
 ## [2.8.1] - 2026-09-02
 
 ### Fixed

--- a/scripts/test-image-healthcheck.sh
+++ b/scripts/test-image-healthcheck.sh
@@ -43,23 +43,28 @@ wait_for_healthy() {
     return 1
 }
 
+# Copy the fixture through the Docker API so this works when the Docker daemon
+# runs outside the CI job container (for example, through a mounted host socket).
+
 # YAML selected through the CLI must drive both the server and image healthcheck.
-docker run --detach \
+docker create \
     --name "$container_yaml" \
-    --mount "type=bind,source=$config_path,target=/etc/dnsweaver/config.yml,readonly" \
-    "$image" --config /etc/dnsweaver/config.yml >/dev/null
+    "$image" --config /tmp/dnsweaver-config.yml >/dev/null
+docker cp "$config_path" "$container_yaml:/tmp/dnsweaver-config.yml"
+docker start "$container_yaml" >/dev/null
 wait_for_healthy "$container_yaml"
 docker exec \
     --env DNSWEAVER_HEALTH_PORT=18080 \
     "$container_yaml" /usr/local/bin/dnsweaver --healthcheck
 
 # An environment override must take precedence over the YAML port for both.
-docker run --detach \
+docker create \
     --name "$container_env" \
-    --mount "type=bind,source=$config_path,target=/etc/dnsweaver/config.yml,readonly" \
-    --env DNSWEAVER_CONFIG=/etc/dnsweaver/config.yml \
+    --env DNSWEAVER_CONFIG=/tmp/dnsweaver-config.yml \
     --env DNSWEAVER_HEALTH_PORT=18081 \
     "$image" >/dev/null
+docker cp "$config_path" "$container_env:/tmp/dnsweaver-config.yml"
+docker start "$container_env" >/dev/null
 wait_for_healthy "$container_env"
 docker exec \
     --env DNSWEAVER_HEALTH_PORT=18081 \


### PR DESCRIPTION
## Summary

- derive the internal image name from `CI_REGISTRY_IMAGE` instead of a stale namespace
- copy the healthcheck fixture through the Docker API so host-socket runners do not need to resolve the job container filesystem
- run Docker jobs when their pipeline configuration, regression script, or fixture changes

## Why

The `v2.8.1` tag pipeline exposed both portability problems after the image itself built: the amd64 regression test used a bind source that the host daemon could not see, while the arm64 push targeted the project former registry namespace. The public release and image jobs therefore did not run. The existing tag remains unchanged.

## Verification

- `sh -n scripts/test-image-healthcheck.sh`
- `./scripts/test-image-healthcheck.sh dnsweaver:healthcheck-test`
- `git diff --check`
- GitLab CI lint: valid, no warnings