### PR TITLE
feat: scope existing-record adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Existing-record adoption can now be scoped to a provider, workload, or
+  named record.** `DNSWEAVER_{NAME}_ADOPT_EXISTING` overrides the global policy
+  for one provider. `dnsweaver.adopt` and `dnsweaver.dev/adopt` apply to every
+  hostname found on a workload, including hostnames discovered through
+  Traefik, while `dnsweaver.records.<name>.adopt` can narrow one named record.
+  Workloads may always disable adoption. Enabling it from a workload requires
+  `DNSWEAVER_{NAME}_ADOPT_EXISTING_ALLOW_OVERRIDES=true` on each provider that
+  permits the takeover, so one label cannot grant itself access to every DNS
+  backend.
+  ([GitHub #178](https://github.com/maxfield-allison/dnsweaver/issues/178))
+
+### Fixed
+
+- **Managed mode now leaves unowned same-type records untouched when adoption
+  is disabled.** A pre-existing A, AAAA, CNAME, or SRV record with a different
+  target could previously be updated even though `ADOPT_EXISTING=false`.
+  Adoption policy now guards ownership creation, provider-state updates,
+  target changes, type-conflict replacement, and create-race conflicts through
+  one decision path.
+
 ## [2.8.2] - 2026-09-03
 
 `v2.8.1` was tagged, but its image pipeline stopped before the public release

--- a/docs/config.example.yml
+++ b/docs/config.example.yml
@@ -38,7 +38,8 @@
 #   TOKEN, API_KEY, AUTH_TOKEN, PASSWORD, TSIG_SECRET, SSH_PASSWORD
 #
 # Non-secret fields (env var override only, no _FILE):
-#   URL, ZONE, ZONE_ID, API_EMAIL, TARGET, TTL, MODE
+#   URL, ZONE, ZONE_ID, API_EMAIL, TARGET, TTL, MODE, ADOPT_EXISTING,
+#   ADOPT_EXISTING_ALLOW_OVERRIDES
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # Logging configuration
@@ -113,6 +114,8 @@ providers:
     target: 192.0.2.100    # Where to point DNS records (your load balancer/gateway IP)
     ttl: 300              # TTL in seconds
     mode: managed         # managed, authoritative, or additive
+    adopt_existing: false # Override the global adoption policy for this provider
+    adopt_existing_allow_overrides: false # Allow workload labels to enable adoption
     config:
       url: http://dns.example.com:5380
       token: ${TECHNITIUM_TOKEN}        # env var interpolation

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -37,7 +37,7 @@ dnsweaver --config /etc/dnsweaver/config.yml
 | `DNSWEAVER_CLEANUP_ORPHANS` | `true` | Delete DNS records when workloads are removed |
 | `DNSWEAVER_CLEANUP_ON_STOP` | `true` | Delete DNS records when containers stop |
 | `DNSWEAVER_OWNERSHIP_TRACKING` | `true` | Use TXT records to track record ownership |
-| `DNSWEAVER_ADOPT_EXISTING` | `false` | Adopt existing DNS records by creating ownership TXT; also replaces a pre-existing record of a conflicting type (for example a CNAME where an A is configured) instead of skipping it |
+| `DNSWEAVER_ADOPT_EXISTING` | `false` | Global default for adopting existing DNS records. In managed mode, adoption permits ownership creation and updates or replacement of matching unowned records. |
 | `DNSWEAVER_DEFAULT_TTL` | `300` | Default TTL for DNS records (seconds) |
 | `DNSWEAVER_RECONCILE_INTERVAL` | `60s` | Periodic reconciliation interval |
 | `DNSWEAVER_SHUTDOWN_TIMEOUT` | `30s` | Graceful shutdown timeout for in-flight updates |
@@ -143,6 +143,8 @@ Replace `{NAME}` with your instance name. For example, instance `internal-dns` u
 | `DNSWEAVER_{NAME}_ENTRYPOINTS` | No | Comma-separated Traefik entrypoint allowlist for this instance (e.g. `webA,webB`). Only routers bound to one of these entrypoints will be matched. Routers without entrypoint metadata always match (wildcard). See [Traefik source](../sources/swarm.md#per-entrypoint-routing). |
 | `DNSWEAVER_{NAME}_TTL` | No | Per-instance TTL override |
 | `DNSWEAVER_{NAME}_MODE` | No | Operational mode: `managed` (default), `authoritative`, `additive` |
+| `DNSWEAVER_{NAME}_ADOPT_EXISTING` | No | Override `DNSWEAVER_ADOPT_EXISTING` for this provider instance. When unset, the global setting is inherited. |
+| `DNSWEAVER_{NAME}_ADOPT_EXISTING_ALLOW_OVERRIDES` | No | Allow workload `adopt=true` labels or annotations to enable adoption for this provider. Default: `false`. Workloads may always disable adoption. |
 | `DNSWEAVER_{NAME}_TLS_CA_FILE` | No | Path to a PEM CA bundle appended to system roots (private CAs). Supports `_FILE` suffix. |
 | `DNSWEAVER_{NAME}_TLS_CERT_FILE` | No | Path to PEM client certificate for mutual TLS. Must be set with `TLS_KEY_FILE`. |
 | `DNSWEAVER_{NAME}_TLS_KEY_FILE` | No | Path to PEM client private key for mutual TLS. Must be set with `TLS_CERT_FILE`. |
@@ -150,6 +152,25 @@ Replace `{NAME}` with your instance name. For example, instance `internal-dns` u
 | `DNSWEAVER_{NAME}_TLS_MIN_VERSION` | No | Minimum TLS protocol version: `1.2` (default) or `1.3`. |
 | `DNSWEAVER_{NAME}_TLS_SKIP_VERIFY` | No | Skip TLS certificate verification (`true`/`false`, default: `false`). **Warning:** disables MITM protection — prefer `TLS_CA_FILE`. |
 | `DNSWEAVER_{NAME}_INSECURE_SKIP_VERIFY` | No | **Deprecated** — alias of `TLS_SKIP_VERIFY`. Will be removed in a future major release. |
+
+### Existing-record adoption
+
+Adoption is resolved for each hostname and provider in this order:
+
+1. `DNSWEAVER_ADOPT_EXISTING` supplies the global default.
+2. `DNSWEAVER_{NAME}_ADOPT_EXISTING` overrides it for one provider.
+3. `dnsweaver.adopt` or `dnsweaver.dev/adopt` overrides it for every hostname discovered from that workload, including hostnames found by Traefik.
+4. `dnsweaver.records.<record>.adopt` overrides the workload value for one named record.
+
+A workload value of `false` is always honored. A workload or record value of
+`true` can raise an effective `false` value only when
+`DNSWEAVER_{NAME}_ADOPT_EXISTING_ALLOW_OVERRIDES=true` for that provider. This
+gate is per provider so access to one DNS backend does not grant workloads
+permission to claim records in every configured backend.
+
+These settings govern adoption in managed mode. Authoritative mode already
+controls every record in its configured scope. Additive mode never deletes a
+conflicting record.
 
 ### Dynamic Targets
 

--- a/docs/configuration/modes.md
+++ b/docs/configuration/modes.md
@@ -144,7 +144,21 @@ These global settings interact with operational modes:
 | `DNSWEAVER_CLEANUP_ORPHANS` | If `false`, disables deletion globally (overrides managed/authoritative) |
 | `DNSWEAVER_CLEANUP_ON_STOP` | If `false`, only delete records when containers are removed, not stopped |
 | `DNSWEAVER_OWNERSHIP_TRACKING` | If `false`, dnsweaver can't distinguish its own records from others |
-| `DNSWEAVER_ADOPT_EXISTING` | If `true`, dnsweaver claims ownership of pre-existing records, and replaces a pre-existing record of a conflicting type (for example a CNAME where an A is configured) instead of skipping it. Managed mode without it skips the record and logs once; additive mode never replaces it |
+| `DNSWEAVER_ADOPT_EXISTING` | Global default for claiming pre-existing records. Managed mode without adoption leaves unowned records untouched, including records with the wrong target or a conflicting type. |
+| `DNSWEAVER_{NAME}_ADOPT_EXISTING` | Overrides the global adoption policy for one provider instance. |
+| `DNSWEAVER_{NAME}_ADOPT_EXISTING_ALLOW_OVERRIDES` | Lets workload labels enable adoption for one provider instance. Defaults to `false`. Workload labels may always disable adoption. |
+
+### Adoption precedence and workload trust
+
+The effective adoption policy is global, then provider instance, then workload,
+then named record. `dnsweaver.adopt` applies to hostnames found by any source on
+the workload. `dnsweaver.records.<name>.adopt` is more specific and wins for
+that named record.
+
+Workload configuration is not trusted to claim existing DNS records by
+default. An `adopt=true` label or annotation is ignored unless the matching
+provider sets `ADOPT_EXISTING_ALLOW_OVERRIDES=true`. An `adopt=false` value is
+always honored because it only narrows dnsweaver's authority.
 
 ## Choosing the Right Mode
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -130,6 +130,7 @@ dnsweaver supports per-resource annotation overrides using the `dnsweaver.dev/` 
 | `dnsweaver.dev/ttl` | seconds (e.g., `300`) | Override the TTL |
 | `dnsweaver.dev/provider` | provider name | Route to a specific provider |
 | `dnsweaver.dev/proxied` | `true` / `false` | Enable Cloudflare proxy |
+| `dnsweaver.dev/adopt` | `true` / `false` | Enable or disable existing-record adoption. Enabling requires the matching provider's `ADOPT_EXISTING_ALLOW_OVERRIDES` gate. Disabling is always honored. |
 
 ### Example: Ingress with Annotations
 

--- a/docs/examples/config.example.yml
+++ b/docs/examples/config.example.yml
@@ -38,7 +38,8 @@
 #   TOKEN, API_KEY, AUTH_TOKEN, PASSWORD
 #
 # Non-secret fields (env var override only, no _FILE):
-#   URL, ZONE, ZONE_ID, API_EMAIL, TARGET, TTL, MODE
+#   URL, ZONE, ZONE_ID, API_EMAIL, TARGET, TTL, MODE, ADOPT_EXISTING,
+#   ADOPT_EXISTING_ALLOW_OVERRIDES
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # Logging configuration
@@ -92,6 +93,8 @@ providers:
     target: 192.0.2.100    # Where to point DNS records (your load balancer/gateway IP)
     ttl: 300              # TTL in seconds
     mode: managed         # managed, authoritative, or additive
+    adopt_existing: false # Override the global adoption policy for this provider
+    adopt_existing_allow_overrides: false # Allow workload labels to enable adoption
     config:
       url: http://dns.example.com:5380
       token: ${TECHNITIUM_TOKEN}        # env var interpolation

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,6 +44,10 @@ By default, dnsweaver only manages records it creates (tracked via ownership TXT
 !!! warning
     This will modify existing records. Test with `DRY_RUN=true` first.
 
+You can override the policy for one provider or workload. Workload labels may
+only enable adoption when the matching provider explicitly allows it. See
+[Existing-record adoption](configuration/environment.md#existing-record-adoption).
+
 ## Configuration
 
 ### Why aren't my container labels being detected?

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -112,8 +112,9 @@ the instance's `PROXIED` default.
 Changing either setting updates records that already exist: when a record's
 proxied state differs from what the label or the `PROXIED` default now asks
 for, dnsweaver updates it in place on the next reconciliation. This applies to
-records dnsweaver manages (its own records, or any matching record when
-`DNSWEAVER_ADOPT_EXISTING=true`); records it does not manage are left as found.
+records dnsweaver manages (its own records, or matching records allowed by the
+effective [adoption policy](../configuration/environment.md#existing-record-adoption)).
+Records it does not manage are left as found.
 
 ## Split-Horizon with Cloudflare
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -196,3 +196,7 @@ To adopt existing records (and take ownership):
 ```bash
 DNSWEAVER_ADOPT_EXISTING=true
 ```
+
+The global policy can be narrowed per provider or workload. Workload requests
+to enable adoption require an explicit per-provider gate. See
+[Existing-record adoption](../configuration/environment.md#existing-record-adoption).

--- a/docs/sources/kubernetes.md
+++ b/docs/sources/kubernetes.md
@@ -70,6 +70,7 @@ The Kubernetes source reads `dnsweaver.dev/*` annotations from resources to over
 | `dnsweaver.dev/ttl` | `int` | _(from provider)_ | Override TTL in seconds |
 | `dnsweaver.dev/provider` | `string` | _(auto-matched)_ | Route to a specific DNS provider by name |
 | `dnsweaver.dev/proxied` | `bool` | _(from provider)_ | Enable Cloudflare proxy for this record |
+| `dnsweaver.dev/adopt` | `bool` | _(from provider/global policy)_ | Enable or disable existing-record adoption for every hostname on this resource. Enabling requires the matching provider's `ADOPT_EXISTING_ALLOW_OVERRIDES` gate. Disabling is always honored. |
 
 ### Behavior
 

--- a/docs/sources/native-labels.md
+++ b/docs/sources/native-labels.md
@@ -41,7 +41,7 @@ labels:
   - "dnsweaver.hostnames=app1.example.com,app2.example.com,app3.example.com"
 ```
 
-Whitespace around commas is trimmed and empty values are skipped. This can be combined with `dnsweaver.ttl` and `dnsweaver.proxied`, which apply to all hostnames in the list.
+Whitespace around commas is trimmed and empty values are skipped. This can be combined with `dnsweaver.ttl`, `dnsweaver.proxied`, and `dnsweaver.adopt`, which apply to all hostnames in the list.
 
 Both `dnsweaver.hostname` (singular) and `dnsweaver.hostnames` (plural) can be used together — all hostnames are processed.
 
@@ -82,6 +82,7 @@ labels:
 | `dnsweaver.enabled` | `true` | Enable/disable processing |
 | `dnsweaver.ttl` | - | Override TTL for this container |
 | `dnsweaver.proxied` | provider default | Cloudflare proxy (orange-cloud) override — `true` or `false`. Applies to every hostname on the container. Ignored by non-Cloudflare providers. |
+| `dnsweaver.adopt` | provider/global policy | Enable or disable existing-record adoption for every hostname discovered from this workload, including hostnames found by Traefik. Enabling requires the matching provider's `ADOPT_EXISTING_ALLOW_OVERRIDES` gate. Disabling is always honored. |
 
 ### Named Record Labels
 
@@ -99,7 +100,35 @@ For advanced use cases, use the named record format: `dnsweaver.records.<name>.<
 | `dnsweaver.records.<name>.weight` | - | Weight (for SRV records) |
 | `dnsweaver.records.<name>.enabled` | `true` | Enable/disable this record |
 | `dnsweaver.records.<name>.proxied` | provider default | Cloudflare proxy (orange-cloud) override for this record — `true` or `false`. Ignored by non-Cloudflare providers. |
+| `dnsweaver.records.<name>.adopt` | workload/provider/global policy | Override existing-record adoption for this named record. Enabling requires the matching provider's `ADOPT_EXISTING_ALLOW_OVERRIDES` gate. Disabling is always honored. |
 | `dnsweaver.records.<name>.meta.<key>` | - | Arbitrary provider metadata passed through to the target provider (advanced). |
+
+### Existing-record adoption
+
+```yaml
+services:
+  app:
+    labels:
+      - "traefik.http.routers.app.rule=Host(`app.example.com`)"
+      - "dnsweaver.adopt=true"
+```
+
+The workload label applies even when Traefik, rather than the native source,
+discovers the hostname. The matching provider must explicitly allow the
+request:
+
+```bash
+DNSWEAVER_PUBLIC_ADOPT_EXISTING_ALLOW_OVERRIDES=true
+```
+
+Use a named record to narrow or override the workload setting:
+
+```yaml
+labels:
+  - "dnsweaver.adopt=true"
+  - "dnsweaver.records.manual.hostname=manual.example.com"
+  - "dnsweaver.records.manual.adopt=false"
+```
 
 ## Examples
 

--- a/internal/config/adoption_override_test.go
+++ b/internal/config/adoption_override_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func boolPointer(value bool) *bool { return &value }
+
+func TestLoadInstanceConfig_AdoptionPolicy(t *testing.T) {
+	const instanceName = "adoption-test"
+	prefix := envPrefix(instanceName)
+
+	tests := []struct {
+		name        string
+		adopt       string
+		allow       string
+		wantAdopt   *bool
+		wantAllow   bool
+		wantErrPart string
+	}{
+		{name: "inherits global when unset"},
+		{name: "instance enables adoption", adopt: "true", wantAdopt: boolPointer(true)},
+		{name: "instance disables adoption", adopt: "false", wantAdopt: boolPointer(false)},
+		{name: "enables workload override gate", allow: "true", wantAllow: true},
+		{name: "invalid adoption fails", adopt: "sometimes", wantErrPart: "ADOPT_EXISTING"},
+		{name: "invalid gate fails", allow: "sometimes", wantErrPart: "ADOPT_EXISTING_ALLOW_OVERRIDES"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearInstanceEnv(t, instanceName)
+			defer clearInstanceEnv(t, instanceName)
+			os.Setenv(prefix+"TYPE", "technitium")
+			os.Setenv(prefix+"TARGET", "10.0.0.1")
+			os.Setenv(prefix+"DOMAINS", "*.example.com")
+			if tt.adopt != "" {
+				os.Setenv(prefix+"ADOPT_EXISTING", tt.adopt)
+			}
+			if tt.allow != "" {
+				os.Setenv(prefix+"ADOPT_EXISTING_ALLOW_OVERRIDES", tt.allow)
+			}
+
+			cfg, errs := loadInstanceConfig(instanceName, 300)
+			if tt.wantErrPart != "" {
+				if len(errs) == 0 || !strings.Contains(errs[0].Error(), tt.wantErrPart) {
+					t.Fatalf("errors = %v, want one containing %q", errs, tt.wantErrPart)
+				}
+				return
+			}
+			if len(errs) != 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if (cfg.AdoptExisting == nil) != (tt.wantAdopt == nil) {
+				t.Fatalf("AdoptExisting = %v, want %v", cfg.AdoptExisting, tt.wantAdopt)
+			}
+			if cfg.AdoptExisting != nil && *cfg.AdoptExisting != *tt.wantAdopt {
+				t.Errorf("AdoptExisting = %v, want %v", *cfg.AdoptExisting, *tt.wantAdopt)
+			}
+			if cfg.AdoptExistingAllowOverrides != tt.wantAllow {
+				t.Errorf("AdoptExistingAllowOverrides = %v, want %v", cfg.AdoptExistingAllowOverrides, tt.wantAllow)
+			}
+		})
+	}
+}
+
+func TestConvertFileProvider_AdoptionPolicy(t *testing.T) {
+	adopt := false
+	cfg, errs := convertFileProvider(FileProviderConfig{
+		Name:                        "internal",
+		Type:                        "technitium",
+		Domains:                     []string{"*.example.com"},
+		Target:                      "10.0.0.1",
+		AdoptExisting:               &adopt,
+		AdoptExistingAllowOverrides: true,
+	}, 300)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if cfg.AdoptExisting == nil || *cfg.AdoptExisting {
+		t.Fatalf("AdoptExisting = %v, want explicit false", cfg.AdoptExisting)
+	}
+	if !cfg.AdoptExistingAllowOverrides {
+		t.Error("AdoptExistingAllowOverrides = false, want true")
+	}
+	providerCfg := cfg.ToProviderConfig()
+	if providerCfg.AdoptExisting == nil || *providerCfg.AdoptExisting {
+		t.Fatalf("provider AdoptExisting = %v, want explicit false", providerCfg.AdoptExisting)
+	}
+	if !providerCfg.AdoptExistingAllowOverrides {
+		t.Error("provider AdoptExistingAllowOverrides = false, want true")
+	}
+}
+
+func TestMergeProviderEnvOverrides_AdoptionPolicy(t *testing.T) {
+	const instanceName = "yaml-adoption"
+	prefix := envPrefix(instanceName)
+	clearInstanceEnv(t, instanceName)
+	defer clearInstanceEnv(t, instanceName)
+
+	fromFile := true
+	cfg := &ProviderInstanceConfig{Name: instanceName, AdoptExisting: &fromFile}
+	os.Setenv(prefix+"ADOPT_EXISTING", "false")
+	os.Setenv(prefix+"ADOPT_EXISTING_ALLOW_OVERRIDES", "true")
+
+	if errs := mergeProviderEnvOverrides(cfg); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if cfg.AdoptExisting == nil || *cfg.AdoptExisting {
+		t.Fatalf("AdoptExisting = %v, want env override false", cfg.AdoptExisting)
+	}
+	if !cfg.AdoptExistingAllowOverrides {
+		t.Error("AdoptExistingAllowOverrides = false, want env override true")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,7 +101,7 @@ func Load() (*Config, error) {
 		for _, fp := range fileProviders {
 			providerNames = append(providerNames, fp.Name)
 			// Apply env var overrides to file-based provider config
-			mergeProviderEnvOverrides(fp)
+			allErrors = append(allErrors, mergeProviderEnvOverrides(fp)...)
 			instances = append(instances, fp)
 		}
 	} else {

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -107,17 +107,19 @@ type FileFileDiscoveryConfig struct {
 
 // FileProviderConfig holds configuration for a DNS provider instance.
 type FileProviderConfig struct {
-	Name                string            `yaml:"name"`                            // Unique instance name
-	Type                string            `yaml:"type"`                            // technitium, cloudflare, pihole, etc.
-	Domains             []string          `yaml:"domains,omitempty"`               // Glob patterns
-	DomainsRegex        []string          `yaml:"domains_regex,omitempty"`         // Regex patterns
-	ExcludeDomains      []string          `yaml:"exclude_domains,omitempty"`       // Glob exclude patterns
-	ExcludeDomainsRegex []string          `yaml:"exclude_domains_regex,omitempty"` // Regex exclude patterns
-	RecordType          string            `yaml:"record_type,omitempty"`           // A, AAAA, CNAME
-	Target              string            `yaml:"target"`                          // IP or hostname
-	TTL                 int               `yaml:"ttl,omitempty"`                   // Default TTL
-	Mode                string            `yaml:"mode,omitempty"`                  // managed, authoritative, additive
-	Config              map[string]string `yaml:"config,omitempty"`                // Provider-specific settings
+	Name                        string            `yaml:"name"`                                     // Unique instance name
+	Type                        string            `yaml:"type"`                                     // technitium, cloudflare, pihole, etc.
+	Domains                     []string          `yaml:"domains,omitempty"`                        // Glob patterns
+	DomainsRegex                []string          `yaml:"domains_regex,omitempty"`                  // Regex patterns
+	ExcludeDomains              []string          `yaml:"exclude_domains,omitempty"`                // Glob exclude patterns
+	ExcludeDomainsRegex         []string          `yaml:"exclude_domains_regex,omitempty"`          // Regex exclude patterns
+	RecordType                  string            `yaml:"record_type,omitempty"`                    // A, AAAA, CNAME
+	Target                      string            `yaml:"target"`                                   // IP or hostname
+	TTL                         int               `yaml:"ttl,omitempty"`                            // Default TTL
+	Mode                        string            `yaml:"mode,omitempty"`                           // managed, authoritative, additive
+	AdoptExisting               *bool             `yaml:"adopt_existing,omitempty"`                 // Override global adoption policy
+	AdoptExistingAllowOverrides bool              `yaml:"adopt_existing_allow_overrides,omitempty"` // Permit workload hints to enable adoption
+	Config                      map[string]string `yaml:"config,omitempty"`                         // Provider-specific settings
 }
 
 // FileServerConfig holds health/metrics server settings.

--- a/internal/config/instance.go
+++ b/internal/config/instance.go
@@ -49,6 +49,14 @@ type ProviderInstanceConfig struct {
 	// Defaults to "managed" if not set.
 	Mode provider.OperationalMode
 
+	// AdoptExisting overrides the global adoption policy for this provider.
+	// nil inherits the global DNSWEAVER_ADOPT_EXISTING setting.
+	AdoptExisting *bool
+
+	// AdoptExistingAllowOverrides permits workload-controlled adopt=true hints
+	// to enable adoption for this provider. adopt=false hints are always honored.
+	AdoptExistingAllowOverrides bool
+
 	// Domain matching patterns
 	Domains             []string // Glob patterns (default)
 	DomainsRegex        []string // Regex patterns (opt-in)
@@ -69,19 +77,21 @@ type ProviderInstanceConfig struct {
 // ToProviderConfig converts this config to the provider package's config type.
 func (c *ProviderInstanceConfig) ToProviderConfig() provider.ProviderInstanceConfig {
 	return provider.ProviderInstanceConfig{
-		Name:                c.Name,
-		TypeName:            c.TypeName,
-		RecordType:          c.RecordType,
-		Target:              c.Target,
-		TargetMode:          c.TargetMode,
-		TTL:                 c.TTL,
-		Mode:                c.Mode,
-		Domains:             c.Domains,
-		DomainsRegex:        c.DomainsRegex,
-		ExcludeDomains:      c.ExcludeDomains,
-		ExcludeDomainsRegex: c.ExcludeDomainsRegex,
-		MetadataFilters:     c.MetadataFilters,
-		ProviderConfig:      c.ProviderConfig,
+		Name:                        c.Name,
+		TypeName:                    c.TypeName,
+		RecordType:                  c.RecordType,
+		Target:                      c.Target,
+		TargetMode:                  c.TargetMode,
+		TTL:                         c.TTL,
+		Mode:                        c.Mode,
+		AdoptExisting:               c.AdoptExisting,
+		AdoptExistingAllowOverrides: c.AdoptExistingAllowOverrides,
+		Domains:                     c.Domains,
+		DomainsRegex:                c.DomainsRegex,
+		ExcludeDomains:              c.ExcludeDomains,
+		ExcludeDomainsRegex:         c.ExcludeDomainsRegex,
+		MetadataFilters:             c.MetadataFilters,
+		ProviderConfig:              c.ProviderConfig,
 	}
 }
 
@@ -194,6 +204,25 @@ func loadInstanceConfig(instanceName string, defaultTTL int) (*ProviderInstanceC
 		}
 	} else {
 		cfg.Mode = provider.ModeManaged
+	}
+
+	// ADOPT_EXISTING (optional) overrides the global setting for this instance.
+	if value := getEnv(prefix + "ADOPT_EXISTING"); value != "" {
+		if parsed, ok := parseBoolValue(value); ok {
+			cfg.AdoptExisting = &parsed
+		} else {
+			errs = append(errs, configErrFull(prefix+"ADOPT_EXISTING", fmt.Sprintf("invalid boolean %q", value), "Use true or false", prefix+"ADOPT_EXISTING=false"))
+		}
+	}
+
+	// Workload labels may only elevate adoption when the operator explicitly
+	// enables that capability for this provider instance.
+	if value := getEnv(prefix + "ADOPT_EXISTING_ALLOW_OVERRIDES"); value != "" {
+		if parsed, ok := parseBoolValue(value); ok {
+			cfg.AdoptExistingAllowOverrides = parsed
+		} else {
+			errs = append(errs, configErrFull(prefix+"ADOPT_EXISTING_ALLOW_OVERRIDES", fmt.Sprintf("invalid boolean %q", value), "Use true or false", prefix+"ADOPT_EXISTING_ALLOW_OVERRIDES=false"))
+		}
 	}
 
 	// Domain patterns - either DOMAINS or DOMAINS_REGEX, not both
@@ -351,7 +380,8 @@ var providerConfigFields = []struct {
 // For secrets, DNSWEAVER_{PROVIDER_NAME}_{FIELD}_FILE is also checked.
 //
 // Any env var that is set will override the corresponding YAML value.
-func mergeProviderEnvOverrides(cfg *ProviderInstanceConfig) {
+func mergeProviderEnvOverrides(cfg *ProviderInstanceConfig) []*ConfigError {
+	var errs []*ConfigError
 	prefix := envPrefix(cfg.Name)
 
 	// Ensure ProviderConfig map exists
@@ -409,9 +439,27 @@ func mergeProviderEnvOverrides(cfg *ProviderInstanceConfig) {
 		}
 	}
 
+	if value := getEnv(prefix + "ADOPT_EXISTING"); value != "" {
+		if parsed, ok := parseBoolValue(value); ok {
+			cfg.AdoptExisting = &parsed
+		} else {
+			errs = append(errs, configErrFull(prefix+"ADOPT_EXISTING", fmt.Sprintf("invalid boolean %q", value), "Use true or false", prefix+"ADOPT_EXISTING=false"))
+		}
+	}
+
+	if value := getEnv(prefix + "ADOPT_EXISTING_ALLOW_OVERRIDES"); value != "" {
+		if parsed, ok := parseBoolValue(value); ok {
+			cfg.AdoptExistingAllowOverrides = parsed
+		} else {
+			errs = append(errs, configErrFull(prefix+"ADOPT_EXISTING_ALLOW_OVERRIDES", fmt.Sprintf("invalid boolean %q", value), "Use true or false", prefix+"ADOPT_EXISTING_ALLOW_OVERRIDES=false"))
+		}
+	}
+
 	// Migrate the legacy INSECURE_SKIP_VERIFY alias (whether it arrived
 	// from YAML or env vars) to the canonical TLS_SKIP_VERIFY key.
 	resolveLegacyTLSSkipVerify(cfg.ProviderConfig, cfg.Name)
+
+	return errs
 }
 
 // splitPatterns splits a comma-separated pattern string into individual patterns.

--- a/internal/config/instance_test.go
+++ b/internal/config/instance_test.go
@@ -22,6 +22,8 @@ func clearInstanceEnv(t *testing.T, instanceName string) {
 		prefix + "TARGET_PUBLIC_ENDPOINTS",
 		prefix + "TTL",
 		prefix + "MODE",
+		prefix + "ADOPT_EXISTING",
+		prefix + "ADOPT_EXISTING_ALLOW_OVERRIDES",
 		prefix + "DOMAINS",
 		prefix + "DOMAINS_REGEX",
 		prefix + "EXCLUDE_DOMAINS",

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -50,13 +50,15 @@ func convertFileProvider(fp FileProviderConfig, defaultTTL int) (*ProviderInstan
 	var errs []*ConfigError
 
 	cfg := &ProviderInstanceConfig{
-		Name:                fp.Name,
-		TypeName:            strings.ToLower(fp.Type),
-		Domains:             fp.Domains,
-		DomainsRegex:        fp.DomainsRegex,
-		ExcludeDomains:      fp.ExcludeDomains,
-		ExcludeDomainsRegex: fp.ExcludeDomainsRegex,
-		ProviderConfig:      make(map[string]string),
+		Name:                        fp.Name,
+		TypeName:                    strings.ToLower(fp.Type),
+		Domains:                     fp.Domains,
+		DomainsRegex:                fp.DomainsRegex,
+		ExcludeDomains:              fp.ExcludeDomains,
+		ExcludeDomainsRegex:         fp.ExcludeDomainsRegex,
+		AdoptExisting:               fp.AdoptExisting,
+		AdoptExistingAllowOverrides: fp.AdoptExistingAllowOverrides,
+		ProviderConfig:              make(map[string]string),
 	}
 
 	// Validate name

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -56,14 +56,24 @@ func getEnvWithFileFallback(prefix, key string) string {
 // parseBool parses a boolean string, returning defaultValue on parse failure.
 // Accepts: true/false, 1/0, yes/no, on/off (case-insensitive).
 func parseBool(s string, defaultValue bool) bool {
+	if value, ok := parseBoolValue(s); ok {
+		return value
+	}
+	return defaultValue
+}
+
+// parseBoolValue parses the accepted boolean spellings and reports whether
+// the input was valid. Callers for new safety-sensitive settings use the ok
+// result to fail fast instead of silently falling back.
+func parseBoolValue(s string) (bool, bool) {
 	s = strings.ToLower(strings.TrimSpace(s))
 	switch s {
 	case "true", "1", "yes", "on":
-		return true
+		return true, true
 	case "false", "0", "no", "off":
-		return false
+		return false, true
 	default:
-		return defaultValue
+		return false, false
 	}
 }
 

--- a/internal/reconciler/actions.go
+++ b/internal/reconciler/actions.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/maxfield-allison/dnsweaver/pkg/provider"
 	"github.com/maxfield-allison/dnsweaver/pkg/source"
@@ -24,7 +25,7 @@ import (
 //
 // When hostname has RecordHints, they override provider defaults:
 // - RecordHints.Provider: route directly to named provider instead of domain matching
-// - RecordHints.Type/Target/TTL: override provider instance defaults
+// - RecordHints.Type/Target/TTL/AdoptExisting: override provider instance defaults
 func (r *Reconciler) ensureRecord(ctx context.Context, hostname *source.Hostname, cache *recordCache) []Action {
 	var actions []Action
 
@@ -174,7 +175,7 @@ func (r *Reconciler) warnSelfReferentialOnce(hostname, providerName, target stri
 // warnTypeConflictOnce reports a type conflict dnsweaver is not allowed to
 // resolve, once per provider/hostname pair, with the setting that would let it.
 func (r *Reconciler) warnTypeConflictOnce(hostname string, inst *provider.ProviderInstance, desiredType string, existingTypes []string) {
-	msg := "skipping due to record type conflict; set DNSWEAVER_ADOPT_EXISTING=true or use authoritative mode to let dnsweaver replace the existing record(s)"
+	msg := "skipping due to record type conflict; enable existing-record adoption for this provider or use authoritative mode to let dnsweaver replace the existing record(s)"
 	if !inst.Mode.AllowsDelete() {
 		msg = "skipping due to record type conflict; additive mode never deletes, so the existing record(s) must be removed by hand"
 	}
@@ -193,14 +194,44 @@ func (r *Reconciler) warnTypeConflictOnce(hostname string, inst *provider.Provid
 // ADOPT_EXISTING is the operator saying pre-existing records are dnsweaver's to
 // manage; otherwise only a record this instance already owns (left over from
 // an earlier configuration) is replaced (issue #171).
-func (r *Reconciler) canReplaceConflicting(inst *provider.ProviderInstance, hostname string, cache *recordCache) bool {
+func (r *Reconciler) canReplaceConflicting(inst *provider.ProviderInstance, hostname string, cache *recordCache, adoptExisting bool) bool {
 	switch {
 	case !inst.Mode.AllowsDelete():
 		return false
-	case !inst.Mode.RequiresOwnership(), r.config.AdoptExisting:
+	case !inst.Mode.RequiresOwnership(), adoptExisting:
 		return true
 	}
 	return cache != nil && cache.hasOwnershipRecord(inst.Name(), hostname, r.config.InstanceID)
+}
+
+// effectiveAdoptExisting resolves the adoption policy for one hostname/provider
+// pair. Provider configuration overrides the global default. Workload hints may
+// always narrow the policy to false, but may only elevate it to true when the
+// operator enabled the per-provider gate.
+func (r *Reconciler) effectiveAdoptExisting(hostname *source.Hostname, inst *provider.ProviderInstance) bool {
+	effective := r.config.AdoptExisting
+	if inst.AdoptExisting != nil {
+		effective = *inst.AdoptExisting
+	}
+
+	requested := hostname.AdoptExisting
+	if hostname.RecordHints != nil && hostname.RecordHints.AdoptExisting != nil {
+		requested = hostname.RecordHints.AdoptExisting
+	}
+	if requested == nil {
+		return effective
+	}
+	if !*requested || effective || inst.AdoptExistingAllowOverrides {
+		return *requested
+	}
+
+	r.warnOnce("adopt-override-blocked|"+inst.Name()+"|"+hostname.Name,
+		"ignoring workload request to enable existing-record adoption; provider does not allow adoption overrides",
+		slog.String("hostname", hostname.Name),
+		slog.String("provider", inst.Name()),
+		slog.String("setting", "DNSWEAVER_"+strings.ToUpper(strings.ReplaceAll(inst.Name(), "-", "_"))+"_ADOPT_EXISTING_ALLOW_OVERRIDES"),
+	)
+	return false
 }
 
 // replaceConflictingRecords deletes the records at hostname whose type cannot
@@ -263,6 +294,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 	ttl := inst.TTL
 	var srvData *provider.SRVData
 	var metadata map[string]string
+	adoptExisting := r.effectiveAdoptExisting(hostname, inst)
 
 	if hints := hostname.RecordHints; hints != nil {
 		if hints.Type != "" {
@@ -376,6 +408,9 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 		}
 	}
 
+	hasOwnership := cache != nil && cache.hasOwnershipRecord(inst.Name(), hostname.Name, r.config.InstanceID)
+	mayManageExisting := hasOwnership || adoptExisting || !r.config.OwnershipTracking || !inst.Mode.RequiresOwnership()
+
 	// Step 3: Handle type conflicts (CNAME vs everything else). A conflicting
 	// record is replaced when this instance may delete it; otherwise the desired
 	// record can never be created and the hostname is skipped (issue #171).
@@ -385,7 +420,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 		for _, rec := range conflictingTypeRecords {
 			conflictTypes = append(conflictTypes, string(rec.Type))
 		}
-		if !r.canReplaceConflicting(inst, hostname.Name, cache) {
+		if !r.canReplaceConflicting(inst, hostname.Name, cache, adoptExisting) {
 			action.Type = ActionSkip
 			action.Status = StatusSkipped
 			action.Error = fmt.Sprintf("type conflict: existing %v record(s) conflict with %s",
@@ -436,6 +471,21 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 		}
 	}
 
+	// Managed mode must not update or delete a pre-existing same-type record
+	// unless it is owned or the effective adoption policy allows taking it over.
+	if len(sameTypeRecords) > 0 && !mayManageExisting {
+		action.Type = ActionSkip
+		action.Status = StatusSkipped
+		action.Error = errRecordAlreadyExists
+		r.logger.Info("existing unmanaged record found, skipping",
+			slog.String("hostname", hostname.Name),
+			slog.String("provider", inst.Name()),
+			slog.String("existing_target", sameTypeRecords[0].Target),
+			slog.String("desired_target", target),
+		)
+		return append(replaced, action)
+	}
+
 	// Step 4a: Delete stale SRV records (same target, different priority/weight/port)
 	for _, stale := range staleSrvRecords {
 		r.logger.Info("deleting stale SRV record with outdated data",
@@ -461,14 +511,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 	// the in-place update in Step 5. Records dnsweaver does not manage are left
 	// exactly as found.
 	if exactMatchFound {
-		// Check if we already own this record
-		hasOwnership := false
-		if cache != nil {
-			hasOwnership = cache.hasOwnershipRecord(inst.Name(), hostname.Name, r.config.InstanceID)
-		}
-		managed := hasOwnership || r.config.AdoptExisting || !r.config.OwnershipTracking
-
-		if !managed || !inst.RecordNeedsUpdate(exactMatch, desired) {
+		if !inst.RecordNeedsUpdate(exactMatch, desired) {
 			action.Type = ActionSkip
 			action.Status = StatusSkipped
 			action.Error = errRecordAlreadyExists
@@ -480,7 +523,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 					slog.String("target", target),
 				)
 				r.ensureOwnershipRecord(ctx, hostname.Name, inst, metadata, cache)
-			} else if r.config.AdoptExisting {
+			} else if adoptExisting {
 				r.logger.Info("adopting existing record",
 					slog.String("hostname", hostname.Name),
 					slog.String("provider", inst.Name()),
@@ -488,7 +531,7 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 				)
 				r.ensureOwnershipRecord(ctx, hostname.Name, inst, metadata, cache)
 			} else {
-				r.logger.Info("existing record found, skipping adoption (set ADOPT_EXISTING=true to manage)",
+				r.logger.Info("existing record found, skipping adoption",
 					slog.String("hostname", hostname.Name),
 					slog.String("provider", inst.Name()),
 					slog.String("target", target),
@@ -558,7 +601,11 @@ func (r *Reconciler) ensureRecordForProvider(ctx context.Context, hostname *sour
 				slog.String("hostname", hostname.Name),
 				slog.String("provider", inst.Name()),
 			)
-			r.ensureOwnershipRecord(ctx, hostname.Name, inst, metadata, cache)
+			// A create conflict may be a record another system added after our
+			// List call. Do not silently adopt it when the effective policy is off.
+			if adoptExisting || !r.config.OwnershipTracking || !inst.Mode.RequiresOwnership() {
+				r.ensureOwnershipRecord(ctx, hostname.Name, inst, metadata, cache)
+			}
 		} else if provider.IsTypeConflict(err) {
 			action.Type = ActionSkip
 			action.Status = StatusSkipped

--- a/internal/reconciler/adoption_override_test.go
+++ b/internal/reconciler/adoption_override_test.go
@@ -1,0 +1,289 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+	"github.com/maxfield-allison/dnsweaver/sources/traefik"
+)
+
+func adoptionBool(value bool) *bool { return &value }
+
+func newAdoptionOverrideFixture(
+	t *testing.T,
+	globalAdopt bool,
+	instanceAdopt *bool,
+	allowOverrides bool,
+	existing provider.Record,
+) (*Reconciler, *provider.ProviderInstance, *testMockProvider, *recordCache) {
+	t.Helper()
+	logger := quietLogger()
+	mock := newTestMockProvider("test-dns")
+	mock.AddRecord(existing)
+
+	providers := provider.NewRegistry(logger)
+	providers.RegisterFactory("adoption-mock", func(provider.FactoryConfig) (provider.Provider, error) {
+		return mock, nil
+	})
+	if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+		Name:                        "test-dns",
+		TypeName:                    "adoption-mock",
+		RecordType:                  provider.RecordTypeA,
+		Target:                      "10.0.0.1",
+		TTL:                         300,
+		Mode:                        provider.ModeManaged,
+		AdoptExisting:               instanceAdopt,
+		AdoptExistingAllowOverrides: allowOverrides,
+		Domains:                     []string{"*.example.com"},
+	}); err != nil {
+		t.Fatalf("CreateInstance failed: %v", err)
+	}
+	inst, ok := providers.Get("test-dns")
+	if !ok {
+		t.Fatal("provider instance not found")
+	}
+
+	cfg := DefaultConfig()
+	cfg.AdoptExisting = globalAdopt
+	r := New(nil, source.NewRegistry(logger), providers, WithConfig(cfg), WithLogger(logger))
+	return r, inst, mock, newRecordCache(context.Background(), providers, logger)
+}
+
+func TestEffectiveAdoptExisting_PrecedenceAndGate(t *testing.T) {
+	tests := []struct {
+		name           string
+		global         bool
+		instance       *bool
+		allowOverrides bool
+		hint           *bool
+		want           bool
+	}{
+		{name: "global default", global: true, want: true},
+		{name: "instance enables against global", instance: adoptionBool(true), want: true},
+		{name: "instance disables against global", global: true, instance: adoptionBool(false), want: false},
+		{name: "workload may always disable", global: true, hint: adoptionBool(false), want: false},
+		{name: "workload enable is blocked by default", hint: adoptionBool(true), want: false},
+		{name: "workload enable allowed per provider", allowOverrides: true, hint: adoptionBool(true), want: true},
+		{name: "workload cannot bypass instance false without gate", global: true, instance: adoptionBool(false), hint: adoptionBool(true), want: false},
+		{name: "workload can bypass instance false with gate", global: true, instance: adoptionBool(false), allowOverrides: true, hint: adoptionBool(true), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, inst, _, _ := newAdoptionOverrideFixture(t, tt.global, tt.instance, tt.allowOverrides, provider.Record{
+				Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1",
+			})
+			hostname := &source.Hostname{Name: "app.example.com"}
+			if tt.hint != nil {
+				hostname.AdoptExisting = tt.hint
+			}
+			if got := r.effectiveAdoptExisting(hostname, inst); got != tt.want {
+				t.Errorf("effectiveAdoptExisting() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveAdoptExisting_RecordHintOverridesWorkloadHint(t *testing.T) {
+	r, inst, _, _ := newAdoptionOverrideFixture(t, false, nil, true, provider.Record{
+		Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1",
+	})
+	hostname := &source.Hostname{
+		Name:          "app.example.com",
+		AdoptExisting: adoptionBool(true),
+		RecordHints:   &source.RecordHints{AdoptExisting: adoptionBool(false)},
+	}
+	if r.effectiveAdoptExisting(hostname, inst) {
+		t.Error("record-specific adopt=false did not override workload adopt=true")
+	}
+}
+
+func TestMergeDuplicateHostname_PreservesRecordSpecificAdoption(t *testing.T) {
+	workloadAdopt := adoptionBool(true)
+	recordAdopt := adoptionBool(false)
+	traefikHostname := &source.Hostname{Name: "app.example.com", Source: "traefik", AdoptExisting: workloadAdopt}
+	nativeHostname := &source.Hostname{
+		Name:          "app.example.com",
+		Source:        "dnsweaver",
+		AdoptExisting: workloadAdopt,
+		RecordHints:   &source.RecordHints{AdoptExisting: recordAdopt},
+	}
+
+	for _, pair := range [][2]*source.Hostname{{traefikHostname, nativeHostname}, {nativeHostname, traefikHostname}} {
+		winner := mergeDuplicateHostname(pair[0], pair[1])
+		if winner.Source != "dnsweaver" || winner.RecordHints == nil || winner.RecordHints.AdoptExisting == nil || *winner.RecordHints.AdoptExisting {
+			t.Errorf("winner = %+v, want native record-specific adopt=false", winner)
+		}
+	}
+}
+
+func TestAdoptionOverride_ControlsExactMatchOwnership(t *testing.T) {
+	tests := []struct {
+		name           string
+		global         bool
+		instance       *bool
+		allowOverrides bool
+		hint           *bool
+		wantOwnership  bool
+	}{
+		{name: "global disabled skips", wantOwnership: false},
+		{name: "instance enables", instance: adoptionBool(true), wantOwnership: true},
+		{name: "instance disables global", global: true, instance: adoptionBool(false), wantOwnership: false},
+		{name: "label disables global", global: true, hint: adoptionBool(false), wantOwnership: false},
+		{name: "label enable blocked", hint: adoptionBool(true), wantOwnership: false},
+		{name: "label enable allowed", allowOverrides: true, hint: adoptionBool(true), wantOwnership: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, inst, mock, cache := newAdoptionOverrideFixture(t, tt.global, tt.instance, tt.allowOverrides, provider.Record{
+				Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1", TTL: 300,
+			})
+			hostname := &source.Hostname{Name: "app.example.com", Source: "test"}
+			if tt.hint != nil {
+				hostname.AdoptExisting = tt.hint
+			}
+			actions := r.ensureRecordForProvider(context.Background(), hostname, inst, cache)
+			if len(actions) != 1 || actions[0].Type != ActionSkip {
+				t.Fatalf("actions = %+v, want one skip", actions)
+			}
+			gotOwnership := len(mock.GetCreatedOwnershipRecords()) == 1
+			if gotOwnership != tt.wantOwnership {
+				t.Errorf("ownership created = %v, want %v", gotOwnership, tt.wantOwnership)
+			}
+		})
+	}
+}
+
+func TestAdoptionOverride_ProtectsUnownedWrongTarget(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowOverrides bool
+		wantUpdate     bool
+	}{
+		{name: "blocked label leaves record untouched"},
+		{name: "allowed label adopts and updates", allowOverrides: true, wantUpdate: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, inst, mock, cache := newAdoptionOverrideFixture(t, false, nil, tt.allowOverrides, provider.Record{
+				Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.99", TTL: 300,
+			})
+			hostname := &source.Hostname{
+				Name:          "app.example.com",
+				AdoptExisting: adoptionBool(true),
+			}
+			actions := r.ensureRecordForProvider(context.Background(), hostname, inst, cache)
+			if len(actions) != 1 {
+				t.Fatalf("actions = %+v", actions)
+			}
+			if tt.wantUpdate {
+				if actions[0].Type != ActionUpdate || len(mock.GetDeleted()) != 1 || len(mock.GetCreatedOwnershipRecords()) != 1 {
+					t.Errorf("adopted update did not complete: action=%+v deleted=%d ownership=%d", actions[0], len(mock.GetDeleted()), len(mock.GetCreatedOwnershipRecords()))
+				}
+			} else if actions[0].Type != ActionSkip || len(mock.GetDeleted()) != 0 || len(mock.GetCreated()) != 0 {
+				t.Errorf("unowned record was modified: action=%+v deleted=%d created=%d", actions[0], len(mock.GetDeleted()), len(mock.GetCreated()))
+			}
+		})
+	}
+}
+
+func TestAdoptionOverride_ControlsTypeConflictReplacement(t *testing.T) {
+	for _, allow := range []bool{false, true} {
+		name := "blocked"
+		if allow {
+			name = "allowed"
+		}
+		t.Run(name, func(t *testing.T) {
+			r, inst, mock, cache := newAdoptionOverrideFixture(t, false, nil, allow, provider.Record{
+				Hostname: "app.example.com", Type: provider.RecordTypeCNAME, Target: "old.example.com", TTL: 300,
+			})
+			hostname := &source.Hostname{
+				Name:          "app.example.com",
+				AdoptExisting: adoptionBool(true),
+			}
+			actions := r.ensureRecordForProvider(context.Background(), hostname, inst, cache)
+			if allow {
+				if len(actions) != 2 || actions[0].Type != ActionDelete || actions[1].Type != ActionCreate {
+					t.Fatalf("actions = %+v, want delete then create", actions)
+				}
+			} else if len(actions) != 1 || actions[0].Type != ActionSkip || len(mock.GetDeleted()) != 0 {
+				t.Fatalf("actions = %+v, deleted=%d; want untouched conflict", actions, len(mock.GetDeleted()))
+			}
+		})
+	}
+}
+
+func TestAdoptionOverride_AppliesToTraefikWorkloadLabels(t *testing.T) {
+	for _, allow := range []bool{false, true} {
+		name := "blocked"
+		if allow {
+			name = "allowed"
+		}
+		t.Run(name, func(t *testing.T) {
+			logger := quietLogger()
+			lister := newTestMockWorkloadLister(workload.PlatformDocker)
+			lister.AddWorkload("app", map[string]string{
+				"traefik.http.routers.app.rule": "Host(`app.example.com`)",
+				"dnsweaver.adopt":               "true",
+			})
+			sources := source.NewRegistry(logger)
+			_ = sources.Register(traefik.New(traefik.WithLogger(logger)))
+
+			mock := newTestMockProvider("test-dns")
+			mock.AddRecord(provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1", TTL: 300})
+			providers := provider.NewRegistry(logger)
+			providers.RegisterFactory("adoption-mock", func(provider.FactoryConfig) (provider.Provider, error) { return mock, nil })
+			if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+				Name:                        "test-dns",
+				TypeName:                    "adoption-mock",
+				RecordType:                  provider.RecordTypeA,
+				Target:                      "10.0.0.1",
+				TTL:                         300,
+				Mode:                        provider.ModeManaged,
+				AdoptExistingAllowOverrides: allow,
+				Domains:                     []string{"*.example.com"},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			r := New([]workload.Lister{lister}, sources, providers, WithConfig(DefaultConfig()), WithLogger(logger))
+			if _, err := r.Reconcile(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			got := len(mock.GetCreatedOwnershipRecords()) == 1
+			if got != allow {
+				t.Errorf("ownership created = %v, want %v", got, allow)
+			}
+		})
+	}
+}
+
+func TestAdoptionOverride_CreateConflictDoesNotBypassPolicy(t *testing.T) {
+	for _, allow := range []bool{false, true} {
+		t.Run(map[bool]string{false: "blocked", true: "allowed"}[allow], func(t *testing.T) {
+			r, inst, mock, cache := newAdoptionOverrideFixture(t, false, nil, allow, provider.Record{
+				Hostname: "unrelated.example.com", Type: provider.RecordTypeA, Target: "10.0.0.1",
+			})
+			mock.createFn = func(_ context.Context, record provider.Record) error {
+				if record.Type == provider.RecordTypeA {
+					return provider.ErrConflict
+				}
+				return nil
+			}
+			hostname := &source.Hostname{Name: "app.example.com", AdoptExisting: adoptionBool(true)}
+			actions := r.ensureRecordForProvider(context.Background(), hostname, inst, cache)
+			if len(actions) != 1 || actions[0].Type != ActionSkip {
+				t.Fatalf("actions = %+v, want one conflict skip", actions)
+			}
+			gotOwnership := len(mock.GetCreatedOwnershipRecords()) == 1
+			if gotOwnership != allow {
+				t.Errorf("ownership created after create conflict = %v, want %v", gotOwnership, allow)
+			}
+		})
+	}
+}

--- a/internal/reconciler/coexistence_test.go
+++ b/internal/reconciler/coexistence_test.go
@@ -83,6 +83,7 @@ func TestEnsureRecord_CompanionHTTPSDoesNotBlockUpdate(t *testing.T) {
 	r, cache, mock := newCoexistenceReconciler(t, provider.RecordTypeA, "10.0.0.1",
 		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "10.0.0.99", TTL: 300},
 		provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeHTTPS, Target: ".", TTL: 300},
+		ownershipTXT("app.example.com"),
 	)
 
 	actions := r.ensureRecord(context.Background(), &source.Hostname{Name: "app.example.com", Source: "test"}, cache)

--- a/internal/reconciler/core_test.go
+++ b/internal/reconciler/core_test.go
@@ -124,6 +124,7 @@ func TestEnsureRecord_UpdatesChangedTarget(t *testing.T) {
 		Target:   "10.0.0.99", // Old target
 		TTL:      300,
 	})
+	mock.AddRecord(ownershipTXT("app.example.com"))
 
 	logger := quietLogger()
 	providers := provider.NewRegistry(logger)

--- a/internal/reconciler/edge_behavioral_test.go
+++ b/internal/reconciler/edge_behavioral_test.go
@@ -113,6 +113,7 @@ func TestReconcile_HostnameSwitchesTarget(t *testing.T) {
 		Type:     provider.RecordTypeA,
 		Target:   "10.0.0.1",
 	})
+	mockProvider.AddRecord(ownershipTXT("app.example.com"))
 
 	providers := provider.NewRegistry(logger)
 	providers.RegisterFactory("mock", func(_ provider.FactoryConfig) (provider.Provider, error) {

--- a/internal/reconciler/edge_failure_test.go
+++ b/internal/reconciler/edge_failure_test.go
@@ -246,6 +246,7 @@ func TestReconcile_ProviderDeleteFails(t *testing.T) {
 		Type:     provider.RecordTypeA,
 		Target:   "10.0.0.99", // different from the 10.0.0.1 the provider instance wants
 	})
+	mockProvider.AddRecord(ownershipTXT("app.example.com"))
 
 	providers := provider.NewRegistry(logger)
 	providers.RegisterFactory("mock", func(_ provider.FactoryConfig) (provider.Provider, error) {

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -1231,6 +1231,7 @@ func TestReconcile_ProviderCreateFailsAfterDelete(t *testing.T) {
 		Target:   "10.0.0.99", // Old target - will be deleted
 		TTL:      300,
 	})
+	mockProvider.AddRecord(ownershipTXT("app.example.com"))
 
 	// Make Create fail
 	createCallCount := 0

--- a/pkg/provider/instance.go
+++ b/pkg/provider/instance.go
@@ -84,6 +84,14 @@ type ProviderInstance struct {
 	// Defaults to ModeManaged if not set.
 	Mode OperationalMode
 
+	// AdoptExisting overrides the reconciler's global adoption policy for this
+	// provider. nil inherits the global setting.
+	AdoptExisting *bool
+
+	// AdoptExistingAllowOverrides permits workload-controlled adopt=true hints
+	// to enable adoption for this provider.
+	AdoptExistingAllowOverrides bool
+
 	// InstanceID is the unique identifier for the dnsweaver instance.
 	// Used for multi-instance coordination to scope ownership records.
 	// Empty string means single-instance mode (legacy behavior).
@@ -575,6 +583,14 @@ type ProviderInstanceConfig struct {
 	// Mode is the operational mode (managed, authoritative, additive).
 	// Defaults to "managed" if not set.
 	Mode OperationalMode
+
+	// AdoptExisting overrides the global adoption policy for this provider.
+	// nil inherits the global setting.
+	AdoptExisting *bool
+
+	// AdoptExistingAllowOverrides permits workload-controlled adopt=true hints
+	// to enable adoption for this provider.
+	AdoptExistingAllowOverrides bool
 
 	// Domains is a list of glob patterns for matching hostnames.
 	// At least one is required.

--- a/pkg/provider/registry.go
+++ b/pkg/provider/registry.go
@@ -150,15 +150,17 @@ func (r *Registry) CreateInstance(cfg ProviderInstanceConfig) error {
 
 	// Create provider instance
 	instance := &ProviderInstance{
-		Provider:        provider,
-		Matcher:         domainMatcher,
-		RecordType:      cfg.RecordType,
-		Target:          cfg.Target,
-		TTL:             cfg.TTL,
-		Mode:            cfg.Mode,
-		InstanceID:      r.instanceID,
-		MetadataFilters: cfg.MetadataFilters,
-		Identity:        IdentityOf(provider),
+		Provider:                    provider,
+		Matcher:                     domainMatcher,
+		RecordType:                  cfg.RecordType,
+		Target:                      cfg.Target,
+		TTL:                         cfg.TTL,
+		Mode:                        cfg.Mode,
+		AdoptExisting:               cfg.AdoptExisting,
+		AdoptExistingAllowOverrides: cfg.AdoptExistingAllowOverrides,
+		InstanceID:                  r.instanceID,
+		MetadataFilters:             cfg.MetadataFilters,
+		Identity:                    IdentityOf(provider),
 	}
 
 	// Default to managed mode if not set

--- a/pkg/source/adoption_hint_test.go
+++ b/pkg/source/adoption_hint_test.go
@@ -1,0 +1,66 @@
+package source
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+)
+
+func TestRegistry_WorkloadAdoptionHintAppliesAcrossSources(t *testing.T) {
+	r := NewRegistry(testLogger())
+	_ = r.Register(&mockSource{name: "traefik", hostnames: []Hostname{{Name: "app.example.com", Source: "traefik"}}})
+
+	hostnames := r.ExtractAll(context.Background(), workload.Workload{
+		Name:     "app",
+		Platform: workload.PlatformDocker,
+		Labels:   map[string]string{"dnsweaver.adopt": "true"},
+	})
+	if len(hostnames) != 1 || hostnames[0].AdoptExisting == nil || !*hostnames[0].AdoptExisting {
+		t.Fatalf("workload adoption hint was not applied: %+v", hostnames)
+	}
+}
+
+func TestRegistry_RecordAdoptionHintOverridesWorkloadHint(t *testing.T) {
+	recordAdopt := false
+	r := NewRegistry(testLogger())
+	_ = r.Register(&mockSource{name: "dnsweaver", hostnames: []Hostname{{
+		Name:        "app.example.com",
+		Source:      "dnsweaver",
+		RecordHints: &RecordHints{AdoptExisting: &recordAdopt},
+	}}})
+
+	hostnames := r.ExtractAll(context.Background(), workload.Workload{
+		Platform: workload.PlatformDocker,
+		Labels:   map[string]string{"dnsweaver.adopt": "true"},
+	})
+	if got := hostnames[0].RecordHints.AdoptExisting; got == nil || *got {
+		t.Fatalf("record adoption hint = %v, want false", got)
+	}
+}
+
+func TestRegistry_KubernetesAdoptionAnnotation(t *testing.T) {
+	r := NewRegistry(testLogger())
+	_ = r.Register(&mockSource{name: "kubernetes", hostnames: []Hostname{{Name: "app.example.com", Source: "kubernetes"}}})
+
+	hostnames := r.ExtractAll(context.Background(), workload.Workload{
+		Platform:    workload.PlatformKubernetes,
+		Annotations: map[string]string{"dnsweaver.dev/adopt": "false"},
+	})
+	if got := hostnames[0].AdoptExisting; got == nil || *got {
+		t.Fatalf("annotation adoption hint = %v, want false", got)
+	}
+}
+
+func TestRegistry_InvalidAdoptionHintIsIgnored(t *testing.T) {
+	r := NewRegistry(testLogger())
+	_ = r.Register(&mockSource{name: "traefik", hostnames: []Hostname{{Name: "app.example.com", Source: "traefik"}}})
+
+	hostnames := r.ExtractAll(context.Background(), workload.Workload{
+		Platform: workload.PlatformDocker,
+		Labels:   map[string]string{"dnsweaver.adopt": "yes"},
+	})
+	if hostnames[0].AdoptExisting != nil {
+		t.Fatalf("invalid hint should be ignored, got %v", hostnames[0].AdoptExisting)
+	}
+}

--- a/pkg/source/hostname.go
+++ b/pkg/source/hostname.go
@@ -265,6 +265,11 @@ type RecordHints struct {
 	// Empty means use domain matching as usual.
 	Provider string
 
+	// AdoptExisting overrides adoption for this hostname. nil inherits the
+	// provider-instance/global policy. Enabling is subject to the provider's
+	// explicit workload-override gate.
+	AdoptExisting *bool
+
 	// SRV contains SRV-specific fields when Type is "SRV".
 	SRV *SRVHints
 
@@ -295,9 +300,15 @@ type Hostname struct {
 	Router string
 
 	// RecordHints contains optional hints for DNS record creation.
-	// These allow per-hostname overrides for record type, target, TTL, and provider.
+	// These allow per-hostname overrides for record type, target, TTL, provider,
+	// and existing-record adoption.
 	// nil means use provider defaults for everything.
 	RecordHints *RecordHints
+
+	// AdoptExisting is the workload-wide adoption hint applied to hostnames
+	// discovered from any source. A record-specific RecordHints.AdoptExisting
+	// value takes precedence.
+	AdoptExisting *bool
 
 	// Metadata carries arbitrary key-value pairs from sources for use by
 	// instance-level filtering (e.g. "traefik.entrypoint" -> "webA"). Unlike

--- a/pkg/source/registry.go
+++ b/pkg/source/registry.go
@@ -107,6 +107,14 @@ func (r *Registry) ExtractAll(ctx context.Context, w workload.Workload) Hostname
 		return nil
 	}
 
+	workloadAdopt, adoptKey, adoptValid := workloadAdoptExistingHint(w)
+	if !adoptValid {
+		r.logger.Warn("invalid workload adoption hint (must be true/false); ignoring",
+			slog.String("workload", w.Name),
+			slog.String("key", adoptKey),
+		)
+	}
+
 	r.mu.RLock()
 	sources := make([]Source, len(r.sources))
 	copy(sources, r.sources)
@@ -130,6 +138,7 @@ func (r *Registry) ExtractAll(ctx context.Context, w workload.Workload) Hostname
 		}
 
 		if len(hostnames) > 0 {
+			applyWorkloadAdoptionHint(hostnames, workloadAdopt)
 			r.logger.Debug("source extracted hostnames",
 				slog.String("source", src.Name()),
 				slog.Int("count", len(hostnames)),
@@ -249,7 +258,67 @@ func (r *Registry) ExtractFrom(ctx context.Context, sourceName string, w workloa
 		return nil, ErrSourceNotFound(sourceName)
 	}
 
-	return src.Extract(ctx, w)
+	hostnames, err := src.Extract(ctx, w)
+	if err != nil {
+		return nil, err
+	}
+	workloadAdopt, adoptKey, valid := workloadAdoptExistingHint(w)
+	if !valid {
+		r.logger.Warn("invalid workload adoption hint (must be true/false); ignoring",
+			slog.String("workload", w.Name),
+			slog.String("key", adoptKey),
+		)
+	} else {
+		applyWorkloadAdoptionHint(hostnames, workloadAdopt)
+	}
+	return hostnames, nil
+}
+
+// workloadAdoptExistingHint reads the workload-wide adoption hint. Docker
+// labels take precedence over Kubernetes annotations, matching native-label
+// conversion behavior. The third return value reports whether a present value
+// was valid; absence is valid and returns nil.
+func workloadAdoptExistingHint(w workload.Workload) (*bool, string, bool) {
+	const (
+		dockerKey = "dnsweaver.adopt"
+		k8sKey    = "dnsweaver.dev/adopt"
+	)
+
+	value, ok := w.Labels[dockerKey]
+	key := dockerKey
+	if !ok {
+		value, ok = w.Annotations[k8sKey]
+		key = k8sKey
+	}
+	if !ok {
+		return nil, "", true
+	}
+
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true":
+		parsed := true
+		return &parsed, key, true
+	case "false":
+		parsed := false
+		return &parsed, key, true
+	default:
+		return nil, key, false
+	}
+}
+
+// applyWorkloadAdoptionHint applies a workload-wide hint to hostnames found by
+// every source, including Traefik. A record-specific hint already attached by
+// the native source takes precedence.
+func applyWorkloadAdoptionHint(hostnames Hostnames, adopt *bool) {
+	if adopt == nil {
+		return
+	}
+	for i := range hostnames {
+		if hostnames[i].AdoptExisting == nil {
+			value := *adopt
+			hostnames[i].AdoptExisting = &value
+		}
+	}
 }
 
 // DiscoverFrom queries a specific source by name for file-based discovery.

--- a/sources/dnsweaver/adoption_test.go
+++ b/sources/dnsweaver/adoption_test.go
@@ -1,0 +1,23 @@
+package dnsweaver
+
+import "testing"
+
+func TestParser_AdoptionHintPrecedence(t *testing.T) {
+	parser := NewParser(WithParserLogger(testLogger()))
+	extractions := parser.ExtractHostnames(map[string]string{
+		"dnsweaver.hostname":               "simple.example.com",
+		"dnsweaver.records.named.hostname": "named.example.com",
+		"dnsweaver.records.named.adopt":    "false",
+	})
+
+	got := make(map[string]*bool, len(extractions))
+	for i := range extractions {
+		got[extractions[i].Hostname] = extractions[i].AdoptExisting
+	}
+	if got["simple.example.com"] != nil {
+		t.Error("workload adoption should be applied by the source registry, not stored as a record hint")
+	}
+	if got["named.example.com"] == nil || *got["named.example.com"] {
+		t.Error("named adopt=false was not parsed")
+	}
+}

--- a/sources/dnsweaver/dnsweaver.go
+++ b/sources/dnsweaver/dnsweaver.go
@@ -106,11 +106,12 @@ func (d *DNSWeaver) Extract(ctx context.Context, w workload.Workload) ([]source.
 		// Copy record hints if present
 		if e.HasHints() {
 			h.RecordHints = &source.RecordHints{
-				Type:     e.Type,
-				Target:   e.Target,
-				TTL:      e.TTL,
-				Provider: e.Provider,
-				Metadata: e.Metadata,
+				Type:          e.Type,
+				Target:        e.Target,
+				TTL:           e.TTL,
+				Provider:      e.Provider,
+				AdoptExisting: e.AdoptExisting,
+				Metadata:      e.Metadata,
 			}
 			if e.SRV != nil {
 				h.RecordHints.SRV = &source.SRVHints{

--- a/sources/dnsweaver/parser.go
+++ b/sources/dnsweaver/parser.go
@@ -40,6 +40,7 @@ const (
 	FieldWeight   = "weight"
 	FieldEnabled  = "enabled"
 	FieldProxied  = "proxied"
+	FieldAdopt    = "adopt"
 )
 
 const (
@@ -95,6 +96,9 @@ type Extraction struct {
 	// Zero means use provider default.
 	TTL int
 
+	// AdoptExisting overrides existing-record adoption for this record.
+	AdoptExisting *bool
+
 	// SRV contains SRV-specific fields when Type is "SRV".
 	SRV *SRVData
 
@@ -106,7 +110,7 @@ type Extraction struct {
 
 // HasHints returns true if any hint fields are set.
 func (e Extraction) HasHints() bool {
-	return e.Type != "" || e.Target != "" || e.Provider != "" || e.TTL > 0 || e.SRV != nil || len(e.Metadata) > 0
+	return e.Type != "" || e.Target != "" || e.Provider != "" || e.TTL > 0 || e.AdoptExisting != nil || e.SRV != nil || len(e.Metadata) > 0
 }
 
 // Parser extracts hostnames from dnsweaver labels.
@@ -153,9 +157,7 @@ func (p *Parser) ExtractHostnames(labels map[string]string) []Extraction {
 	if hostname, ok := labels[SimpleHostnameLabel]; ok {
 		hostname = strings.TrimSpace(hostname)
 		if hostname != "" {
-			extraction := Extraction{
-				Hostname: hostname,
-			}
+			extraction := Extraction{Hostname: hostname}
 
 			// Parse TTL for simple hostname
 			if ttlStr, ok := labels[TTLLabel]; ok && ttlStr != "" {
@@ -281,6 +283,13 @@ func (p *Parser) ExtractHostnames(labels map[string]string) []Extraction {
 			Provider:   fields[FieldProvider],
 		}
 
+		// A named-record adoption hint overrides the workload-wide hint later in
+		// reconciliation. The workload hint is applied source-independently by
+		// the source registry.
+		if value, ok := fields[FieldAdopt]; ok {
+			extraction.AdoptExisting = p.parseAdoptExisting(value, "record "+name)
+		}
+
 		// Parse TTL
 		if ttlStr, ok := fields[FieldTTL]; ok && ttlStr != "" {
 			if ttl, err := strconv.Atoi(ttlStr); err == nil && ttl > 0 {
@@ -385,4 +394,25 @@ func (p *Parser) ExtractHostnames(labels map[string]string) []Extraction {
 	}
 
 	return extractions
+}
+
+func (p *Parser) parseAdoptExisting(value, scope string) *bool {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case boolTrue:
+		parsed := true
+		return &parsed
+	case boolFalse:
+		parsed := false
+		return &parsed
+	default:
+		p.logger.Warn("invalid adopt value (must be true/false)",
+			slog.String("scope", scope),
+			slog.String("adopt", value),
+		)
+		return nil
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `DNSWEAVER_{NAME}_ADOPT_EXISTING` and the equivalent provider YAML setting.
- Adds workload-wide `dnsweaver.adopt` and `dnsweaver.dev/adopt` hints, including for hostnames discovered by Traefik.
- Adds `dnsweaver.records.<name>.adopt` for one named record.
- Resolves adoption in global, provider, workload, then named-record order.

Workloads can always disable adoption. Enabling it from a workload requires `DNSWEAVER_{NAME}_ADOPT_EXISTING_ALLOW_OVERRIDES=true` on each provider where that permission is intended. The provider override itself is operator configuration, so it doesn't need a second gate.

The existing reconciler also has two adoption-policy bypasses. It updates an unowned same-type record with a different target when adoption is off, and a create conflict can add an ownership marker for a record that appeared after the provider was listed. Both paths now use the same effective adoption decision as exact matches and type conflicts.

## Related issues

Closes #178.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Maintenance / refactor / CI

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run --config .golangci.yml --timeout 5m`

## Checklist

- [x] `gofmt` clean and `golangci-lint run ./...` passes
- [x] `go test ./...` passes (added/updated tests where relevant)
- [x] `go build ./...` succeeds
- [x] Docs updated (README / docs site) if behavior or config changed
- [x] CHANGELOG.md updated under the Unreleased section if user-facing
