### PR TITLE
feat: reconcile provider-scoped A/AAAA record sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Technitium instances on different servers remain distinct backends.** The
+  normal provider factory discarded the configured API URL from its backend
+  identity, so instances serving the same zone on separate servers could be
+  grouped together and leave the previous route stale when selection changed.
 - **Kubernetes namespace filters now scope informer API requests.** Configured
   namespaces previously filtered the local cache only, so dnsweaver still
   required cluster-wide list/watch permissions. Each configured namespace now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Kubernetes namespace filters now scope informer API requests.** Configured
+  namespaces previously filtered the local cache only, so dnsweaver still
+  required cluster-wide list/watch permissions. Each configured namespace now
+  gets its own informer and can be authorized with namespace-scoped RBAC.
 - **Managed mode now leaves unowned same-type records untouched when adoption
   is disabled.** A pre-existing A, AAAA, CNAME, or SRV record with a different
   target could previously be updated even though `ADOPT_EXISTING=false`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Provider-scoped record sets preserve every distinct A and AAAA member.**
+  Claims are deduplicated only after provider routing and target resolution, so
+  repeated claims for one target create one record while distinct Proxmox,
+  Incus, or named-record targets remain separate members. Ownership markers,
+  replacement, orphan cleanup, provider-route changes, restart recovery, and
+  the deletion circuit breaker now operate on exact members without removing
+  unrelated siblings. Built-in providers either delete an exact member or
+  retain their documented safe limitation.
+  ([GitHub #177](https://github.com/maxfield-allison/dnsweaver/issues/177))
 - **Existing-record adoption can now be scoped to a provider, workload, or
   named record.** `DNSWEAVER_{NAME}_ADOPT_EXISTING` overrides the global policy
   for one provider. `dnsweaver.adopt` and `dnsweaver.dev/adopt` apply to every

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -73,15 +75,17 @@ type Watcher struct {
 	logger      *slog.Logger
 	onReconcile ReconcileFunc
 
-	// Typed informer factory for core resources (Ingress, Service).
-	typedFactory informers.SharedInformerFactory
+	// One informer factory per configured namespace. A single all-namespace
+	// factory is used when no namespace filter is configured.
+	typedFactories []informers.SharedInformerFactory
 
-	// Dynamic informer factory for CRDs (IngressRoute, HTTPRoute).
-	dynamicFactory dynamicinformer.DynamicSharedInformerFactory
+	// Dynamic informer factories for CRDs (IngressRoute, HTTPRoute), aligned
+	// by index with typedFactories when CRD watching is enabled.
+	dynamicFactories []dynamicinformer.DynamicSharedInformerFactory
 
-	// Typed informers (nil if not watching that resource type).
-	ingressInformer networkinginformers.IngressInformer
-	serviceInformer coreinformers.ServiceInformer
+	// Typed informers (empty if not watching that resource type).
+	ingressInformers []networkinginformers.IngressInformer
+	serviceInformers []coreinformers.ServiceInformer
 
 	// CRD availability (detected at start time).
 	hasIngressRoute bool
@@ -150,16 +154,20 @@ func (w *Watcher) Start(ctx context.Context) error {
 	}
 
 	// Start factories.
-	w.typedFactory.Start(ctx.Done())
-	if w.dynamicFactory != nil {
-		w.dynamicFactory.Start(ctx.Done())
+	for _, factory := range w.typedFactories {
+		factory.Start(ctx.Done())
+	}
+	for _, factory := range w.dynamicFactories {
+		factory.Start(ctx.Done())
 	}
 
 	// Wait for initial cache sync.
 	w.logger.Info("waiting for kubernetes informer cache sync")
-	w.typedFactory.WaitForCacheSync(ctx.Done())
-	if w.dynamicFactory != nil {
-		w.dynamicFactory.WaitForCacheSync(ctx.Done())
+	for _, factory := range w.typedFactories {
+		factory.WaitForCacheSync(ctx.Done())
+	}
+	for _, factory := range w.dynamicFactories {
+		factory.WaitForCacheSync(ctx.Done())
 	}
 
 	w.logger.Info("kubernetes watcher started",
@@ -217,8 +225,8 @@ func (w *Watcher) ListWorkloads(ctx context.Context) ([]workload.Workload, error
 	}
 
 	// List Ingress resources.
-	if w.ingressInformer != nil {
-		ingresses, err := w.ingressInformer.Lister().List(selector)
+	for _, informer := range w.ingressInformers {
+		ingresses, err := informer.Lister().List(selector)
 		if err != nil {
 			return nil, fmt.Errorf("listing ingresses: %w", err)
 		}
@@ -230,8 +238,8 @@ func (w *Watcher) ListWorkloads(ctx context.Context) ([]workload.Workload, error
 	}
 
 	// List Service resources.
-	if w.serviceInformer != nil {
-		services, err := w.serviceInformer.Lister().List(selector)
+	for _, informer := range w.serviceInformers {
+		services, err := informer.Lister().List(selector)
 		if err != nil {
 			return nil, fmt.Errorf("listing services: %w", err)
 		}
@@ -243,8 +251,11 @@ func (w *Watcher) ListWorkloads(ctx context.Context) ([]workload.Workload, error
 	}
 
 	// List IngressRoute resources (dynamic/unstructured).
-	if w.hasIngressRoute && w.dynamicFactory != nil {
-		lister := w.dynamicFactory.ForResource(IngressRouteGVR).Lister()
+	for _, factory := range w.dynamicFactories {
+		if !w.hasIngressRoute {
+			break
+		}
+		lister := factory.ForResource(IngressRouteGVR).Lister()
 		items, err := lister.List(selector)
 		if err != nil {
 			return nil, fmt.Errorf("listing ingressroutes: %w", err)
@@ -261,8 +272,11 @@ func (w *Watcher) ListWorkloads(ctx context.Context) ([]workload.Workload, error
 	}
 
 	// List HTTPRoute resources (dynamic/unstructured).
-	if w.hasHTTPRoute && w.dynamicFactory != nil {
-		lister := w.dynamicFactory.ForResource(HTTPRouteGVR).Lister()
+	for _, factory := range w.dynamicFactories {
+		if !w.hasHTTPRoute {
+			break
+		}
+		lister := factory.ForResource(HTTPRouteGVR).Lister()
 		items, err := lister.List(selector)
 		if err != nil {
 			return nil, fmt.Errorf("listing httproutes: %w", err)
@@ -321,17 +335,59 @@ func (w *Watcher) detectCRDs() {
 
 // createFactories initializes the informer factories.
 func (w *Watcher) createFactories() {
-	w.typedFactory = informers.NewSharedInformerFactoryWithOptions(
-		w.clients.Typed, DefaultResyncInterval,
-		informers.WithTransform(stripManagedFields),
-	)
+	// Start may be called again after Stop. Informers themselves cannot be
+	// restarted, so build a fresh set of factories instead of appending to the
+	// stopped set from the previous run.
+	w.typedFactories = nil
+	w.dynamicFactories = nil
+	w.ingressInformers = nil
+	w.serviceInformers = nil
 
-	// Only create dynamic factory if CRDs are available.
-	if w.hasIngressRoute || w.hasHTTPRoute {
-		w.dynamicFactory = dynamicinformer.NewDynamicSharedInformerFactory(
-			w.clients.Dynamic, DefaultResyncInterval,
+	for _, namespace := range w.factoryNamespaces() {
+		w.typedFactories = append(w.typedFactories,
+			informers.NewSharedInformerFactoryWithOptions(
+				w.clients.Typed, DefaultResyncInterval,
+				informers.WithNamespace(namespace),
+				informers.WithTransform(stripManagedFields),
+			),
 		)
+
+		// Only create dynamic factories if CRDs are available.
+		if w.hasIngressRoute || w.hasHTTPRoute {
+			w.dynamicFactories = append(w.dynamicFactories,
+				dynamicinformer.NewFilteredDynamicSharedInformerFactory(
+					w.clients.Dynamic, DefaultResyncInterval, namespace, nil,
+				),
+			)
+		}
 	}
+}
+
+// factoryNamespaces returns the API namespaces each informer factory should
+// watch. Scoping the list/watch itself is required for namespace-only RBAC;
+// filtering a cluster-wide cache after the fact is both broader and noisier.
+func (w *Watcher) factoryNamespaces() []string {
+	if !w.config.HasNamespaceFilter() {
+		return []string{metav1.NamespaceAll}
+	}
+
+	seen := make(map[string]struct{}, len(w.config.Namespaces))
+	namespaces := make([]string, 0, len(w.config.Namespaces))
+	for _, configured := range w.config.Namespaces {
+		namespace := strings.TrimSpace(configured)
+		if namespace == "" {
+			continue
+		}
+		if _, exists := seen[namespace]; exists {
+			continue
+		}
+		seen[namespace] = struct{}{}
+		namespaces = append(namespaces, namespace)
+	}
+	if len(namespaces) == 0 {
+		return []string{metav1.NamespaceAll}
+	}
+	return namespaces
 }
 
 // setupInformers creates and registers event handlers for each resource type.
@@ -344,31 +400,37 @@ func (w *Watcher) setupInformers() error {
 		DeleteFunc: func(_ interface{}) { w.handleEvent("delete") },
 	}
 
-	if w.config.WatchIngress {
-		w.ingressInformer = w.typedFactory.Networking().V1().Ingresses()
-		if _, err := w.ingressInformer.Informer().AddEventHandler(handler); err != nil {
-			return fmt.Errorf("adding ingress event handler: %w", err)
+	for _, factory := range w.typedFactories {
+		if w.config.WatchIngress {
+			informer := factory.Networking().V1().Ingresses()
+			if _, err := informer.Informer().AddEventHandler(handler); err != nil {
+				return fmt.Errorf("adding ingress event handler: %w", err)
+			}
+			w.ingressInformers = append(w.ingressInformers, informer)
+		}
+
+		if w.config.WatchServices {
+			informer := factory.Core().V1().Services()
+			if _, err := informer.Informer().AddEventHandler(handler); err != nil {
+				return fmt.Errorf("adding service event handler: %w", err)
+			}
+			w.serviceInformers = append(w.serviceInformers, informer)
 		}
 	}
 
-	if w.config.WatchServices {
-		w.serviceInformer = w.typedFactory.Core().V1().Services()
-		if _, err := w.serviceInformer.Informer().AddEventHandler(handler); err != nil {
-			return fmt.Errorf("adding service event handler: %w", err)
+	for _, factory := range w.dynamicFactories {
+		if w.hasIngressRoute {
+			informer := factory.ForResource(IngressRouteGVR).Informer()
+			if _, err := informer.AddEventHandler(handler); err != nil {
+				return fmt.Errorf("adding ingressroute event handler: %w", err)
+			}
 		}
-	}
 
-	if w.hasIngressRoute {
-		informer := w.dynamicFactory.ForResource(IngressRouteGVR).Informer()
-		if _, err := informer.AddEventHandler(handler); err != nil {
-			return fmt.Errorf("adding ingressroute event handler: %w", err)
-		}
-	}
-
-	if w.hasHTTPRoute {
-		informer := w.dynamicFactory.ForResource(HTTPRouteGVR).Informer()
-		if _, err := informer.AddEventHandler(handler); err != nil {
-			return fmt.Errorf("adding httproute event handler: %w", err)
+		if w.hasHTTPRoute {
+			informer := factory.ForResource(HTTPRouteGVR).Informer()
+			if _, err := informer.AddEventHandler(handler); err != nil {
+				return fmt.Errorf("adding httproute event handler: %w", err)
+			}
 		}
 	}
 
@@ -403,7 +465,7 @@ func (w *Watcher) matchesFilters(namespace string, annotations map[string]string
 	if w.config.HasNamespaceFilter() {
 		found := false
 		for _, ns := range w.config.Namespaces {
-			if ns == namespace {
+			if strings.TrimSpace(ns) == namespace {
 				found = true
 				break
 			}

--- a/internal/kubernetes/watcher_test.go
+++ b/internal/kubernetes/watcher_test.go
@@ -1,0 +1,97 @@
+package kubernetes
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestFactoryNamespaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configured []string
+		want       []string
+	}{
+		{name: "all namespaces", want: []string{""}},
+		{name: "one namespace", configured: []string{"apps"}, want: []string{"apps"}},
+		{
+			name:       "multiple namespaces are trimmed and deduplicated",
+			configured: []string{"apps", " edge ", "apps", ""},
+			want:       []string{"apps", "edge"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			watcher := New(nil, WithConfig(Config{Namespaces: tt.configured}))
+			if got := watcher.factoryNamespaces(); !slices.Equal(got, tt.want) {
+				t.Fatalf("factoryNamespaces() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesFiltersNormalizesConfiguredNamespaces(t *testing.T) {
+	t.Parallel()
+
+	watcher := New(nil, WithConfig(Config{Namespaces: []string{" apps "}}))
+	if !watcher.matchesFilters("apps", nil) {
+		t.Fatal("matchesFilters() rejected a namespace normalized by factoryNamespaces()")
+	}
+}
+
+func TestWatcherScopesInformerRequestsToConfiguredNamespaces(t *testing.T) {
+	t.Parallel()
+
+	client := kubernetesfake.NewClientset()
+	watcher := New(
+		&Clients{Typed: client},
+		WithConfig(Config{
+			Namespaces:       []string{"apps", "edge"},
+			WatchIngress:     true,
+			DebounceInterval: time.Hour,
+		}),
+		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(watcher.Stop)
+
+	listed := make(map[string]bool)
+	watched := make(map[string]bool)
+	for _, action := range client.Actions() {
+		if action.GetResource().Resource != "ingresses" {
+			continue
+		}
+		switch action.GetVerb() {
+		case "list":
+			listed[action.GetNamespace()] = true
+		case "watch":
+			watched[action.GetNamespace()] = true
+		}
+	}
+
+	for _, namespace := range []string{"apps", "edge"} {
+		if !listed[namespace] {
+			t.Errorf("no Ingress list request for namespace %q", namespace)
+		}
+		if !watched[namespace] {
+			t.Errorf("no Ingress watch request for namespace %q", namespace)
+		}
+	}
+	if listed[""] || watched[""] {
+		t.Fatal("namespace-filtered watcher made a cluster-scope Ingress request")
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -67,6 +67,15 @@ var (
 			Help:      "Number of hostnames discovered in the last reconciliation.",
 		},
 	)
+
+	// DesiredRecordMembers counts distinct provider-routed DNS members.
+	DesiredRecordMembers = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "desired_record_members",
+			Help:      "Number of distinct provider-routed DNS record members in the last reconciliation.",
+		},
+	)
 )
 
 // Record operation metrics.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -131,6 +131,7 @@ func TestMetricNames(t *testing.T) {
 		ReconciliationDuration,
 		WorkloadsScanned,
 		HostnamesDiscovered,
+		DesiredRecordMembers,
 		RecordsCreatedTotal,
 		RecordsDeletedTotal,
 		RecordsSkippedTotal,

--- a/internal/reconciler/cache.go
+++ b/internal/reconciler/cache.go
@@ -20,6 +20,12 @@ type recordCache struct {
 	logger  *slog.Logger
 }
 
+type cachedOwnedMember struct {
+	Member   provider.Record
+	Marker   provider.Record
+	Metadata map[string]string
+}
+
 // newRecordCache creates a new record cache by querying all providers.
 // Failed providers are logged but don't prevent caching other providers.
 func newRecordCache(ctx context.Context, providers *provider.Registry, logger *slog.Logger) *recordCache {
@@ -137,4 +143,67 @@ func (c *recordCache) hasOwnershipRecord(providerName, hostname, instanceID stri
 	}
 
 	return false
+}
+
+func (c *recordCache) memberOwnershipRecord(providerName string, member provider.Record, instanceID string) (provider.Record, bool) {
+	for _, ownership := range c.ownershipRecords(providerName, member.Hostname) {
+		if provider.MatchesMemberOwnership(ownership.Target, instanceID, member) {
+			return ownership, true
+		}
+	}
+	return provider.Record{}, false
+}
+
+func (c *recordCache) legacyOwnershipRecord(providerName, hostname, instanceID string) (provider.Record, bool) {
+	for _, ownership := range c.ownershipRecords(providerName, hostname) {
+		if provider.MatchesLegacyOwnership(ownership.Target, instanceID) {
+			return ownership, true
+		}
+	}
+	return provider.Record{}, false
+}
+
+func (c *recordCache) ownershipRecords(providerName, hostname string) []provider.Record {
+	byHostname, exists := c.records[providerName]
+	if !exists || byHostname == nil {
+		return nil
+	}
+	normalized := source.NormalizeHostname(provider.OwnershipRecordName(hostname))
+	var ownership []provider.Record
+	for _, record := range byHostname[normalized] {
+		if record.Type == provider.RecordTypeTXT {
+			ownership = append(ownership, record)
+		}
+	}
+	return ownership
+}
+
+func (c *recordCache) providerAvailable(providerName string) bool {
+	records, exists := c.records[providerName]
+	return exists && records != nil
+}
+
+func (c *recordCache) ownedMembers(providerName, instanceID string) []cachedOwnedMember {
+	byHostname, exists := c.records[providerName]
+	if !exists || byHostname == nil {
+		return nil
+	}
+	var owned []cachedOwnedMember
+	for _, records := range byHostname {
+		for _, marker := range records {
+			if marker.Type != provider.RecordTypeTXT || !provider.IsOwnershipRecord(marker.Hostname) {
+				continue
+			}
+			isOwned, markerInstance, member, metadata := provider.ParseMemberOwnershipValue(marker.Target)
+			if !isOwned || markerInstance != instanceID || member == nil {
+				continue
+			}
+			member.Hostname = provider.ExtractHostnameFromOwnership(marker.Hostname)
+			if member.Hostname == "" {
+				continue
+			}
+			owned = append(owned, cachedOwnedMember{Member: *member, Marker: marker, Metadata: metadata})
+		}
+	}
+	return owned
 }

--- a/internal/reconciler/cache_test.go
+++ b/internal/reconciler/cache_test.go
@@ -215,3 +215,29 @@ func TestRecordCache_GetExistingRecords(t *testing.T) {
 		})
 	}
 }
+
+func TestRecordCache_DistinguishesMemberAndLegacyOwnership(t *testing.T) {
+	member := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10"}
+	memberMarker := provider.MemberOwnershipRecord(member.Hostname, 300, "instance-a", member, map[string]string{"source": "native"})
+	legacyMarker := provider.OwnershipRecord(member.Hostname, 300, "instance-a", nil)
+	cache := &recordCache{
+		records: map[string]map[string][]provider.Record{
+			"dns": {
+				"_dnsweaver.app.example.com": {memberMarker, legacyMarker},
+			},
+		},
+		logger: slog.Default(),
+	}
+
+	gotMember, found := cache.memberOwnershipRecord("dns", member, "instance-a")
+	if !found || gotMember.Target != memberMarker.Target {
+		t.Fatalf("member marker = %+v, %v", gotMember, found)
+	}
+	gotLegacy, found := cache.legacyOwnershipRecord("dns", member.Hostname, "instance-a")
+	if !found || gotLegacy.Target != legacyMarker.Target {
+		t.Fatalf("legacy marker = %+v, %v", gotLegacy, found)
+	}
+	if _, found := cache.memberOwnershipRecord("dns", provider.Record{Hostname: member.Hostname, Type: member.Type, Target: "192.0.2.11"}, "instance-a"); found {
+		t.Fatal("member marker matched another target")
+	}
+}

--- a/internal/reconciler/claims.go
+++ b/internal/reconciler/claims.go
@@ -1,0 +1,171 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+)
+
+type extractedClaims struct {
+	Claims   []*source.Hostname
+	Unique   map[string]*source.Hostname
+	Complete bool
+}
+
+func (r *Reconciler) extractClaims(ctx context.Context, workloads []workload.Workload, result *Result) extractedClaims {
+	extracted := extractedClaims{
+		Unique:   make(map[string]*source.Hostname),
+		Complete: true,
+	}
+	origins := make(map[string]string)
+	reportedDuplicates := make(map[string]struct{})
+
+	for _, currentWorkload := range workloads {
+		hostnames, complete := r.sources.ExtractAllWithStatus(ctx, currentWorkload)
+		if !complete {
+			extracted.Complete = false
+		}
+		valid := r.validateClaims(hostnames, currentWorkload.Name, false, result)
+		selected := selectClaimsWithinWorkload(valid)
+		for _, claim := range selected {
+			normalized := claim.NormalizedName()
+			if firstWorkload, exists := origins[normalized]; exists && firstWorkload != currentWorkload.Name {
+				duplicateKey := normalized + "\x00" + currentWorkload.Name
+				if _, reported := reportedDuplicates[duplicateKey]; !reported {
+					reportedDuplicates[duplicateKey] = struct{}{}
+					result.HostnamesDuplicate++
+					r.logger.Warn("duplicate hostname found in multiple workloads",
+						slog.String("hostname", claim.Name),
+						slog.String("first_workload", firstWorkload),
+						slog.String("duplicate_workload", currentWorkload.Name),
+					)
+				}
+			} else if !exists {
+				origins[normalized] = currentWorkload.Name
+			}
+			extracted.Claims = append(extracted.Claims, claim)
+			extracted.addUnique(claim)
+		}
+	}
+
+	fileHostnames, complete := r.sources.DiscoverAllWithStatus(ctx)
+	if !complete {
+		extracted.Complete = false
+	}
+	validFiles := r.validateClaims(fileHostnames, "", true, result)
+	for _, claim := range selectClaimsWithinWorkload(validFiles) {
+		extracted.Claims = append(extracted.Claims, claim)
+		extracted.addUnique(claim)
+	}
+
+	return extracted
+}
+
+func (r *Reconciler) validateClaims(hostnames source.Hostnames, workloadName string, fromFile bool, result *Result) source.Hostnames {
+	validation := hostnames.ValidateAll()
+	for _, invalid := range validation.Invalid {
+		attrs := []any{
+			slog.String("hostname", invalid.Hostname.Name),
+			slog.String("source", invalid.Hostname.Source),
+			slog.String("error", invalid.Error.Error()),
+		}
+		message := "skipping invalid hostname from workload"
+		if fromFile {
+			message = "skipping invalid hostname from file"
+			attrs = append(attrs, slog.String("router", invalid.Hostname.Router))
+		} else {
+			attrs = append(attrs, slog.String("workload", workloadName))
+		}
+		r.logger.Warn(message, attrs...)
+		result.HostnamesInvalid++
+	}
+	return validation.Valid
+}
+
+func (e *extractedClaims) addUnique(claim *source.Hostname) {
+	normalized := claim.NormalizedName()
+	if existing, found := e.Unique[normalized]; found {
+		e.Unique[normalized] = mergeDuplicateHostname(existing, claim)
+		return
+	}
+	e.Unique[normalized] = claim
+}
+
+// selectClaimsWithinWorkload preserves distinct record members declared by one
+// workload while retaining the existing precedence rule between a bare source
+// claim and a record-specific claim for the same hostname.
+func selectClaimsWithinWorkload(hostnames source.Hostnames) []*source.Hostname {
+	selected := make([]*source.Hostname, 0, len(hostnames))
+	for i := range hostnames {
+		candidate := &hostnames[i]
+		var sameName []int
+		for index, existing := range selected {
+			if existing.NormalizedName() == candidate.NormalizedName() {
+				sameName = append(sameName, index)
+			}
+		}
+		if len(sameName) == 0 {
+			selected = append(selected, candidate)
+			continue
+		}
+		if candidate.RecordHints == nil {
+			mergedIntoHinted := false
+			for _, index := range sameName {
+				if selected[index].RecordHints != nil {
+					selected[index] = mergeDuplicateHostname(selected[index], candidate)
+					mergedIntoHinted = true
+				}
+			}
+			if mergedIntoHinted {
+				continue
+			}
+		}
+
+		merged := false
+		for _, index := range sameName {
+			existing := selected[index]
+			switch {
+			case sameDeclaredMember(existing, candidate):
+				selected[index] = mergeDuplicateHostname(existing, candidate)
+				merged = true
+			case existing.RecordHints == nil && candidate.RecordHints != nil:
+				selected[index] = mergeDuplicateHostname(existing, candidate)
+				merged = true
+			case existing.RecordHints != nil && candidate.RecordHints == nil:
+				selected[index] = mergeDuplicateHostname(existing, candidate)
+				merged = true
+			}
+			if merged {
+				break
+			}
+		}
+		if !merged {
+			candidate.Metadata = mergeInstanceMetadata(candidate.Metadata, selected[sameName[0]].Metadata)
+			selected = append(selected, candidate)
+		}
+	}
+	return selected
+}
+
+func sameDeclaredMember(a, b *source.Hostname) bool {
+	if a.RecordHints == nil || b.RecordHints == nil {
+		return a.RecordHints == nil && b.RecordHints == nil
+	}
+	if a.RecordHints.Provider != b.RecordHints.Provider ||
+		!strings.EqualFold(a.RecordHints.Type, b.RecordHints.Type) {
+		return false
+	}
+	recordA := provider.Record{Type: provider.RecordType(strings.ToUpper(a.RecordHints.Type)), Target: a.RecordHints.Target}
+	recordB := provider.Record{Type: provider.RecordType(strings.ToUpper(b.RecordHints.Type)), Target: b.RecordHints.Target}
+	if a.RecordHints.SRV != nil {
+		recordA.SRV = &provider.SRVData{Priority: a.RecordHints.SRV.Priority, Weight: a.RecordHints.SRV.Weight, Port: a.RecordHints.SRV.Port}
+	}
+	if b.RecordHints.SRV != nil {
+		recordB.SRV = &provider.SRVData{Priority: b.RecordHints.SRV.Priority, Weight: b.RecordHints.SRV.Weight, Port: b.RecordHints.SRV.Port}
+	}
+	return provider.SameRecordMember(recordA, recordB)
+}

--- a/internal/reconciler/claims_test.go
+++ b/internal/reconciler/claims_test.go
@@ -1,0 +1,88 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+)
+
+func TestExtractClaims_PreservesDualStackAndCountsUniqueHostnames(t *testing.T) {
+	sources := testSourceRegistry(quietLogger(), newTestMockSource("proxmox",
+		source.Hostname{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+		source.Hostname{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "AAAA", Target: "2001:db8::10"}},
+	))
+	r := New(nil, sources, testProviderRegistry(quietLogger()), WithLogger(quietLogger()))
+	result := NewResult(false)
+	extracted := r.extractClaims(context.Background(), []workload.Workload{{Name: "vm", Platform: workload.PlatformProxmox}}, result)
+	if !extracted.Complete {
+		t.Fatal("snapshot unexpectedly incomplete")
+	}
+	if len(extracted.Claims) != 2 {
+		t.Fatalf("claims = %+v, want A and AAAA", extracted.Claims)
+	}
+	if len(extracted.Unique) != 1 {
+		t.Fatalf("unique hostnames = %d, want 1", len(extracted.Unique))
+	}
+}
+
+func TestExtractClaims_CountsDuplicateHostnameOncePerWorkload(t *testing.T) {
+	sources := testSourceRegistry(quietLogger(), newTestMockSource("proxmox",
+		source.Hostname{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+		source.Hostname{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "AAAA", Target: "2001:db8::10"}},
+	))
+	r := New(nil, sources, testProviderRegistry(quietLogger()), WithLogger(quietLogger()))
+	result := NewResult(false)
+	extracted := r.extractClaims(context.Background(), []workload.Workload{
+		{Name: "first", Platform: workload.PlatformProxmox},
+		{Name: "second", Platform: workload.PlatformProxmox},
+	}, result)
+	if len(extracted.Claims) != 4 {
+		t.Fatalf("claims = %d, want all four member claims", len(extracted.Claims))
+	}
+	if result.HostnamesDuplicate != 1 {
+		t.Fatalf("HostnamesDuplicate = %d, want one duplicate hostname", result.HostnamesDuplicate)
+	}
+}
+
+func TestSelectClaimsWithinWorkload_RecordHintSupersedesBareClaim(t *testing.T) {
+	hostnames := source.Hostnames{
+		{Name: "app.example.com", Source: "traefik", Metadata: map[string]string{"traefik.entrypoint": "web"}},
+		{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+	}
+	selected := selectClaimsWithinWorkload(hostnames)
+	if len(selected) != 1 || selected[0].RecordHints == nil || selected[0].RecordHints.Target != "192.0.2.10" {
+		t.Fatalf("selected = %+v, want hinted claim only", selected)
+	}
+	if selected[0].Metadata["traefik.entrypoint"] != "web" {
+		t.Fatalf("metadata = %v, want entrypoint preserved", selected[0].Metadata)
+	}
+}
+
+func TestSelectClaimsWithinWorkload_PreservesDistinctTargets(t *testing.T) {
+	hostnames := source.Hostnames{
+		{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+		{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.11"}},
+	}
+	if selected := selectClaimsWithinWorkload(hostnames); len(selected) != 2 {
+		t.Fatalf("selected = %+v, want two distinct members", selected)
+	}
+}
+
+func TestSelectClaimsWithinWorkload_BareMetadataReachesEveryDistinctMember(t *testing.T) {
+	hostnames := source.Hostnames{
+		{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+		{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.11"}},
+		{Name: "app.example.com", Source: "traefik", Metadata: map[string]string{"traefik.entrypoint": "web"}},
+	}
+	selected := selectClaimsWithinWorkload(hostnames)
+	if len(selected) != 2 {
+		t.Fatalf("selected = %+v, want two distinct members", selected)
+	}
+	for _, claim := range selected {
+		if claim.Metadata["traefik.entrypoint"] != "web" {
+			t.Fatalf("metadata = %v, want entrypoint on every member", claim.Metadata)
+		}
+	}
+}

--- a/internal/reconciler/cloudflare_state_test.go
+++ b/internal/reconciler/cloudflare_state_test.go
@@ -38,12 +38,14 @@ type fakeCFRecord struct {
 }
 
 type fakeCloudflareAPI struct {
-	mu      sync.Mutex
-	nextID  int
-	records []fakeCFRecord
-	patches []fakeCFRecord // bodies of PATCH requests, in order
-	posts   int
-	deletes int
+	mu          sync.Mutex
+	nextID      int
+	records     []fakeCFRecord
+	patches     []fakeCFRecord // bodies of PATCH requests, in order
+	posts       int
+	deletes     int
+	postTypes   []string
+	deleteTypes []string
 }
 
 func (f *fakeCloudflareAPI) add(recordType, name, content string, ttl int, proxied bool) {
@@ -107,6 +109,7 @@ func (f *fakeCloudflareAPI) handler() http.Handler {
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		f.mu.Lock()
 		f.posts++
+		f.postTypes = append(f.postTypes, body.Type)
 		f.mu.Unlock()
 		f.add(body.Type, body.Name, body.Content, body.TTL, body.Proxied)
 		rec, _ := f.find(body.Type, body.Name)
@@ -144,15 +147,33 @@ func (f *fakeCloudflareAPI) handler() http.Handler {
 		id := r.PathValue("id")
 		kept := f.records[:0]
 		for _, rec := range f.records {
-			if rec.ID != id {
-				kept = append(kept, rec)
+			if rec.ID == id {
+				f.deleteTypes = append(f.deleteTypes, rec.Type)
+				continue
 			}
+			kept = append(kept, rec)
 		}
 		f.records = kept
 		writeCFResult(w, map[string]string{"id": id})
 	})
 
 	return mux
+}
+
+func (f *fakeCloudflareAPI) mutationCount(method, recordType string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	types := f.postTypes
+	if method == http.MethodDelete {
+		types = f.deleteTypes
+	}
+	count := 0
+	for _, current := range types {
+		if current == recordType {
+			count++
+		}
+	}
+	return count
 }
 
 // rewriteTransport sends every request to base instead of the Cloudflare API,
@@ -269,8 +290,17 @@ func TestReconcile_CloudflareProxiedLabelUpdatesExistingRecord(t *testing.T) {
 	if got := api.patchCount(); got != len(hosts) {
 		t.Errorf("second pass issued %d extra PATCH requests", got-len(hosts))
 	}
-	if api.posts != 0 || api.deletes != 0 {
-		t.Errorf("expected no creates or deletes, got %d POST and %d DELETE", api.posts, api.deletes)
+	if got := api.mutationCount(http.MethodPost, "TXT"); got != len(hosts) {
+		t.Errorf("ownership marker creates = %d, want %d for one-time legacy migration", got, len(hosts))
+	}
+	if got := api.mutationCount(http.MethodDelete, "TXT"); got != len(hosts) {
+		t.Errorf("ownership marker deletes = %d, want %d for one-time legacy migration", got, len(hosts))
+	}
+	if got := api.mutationCount(http.MethodPost, "A"); got != 0 {
+		t.Errorf("A record creates = %d, want 0", got)
+	}
+	if got := api.mutationCount(http.MethodDelete, "A"); got != 0 {
+		t.Errorf("A record deletes = %d, want 0", got)
 	}
 }
 
@@ -310,7 +340,19 @@ func TestReconcile_CloudflareProxiedSteadyStateIsNotChurn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			api := &fakeCloudflareAPI{}
 			api.add("A", host, target, 300, tt.recordProxied)
-			api.add("TXT", provider.OwnershipRecordName(host), provider.OwnershipValue, 300, false)
+			var metadata map[string]string
+			if proxied, ok := tt.labels["dnsweaver.proxied"]; ok {
+				metadata = map[string]string{"proxied": proxied}
+			}
+			member := provider.Record{
+				Hostname: host,
+				Type:     provider.RecordTypeA,
+				Target:   target,
+				TTL:      300,
+				Metadata: metadata,
+			}
+			marker := provider.MemberOwnershipRecord(host, 300, "", member, metadata)
+			api.add("TXT", marker.Hostname, marker.Target, marker.TTL, false)
 
 			r, lister := newCloudflareStateFixture(t, api, tt.proxiedDefault, target)
 			lister.AddWorkload("app", tt.labels)

--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -1,0 +1,291 @@
+package reconciler
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+)
+
+type desiredSetKey struct {
+	Identity   provider.ProviderIdentity
+	Hostname   string
+	RecordType provider.RecordType
+}
+
+type desiredRecordMember struct {
+	Record     provider.Record
+	Claim      *source.Hostname
+	ClaimCount int
+}
+
+type desiredRecordSet struct {
+	Instance *provider.ProviderInstance
+	Key      desiredSetKey
+	Members  []desiredRecordMember
+}
+
+type desiredCompilation struct {
+	Sets              []*desiredRecordSet
+	Skipped           []Action
+	HostnameProviders map[string][]string
+}
+
+type previousDesiredSet struct {
+	ProviderName string
+	Records      []provider.Record
+}
+
+// compileDesiredRecordSets routes source claims to physical provider backends,
+// resolves instance defaults, and deduplicates identical DNS members while
+// retaining how many claims want each one.
+func (r *Reconciler) compileDesiredRecordSets(claims []*source.Hostname) desiredCompilation {
+	compiled := desiredCompilation{HostnameProviders: make(map[string][]string)}
+	sets := make(map[desiredSetKey]*desiredRecordSet)
+
+	for _, claim := range claims {
+		candidates, skip := r.providersForClaim(claim)
+		if skip != nil {
+			compiled.Skipped = append(compiled.Skipped, *skip)
+			continue
+		}
+
+		seenBackends := make(map[desiredSetKey]struct{}, len(candidates))
+		for _, instance := range candidates {
+			record := desiredRecordForClaim(claim, instance)
+			key := desiredSetKey{
+				Identity:   instance.Identity,
+				Hostname:   source.NormalizeHostname(record.Hostname),
+				RecordType: record.Type,
+			}
+			if _, duplicate := seenBackends[key]; duplicate {
+				continue
+			}
+			seenBackends[key] = struct{}{}
+
+			set := sets[key]
+			if set == nil {
+				set = &desiredRecordSet{Instance: instance, Key: key}
+				sets[key] = set
+				compiled.Sets = append(compiled.Sets, set)
+			}
+			compiled.HostnameProviders[key.Hostname] = appendUnique(compiled.HostnameProviders[key.Hostname], set.Instance.Name())
+
+			memberIndex := -1
+			for i := range set.Members {
+				if provider.SameRecordMember(set.Members[i].Record, record) {
+					memberIndex = i
+					break
+				}
+			}
+			if memberIndex < 0 {
+				set.Members = append(set.Members, desiredRecordMember{Record: record, Claim: claim, ClaimCount: 1})
+				continue
+			}
+
+			member := &set.Members[memberIndex]
+			member.ClaimCount++
+			// A record-specific declaration carries more intent than a bare
+			// hostname that happened to resolve to the same member.
+			if member.Claim.RecordHints == nil && claim.RecordHints != nil {
+				member.Record = record
+				member.Claim = claim
+			}
+		}
+	}
+
+	return compiled
+}
+
+func (r *Reconciler) providersForClaim(claim *source.Hostname) ([]*provider.ProviderInstance, *Action) {
+	if claim.RecordHints != nil && claim.RecordHints.Provider != "" {
+		name := claim.RecordHints.Provider
+		instance, exists := r.providers.Get(name)
+		if !exists {
+			return nil, &Action{
+				Type:     ActionSkip,
+				Status:   StatusSkipped,
+				Hostname: claim.Name,
+				Error:    fmt.Sprintf("explicit provider %q not found", name),
+			}
+		}
+		return []*provider.ProviderInstance{instance}, nil
+	}
+
+	instances := r.providers.MatchingProvidersForHostname(claim.Name, claim.Metadata)
+	if len(instances) == 0 {
+		return nil, &Action{
+			Type:     ActionSkip,
+			Status:   StatusSkipped,
+			Hostname: claim.Name,
+			Error:    errNoMatchingProvider,
+		}
+	}
+	return instances, nil
+}
+
+func desiredRecordForClaim(claim *source.Hostname, instance *provider.ProviderInstance) provider.Record {
+	record := provider.Record{
+		Hostname: claim.Name,
+		Type:     instance.RecordType,
+		Target:   instance.EffectiveTarget(),
+		TTL:      instance.TTL,
+	}
+	if hints := claim.RecordHints; hints != nil {
+		if hints.Type != "" {
+			record.Type = provider.RecordType(hints.Type)
+		}
+		if hints.Target != "" {
+			record.Target = hints.Target
+		}
+		if hints.TTL > 0 {
+			record.TTL = hints.TTL
+		}
+		if hints.SRV != nil {
+			record.SRV = &provider.SRVData{
+				Priority: hints.SRV.Priority,
+				Weight:   hints.SRV.Weight,
+				Port:     hints.SRV.Port,
+			}
+		}
+		if len(hints.Metadata) > 0 {
+			record.Metadata = hints.Metadata
+		}
+	}
+	return record
+}
+
+func (r *Reconciler) reconciliationSets(compiled desiredCompilation, cache *recordCache) ([]*desiredRecordSet, map[desiredSetKey]previousDesiredSet) {
+	sets := append([]*desiredRecordSet(nil), compiled.Sets...)
+	byKey := make(map[desiredSetKey]*desiredRecordSet, len(sets))
+	for _, set := range sets {
+		byKey[set.Key] = set
+	}
+
+	previous := r.previousDesiredSnapshot()
+	for key, prior := range previous {
+		if byKey[key] != nil {
+			continue
+		}
+		instance, exists := r.providers.Get(prior.ProviderName)
+		if !exists {
+			continue
+		}
+		set := &desiredRecordSet{Instance: instance, Key: key}
+		sets = append(sets, set)
+		byKey[key] = set
+	}
+
+	if cache == nil {
+		return sets, previous
+	}
+	for _, instance := range r.providers.All() {
+		for _, owned := range cache.ownedMembers(instance.Name(), instance.InstanceID) {
+			key := desiredSetKey{
+				Identity:   instance.Identity,
+				Hostname:   source.NormalizeHostname(owned.Member.Hostname),
+				RecordType: owned.Member.Type,
+			}
+			if byKey[key] != nil {
+				continue
+			}
+			set := &desiredRecordSet{Instance: instance, Key: key}
+			sets = append(sets, set)
+			byKey[key] = set
+		}
+	}
+	return sets, previous
+}
+
+func (r *Reconciler) previousDesiredSnapshot() map[desiredSetKey]previousDesiredSet {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	snapshot := make(map[desiredSetKey]previousDesiredSet, len(r.previousDesired))
+	for key, set := range r.previousDesired {
+		snapshot[key] = previousDesiredSet{
+			ProviderName: set.ProviderName,
+			Records:      append([]provider.Record(nil), set.Records...),
+		}
+	}
+	return snapshot
+}
+
+func (r *Reconciler) rememberDesired(next map[desiredSetKey]previousDesiredSet) {
+	r.mu.Lock()
+	r.previousDesired = next
+	r.mu.Unlock()
+}
+
+func (r *Reconciler) memberRemovalsAllowed(compiled desiredCompilation, cache *recordCache, previous map[desiredSetKey]previousDesiredSet) bool {
+	current := make(map[desiredSetKey][]provider.Record, len(compiled.Sets))
+	for _, set := range compiled.Sets {
+		for _, member := range set.Members {
+			current[set.Key] = append(current[set.Key], member.Record)
+		}
+	}
+
+	type baselineMember struct {
+		key    desiredSetKey
+		record provider.Record
+	}
+	var baseline []baselineMember
+	addBaseline := func(key desiredSetKey, record provider.Record) {
+		for _, existing := range baseline {
+			if existing.key == key && provider.SameRecordMember(existing.record, record) {
+				return
+			}
+		}
+		baseline = append(baseline, baselineMember{key: key, record: record})
+	}
+	for key, set := range previous {
+		for _, record := range set.Records {
+			addBaseline(key, record)
+		}
+	}
+	if cache != nil {
+		for _, instance := range r.providers.All() {
+			for _, owned := range cache.ownedMembers(instance.Name(), instance.InstanceID) {
+				key := desiredSetKey{Identity: instance.Identity, Hostname: source.NormalizeHostname(owned.Member.Hostname), RecordType: owned.Member.Type}
+				addBaseline(key, owned.Member)
+			}
+		}
+	}
+	if len(baseline) == 0 {
+		return true
+	}
+
+	removed := 0
+	for _, old := range baseline {
+		found := false
+		for _, record := range current[old.key] {
+			if provider.SameRecordMember(old.record, record) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			removed++
+		}
+	}
+	const massDeleteThreshold = 0.5
+	ratio := float64(removed) / float64(len(baseline))
+	if removed > 1 && ratio > massDeleteThreshold {
+		r.logger.Error("member deletion circuit breaker triggered; skipping removals",
+			slog.Int("previous_members", len(baseline)),
+			slog.Int("removed_members", removed),
+			slog.Float64("removal_ratio", ratio),
+			slog.Float64("threshold", massDeleteThreshold),
+		)
+		return false
+	}
+	return true
+}
+
+func desiredMemberCount(compiled desiredCompilation) int {
+	count := 0
+	for _, set := range compiled.Sets {
+		count += len(set.Members)
+	}
+	return count
+}

--- a/internal/reconciler/desired.go
+++ b/internal/reconciler/desired.go
@@ -219,7 +219,9 @@ func (r *Reconciler) rememberDesired(next map[desiredSetKey]previousDesiredSet) 
 
 func (r *Reconciler) memberRemovalsAllowed(compiled desiredCompilation, cache *recordCache, previous map[desiredSetKey]previousDesiredSet) bool {
 	current := make(map[desiredSetKey][]provider.Record, len(compiled.Sets))
+	currentHostnames := make(map[string]struct{}, len(compiled.Sets))
 	for _, set := range compiled.Sets {
+		currentHostnames[set.Key.Hostname] = struct{}{}
 		for _, member := range set.Members {
 			current[set.Key] = append(current[set.Key], member.Record)
 		}
@@ -257,6 +259,16 @@ func (r *Reconciler) memberRemovalsAllowed(compiled desiredCompilation, cache *r
 
 	removed := 0
 	for _, old := range baseline {
+		// A desired hostname moving away from this provider/type is an explicit
+		// route retirement, not evidence that discovery lost the hostname. The
+		// circuit breaker must not make multi-member route changes permanent by
+		// retaining every member on the old backend.
+		if _, stillRouted := current[old.key]; !stillRouted {
+			if _, hostnameStillDesired := currentHostnames[old.key.Hostname]; hostnameStillDesired {
+				continue
+			}
+		}
+
 		found := false
 		for _, record := range current[old.key] {
 			if provider.SameRecordMember(old.record, record) {

--- a/internal/reconciler/desired_test.go
+++ b/internal/reconciler/desired_test.go
@@ -1,0 +1,89 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+)
+
+func TestCompileDesiredRecordSets_PreservesDistinctMembersAndClaimCounts(t *testing.T) {
+	mock := newTestMockProvider("dns")
+	providers := testProviderRegistry(quietLogger(), mock)
+	if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+		Name: "dns", TypeName: "mock", RecordType: provider.RecordTypeA,
+		Target: "192.0.2.1", TTL: 300, Domains: []string{"*.example.com"},
+	}); err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	r := New(nil, source.NewRegistry(quietLogger()), providers, WithLogger(quietLogger()))
+
+	claims := []*source.Hostname{
+		{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+		{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.11"}},
+		{Name: "app.example.com", Source: "traefik", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+	}
+	compiled := r.compileDesiredRecordSets(claims)
+	if len(compiled.Sets) != 1 {
+		t.Fatalf("sets = %d, want 1", len(compiled.Sets))
+	}
+	set := compiled.Sets[0]
+	if len(set.Members) != 2 {
+		t.Fatalf("members = %+v, want two distinct targets", set.Members)
+	}
+	if set.Members[0].Record.Target != "192.0.2.10" || set.Members[0].ClaimCount != 2 {
+		t.Fatalf("first member = %+v, want target .10 with two claims", set.Members[0])
+	}
+	if set.Members[1].Record.Target != "192.0.2.11" || set.Members[1].ClaimCount != 1 {
+		t.Fatalf("second member = %+v, want target .11 with one claim", set.Members[1])
+	}
+}
+
+func TestCompileDesiredRecordSets_PreservesDualStackClaims(t *testing.T) {
+	mock := newTestMockProvider("dns")
+	providers := testProviderRegistry(quietLogger(), mock)
+	if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+		Name: "dns", TypeName: "mock", RecordType: provider.RecordTypeA,
+		Target: "192.0.2.1", TTL: 300, Domains: []string{"*.example.com"},
+	}); err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	r := New(nil, source.NewRegistry(quietLogger()), providers, WithLogger(quietLogger()))
+	claims := []*source.Hostname{
+		{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+		{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "AAAA", Target: "2001:db8::10"}},
+	}
+
+	compiled := r.compileDesiredRecordSets(claims)
+	if len(compiled.Sets) != 2 {
+		t.Fatalf("sets = %+v, want separate A and AAAA sets", compiled.Sets)
+	}
+	if compiled.Sets[0].Key.RecordType != provider.RecordTypeA || compiled.Sets[1].Key.RecordType != provider.RecordTypeAAAA {
+		t.Fatalf("record types = %s, %s", compiled.Sets[0].Key.RecordType, compiled.Sets[1].Key.RecordType)
+	}
+}
+
+func TestCompileDesiredRecordSets_DeduplicatesBackendIdentity(t *testing.T) {
+	first := newTestMockProvider("first")
+	second := newTestMockProvider("second")
+	identity := provider.ProviderIdentity{Type: "mock", Endpoint: "same", Zone: "example.com"}
+	first.identity = &identity
+	second.identity = &identity
+	providers := testProviderRegistry(quietLogger(), first, second)
+	for _, name := range []string{"first", "second"} {
+		if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+			Name: name, TypeName: "mock", RecordType: provider.RecordTypeA,
+			Target: "192.0.2.1", TTL: 300, Domains: []string{"*.example.com"},
+		}); err != nil {
+			t.Fatalf("CreateInstance(%s) error = %v", name, err)
+		}
+	}
+	r := New(nil, source.NewRegistry(quietLogger()), providers, WithLogger(quietLogger()))
+	compiled := r.compileDesiredRecordSets([]*source.Hostname{{Name: "app.example.com", Source: "traefik"}})
+	if len(compiled.Sets) != 1 || compiled.Sets[0].Instance.Name() != "first" {
+		t.Fatalf("sets = %+v, want first instance only", compiled.Sets)
+	}
+	if got := compiled.HostnameProviders["app.example.com"]; len(got) != 1 || got[0] != "first" {
+		t.Fatalf("provider mapping = %v, want first", got)
+	}
+}

--- a/internal/reconciler/edge_behavioral_test.go
+++ b/internal/reconciler/edge_behavioral_test.go
@@ -96,7 +96,8 @@ func TestReconcile_HostnameMovesToDifferentProvider(t *testing.T) {
 func TestReconcile_HostnameSwitchesTarget(t *testing.T) {
 	// Cycle 1: record created with target 10.0.0.1
 	// Cycle 2: same hostname but provider target changed to 10.0.0.2
-	// Should update the record (delete old + create new).
+	// The set diff should create the replacement and then remove the exact old
+	// member, without treating an unrelated sibling as an update candidate.
 	dockerMock := newTestMockWorkloadLister(workload.PlatformDocker)
 	dockerMock.AddWorkload("app", map[string]string{
 		"traefik.http.routers.app.rule": "Host(`app.example.com`)",
@@ -107,24 +108,16 @@ func TestReconcile_HostnameSwitchesTarget(t *testing.T) {
 	sources.Register(traefik.New(traefik.WithLogger(logger)))
 
 	mockProvider := newTestMockProvider("test-dns")
-	// Pre-seed with old target to simulate previous cycle
-	mockProvider.AddRecord(provider.Record{
-		Hostname: "app.example.com",
-		Type:     provider.RecordTypeA,
-		Target:   "10.0.0.1",
-	})
-	mockProvider.AddRecord(ownershipTXT("app.example.com"))
 
 	providers := provider.NewRegistry(logger)
 	providers.RegisterFactory("mock", func(_ provider.FactoryConfig) (provider.Provider, error) {
 		return mockProvider, nil
 	})
-	// New target is 10.0.0.2
 	_ = providers.CreateInstance(provider.ProviderInstanceConfig{
 		Name:       "test-dns",
 		TypeName:   "mock",
 		RecordType: provider.RecordTypeA,
-		Target:     "10.0.0.2",
+		Target:     "10.0.0.1",
 		TTL:        300,
 		Domains:    []string{"*.example.com"},
 	})
@@ -134,18 +127,27 @@ func TestReconcile_HostnameSwitchesTarget(t *testing.T) {
 		WithLogger(logger),
 	)
 
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("first Reconcile error: %v", err)
+	}
+	instance, ok := providers.Get("test-dns")
+	if !ok {
+		t.Fatal("provider instance not found")
+	}
+	instance.SetDynamicTarget("10.0.0.2")
+
 	result, err := r.Reconcile(context.Background())
 	if err != nil {
-		t.Fatalf("Reconcile error: %v", err)
+		t.Fatalf("second Reconcile error: %v", err)
 	}
 
-	// Should see an update action
-	updated := result.Updated()
-	if len(updated) != 1 {
-		t.Errorf("expected 1 update action, got %d", len(updated))
+	created := result.Created()
+	if len(created) != 1 || created[0].Target != "10.0.0.2" {
+		t.Errorf("created actions = %+v, want replacement target 10.0.0.2", created)
 	}
-	if len(updated) > 0 && updated[0].Target != "10.0.0.2" {
-		t.Errorf("updated target = %q, want 10.0.0.2", updated[0].Target)
+	deleted := result.Deleted()
+	if len(deleted) != 1 || deleted[0].Target != "10.0.0.1" {
+		t.Errorf("deleted actions = %+v, want old target 10.0.0.1", deleted)
 	}
 }
 
@@ -930,16 +932,7 @@ func TestReconcile_AdditiveModePreventsOrphanDeletion(t *testing.T) {
 		t.Errorf("additive mode should prevent deletion, but %d records were deleted", len(deleted))
 	}
 
-	// Should have a skip action for the orphan
-	skipped := result.Skipped()
-	hasAdditiveSkip := false
-	for _, a := range skipped {
-		if strings.Contains(a.Error, "additive") {
-			hasAdditiveSkip = true
-			break
-		}
-	}
-	if !hasAdditiveSkip {
-		t.Error("expected skip action mentioning additive mode")
+	if len(result.Deleted()) != 0 {
+		t.Errorf("additive mode reported deletions: %+v", result.Deleted())
 	}
 }

--- a/internal/reconciler/edge_failure_test.go
+++ b/internal/reconciler/edge_failure_test.go
@@ -117,12 +117,7 @@ func TestReconcile_CanceledContextDuringProviderDelete(t *testing.T) {
 		Type:     provider.RecordTypeA,
 		Target:   "10.0.0.1",
 	})
-	// Add ownership TXT at the correct hostname (_dnsweaver. prefix)
-	mockProvider.AddRecord(provider.Record{
-		Hostname: provider.OwnershipRecordName("orphan.example.com"),
-		Type:     provider.RecordTypeTXT,
-		Target:   "heritage=dnsweaver",
-	})
+	mockProvider.AddRecord(memberOwnershipTXT("orphan.example.com", "10.0.0.1"))
 
 	mockProvider.deleteFn = func(_ context.Context, _ provider.Record) error {
 		return context.Canceled
@@ -228,8 +223,8 @@ func TestReconcile_ProviderListFailureDuringCacheBuild(t *testing.T) {
 }
 
 func TestReconcile_ProviderDeleteFails(t *testing.T) {
-	// When provider.Delete() fails during ensureRecord (target change),
-	// the action should report failure.
+	// When deletion of the old member fails during a target change, the
+	// replacement stays created and the exact failed deletion is reported.
 	dockerMock := newTestMockWorkloadLister(workload.PlatformDocker)
 	dockerMock.AddWorkload("app", map[string]string{
 		"traefik.http.routers.app.rule": "Host(`app.example.com`)",
@@ -246,7 +241,13 @@ func TestReconcile_ProviderDeleteFails(t *testing.T) {
 		Type:     provider.RecordTypeA,
 		Target:   "10.0.0.99", // different from the 10.0.0.1 the provider instance wants
 	})
-	mockProvider.AddRecord(ownershipTXT("app.example.com"))
+	mockProvider.AddRecord(memberOwnershipTXT("app.example.com", "10.0.0.99"))
+	mockProvider.deleteFn = func(_ context.Context, record provider.Record) error {
+		if record.Type == provider.RecordTypeA {
+			return errors.New("provider delete failed")
+		}
+		return nil
+	}
 
 	providers := provider.NewRegistry(logger)
 	providers.RegisterFactory("mock", func(_ provider.FactoryConfig) (provider.Provider, error) {
@@ -271,10 +272,13 @@ func TestReconcile_ProviderDeleteFails(t *testing.T) {
 		t.Fatalf("Reconcile returned hard error: %v", err)
 	}
 
-	// Should have an update action (old target 10.0.0.99 → new target 10.0.0.1)
-	updated := result.Updated()
-	if len(updated) != 1 {
-		t.Errorf("expected 1 updated action, got %d", len(updated))
+	created := result.Created()
+	if len(created) != 1 || created[0].Target != "10.0.0.1" {
+		t.Errorf("created actions = %+v, want replacement member", created)
+	}
+	failed := result.Failed()
+	if len(failed) != 1 || failed[0].Type != ActionDelete || failed[0].Target != "10.0.0.99" {
+		t.Errorf("failed actions = %+v, want exact old-member deletion failure", failed)
 	}
 }
 

--- a/internal/reconciler/edge_observability_test.go
+++ b/internal/reconciler/edge_observability_test.go
@@ -381,12 +381,8 @@ func TestReconcile_DryRunOrphanCleanupReportsActions(t *testing.T) {
 		Target:   "10.0.0.1",
 		TTL:      300,
 	})
-	// Also seed the ownership TXT record (managed mode requires it)
-	mockProvider.AddRecord(provider.Record{
-		Hostname: "_dnsweaver.orphan.example.com",
-		Type:     provider.RecordTypeTXT,
-		Target:   "heritage=dnsweaver",
-	})
+	// Also seed the exact ownership TXT record (managed mode requires it).
+	mockProvider.AddRecord(memberOwnershipTXT("orphan.example.com", "10.0.0.1"))
 
 	r := New([]workload.Lister{dockerMock}, sources, providers,
 		WithConfig(cfg),

--- a/internal/reconciler/reconcile_test.go
+++ b/internal/reconciler/reconcile_test.go
@@ -497,13 +497,8 @@ func TestReconcile_OrphanCleanup(t *testing.T) {
 		Target:   "10.0.0.1",
 		TTL:      300,
 	})
-	// Add ownership record for current app (correct format: _dnsweaver.hostname)
-	mockProvider.AddRecord(provider.Record{
-		Hostname: "_dnsweaver.current.example.com",
-		Type:     provider.RecordTypeTXT,
-		Target:   "heritage=dnsweaver",
-		TTL:      300,
-	})
+	// Add exact ownership record for current app.
+	mockProvider.AddRecord(memberOwnershipTXT("current.example.com", "10.0.0.1"))
 	// Add orphan record (workload no longer exists)
 	mockProvider.AddRecord(provider.Record{
 		Hostname: "orphan.example.com",
@@ -511,13 +506,8 @@ func TestReconcile_OrphanCleanup(t *testing.T) {
 		Target:   "10.0.0.1",
 		TTL:      300,
 	})
-	// Add ownership record for orphan (so it can be deleted)
-	mockProvider.AddRecord(provider.Record{
-		Hostname: "_dnsweaver.orphan.example.com",
-		Type:     provider.RecordTypeTXT,
-		Target:   "heritage=dnsweaver",
-		TTL:      300,
-	})
+	// Add exact ownership record for orphan (so it can be deleted).
+	mockProvider.AddRecord(memberOwnershipTXT("orphan.example.com", "10.0.0.1"))
 
 	providers := provider.NewRegistry(logger)
 	providers.RegisterFactory("mock", func(cfg provider.FactoryConfig) (provider.Provider, error) {
@@ -1207,12 +1197,9 @@ func TestReconcile_CaseSensitivity(t *testing.T) {
 	}
 }
 
-// TestReconcile_ProviderCreateFailsAfterDelete tests the scenario where:
-// 1. Old record exists with wrong target
-// 2. Old record is deleted successfully
-// 3. New record creation FAILS
-// Result: Hostname has NO DNS record - partial failure state
-func TestReconcile_ProviderCreateFailsAfterDelete(t *testing.T) {
+// TestReconcile_ProviderCreateFailurePreservesOldMember verifies that a target
+// change does not delete the working old member when its replacement fails.
+func TestReconcile_ProviderCreateFailurePreservesOldMember(t *testing.T) {
 	dockerMock := newTestMockWorkloadLister(workload.PlatformDocker)
 	dockerMock.AddWorkload("my-app", map[string]string{
 		"traefik.http.routers.myapp.rule": "Host(`app.example.com`)",
@@ -1231,7 +1218,7 @@ func TestReconcile_ProviderCreateFailsAfterDelete(t *testing.T) {
 		Target:   "10.0.0.99", // Old target - will be deleted
 		TTL:      300,
 	})
-	mockProvider.AddRecord(ownershipTXT("app.example.com"))
+	mockProvider.AddRecord(memberOwnershipTXT("app.example.com", "10.0.0.99"))
 
 	// Make Create fail
 	createCallCount := 0
@@ -1269,10 +1256,10 @@ func TestReconcile_ProviderCreateFailsAfterDelete(t *testing.T) {
 		t.Fatalf("Reconcile returned error: %v", err)
 	}
 
-	// Old record should have been deleted
+	// The old record must remain until the replacement exists.
 	deleted := mockProvider.GetDeleted()
-	if len(deleted) < 1 {
-		t.Errorf("expected old record to be deleted, got %d deletions", len(deleted))
+	if len(deleted) != 0 {
+		t.Errorf("replacement failure deleted existing records: %+v", deleted)
 	}
 
 	// Create should have been attempted and failed
@@ -1285,10 +1272,6 @@ func TestReconcile_ProviderCreateFailsAfterDelete(t *testing.T) {
 	if len(failed) != 1 {
 		t.Errorf("expected 1 failed action, got %d", len(failed))
 	}
-
-	// The concerning state: old record deleted, new record not created
-	// This is a known limitation - the test documents it
-	t.Log("Note: After this failure, the hostname has no DNS record (old deleted, new failed)")
 }
 
 // TestReconcile_FirstRunAfterRestart verifies that the first reconciliation
@@ -1312,12 +1295,7 @@ func TestReconcile_FirstRunAfterRestart(t *testing.T) {
 		Target:   "10.0.0.1",
 		TTL:      300,
 	})
-	mockProvider.AddRecord(provider.Record{
-		Hostname: "_dnsweaver.app.example.com",
-		Type:     provider.RecordTypeTXT,
-		Target:   "heritage=dnsweaver",
-		TTL:      300,
-	})
+	mockProvider.AddRecord(memberOwnershipTXT("app.example.com", "10.0.0.1"))
 
 	providers := provider.NewRegistry(logger)
 	providers.RegisterFactory("mock", func(cfg provider.FactoryConfig) (provider.Provider, error) {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -22,6 +22,7 @@ const (
 	errRecordTypeConflict   = "record type conflict"
 	errNoMatchingProvider   = "no matching provider"
 	errSelfReferentialCNAME = "self-referential CNAME (target equals hostname)"
+	errMultipleCNAMEMembers = "CNAME record set cannot contain multiple members"
 )
 
 // Reconciliation-level outcome labels used for the reconciliations_total metric.
@@ -114,6 +115,11 @@ type Reconciler struct {
 	// from the correct provider even when domain patterns have changed (#51).
 	hostnameProviders map[string][]string
 
+	// previousDesired retains the last complete provider-routed member set.
+	// Providers without durable TXT ownership use it to make safe removals
+	// during this process lifetime; it is deliberately empty after restart.
+	previousDesired map[desiredSetKey]previousDesiredSet
+
 	// reconcileMu serializes full Reconcile() calls to prevent concurrent
 	// reconciliation cycles from interleaving (e.g., periodic timer firing
 	// while a Docker/K8s event-triggered reconciliation is still running).
@@ -163,6 +169,7 @@ func New(
 		logger:            slog.Default(),
 		knownHostnames:    make(map[string]struct{}),
 		hostnameProviders: make(map[string][]string),
+		previousDesired:   make(map[desiredSetKey]previousDesiredSet),
 	}
 
 	for _, opt := range opts {
@@ -230,49 +237,70 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*Result, error) {
 	}
 	result.WorkloadsScanned = len(allWorkloads)
 
-	// Step 2: Extract hostnames from each workload
-	discoveredHostnames := r.extractHostnames(ctx, allWorkloads, result)
-
-	result.HostnamesDiscovered = len(discoveredHostnames)
+	// Step 2: Extract source claims without collapsing distinct DNS members.
+	extracted := r.extractClaims(ctx, allWorkloads, result)
+	result.HostnamesDiscovered = len(extracted.Unique)
 
 	r.logger.Info("hostname extraction complete",
 		slog.Int("workloads", len(allWorkloads)),
-		slog.Int("hostnames", len(discoveredHostnames)),
+		slog.Int("hostnames", len(extracted.Unique)),
+		slog.Int("claims", len(extracted.Claims)),
+		slog.Bool("complete", extracted.Complete),
 	)
 
 	// Step 3: Build record cache for all providers (single List() call per provider).
 	// Built even in dry-run mode so orphan cleanup can report accurate record counts.
 	cache := newRecordCache(ctx, r.providers, r.logger)
 
-	// Step 4: Ensure records exist for all discovered hostnames.
-	// Track which providers each hostname is routed to for orphan cleanup (#51).
-	currentProviderMapping := make(map[string][]string, len(discoveredHostnames))
-	for _, hostname := range discoveredHostnames {
-		actions := r.ensureRecord(ctx, hostname, cache)
+	// Step 4: Compile provider-routed desired sets, then reconcile every set
+	// once. Previous in-memory sets and durable member markers contribute empty
+	// desired sets so removed routes and post-restart orphans are handled by the
+	// same exact-member diff.
+	compiled := r.compileDesiredRecordSets(extracted.Claims)
+	result.DesiredMembers = desiredMemberCount(compiled)
+	for _, action := range compiled.Skipped {
+		result.AddAction(action)
+	}
+	sets, previous := r.reconciliationSets(compiled, cache)
+	nextPrevious := make(map[desiredSetKey]previousDesiredSet, len(previous)+len(compiled.Sets))
+	for key, prior := range previous {
+		nextPrevious[key] = prior
+	}
+	allowRemovals := r.config.CleanupOrphans && extracted.Complete
+	if allowRemovals {
+		allowRemovals = r.memberRemovalsAllowed(compiled, cache, previous)
+	} else if r.config.CleanupOrphans && !extracted.Complete {
+		r.logger.Warn("desired-state snapshot is partial; suppressing member removals")
+	}
+	for _, set := range sets {
+		prior := previous[set.Key]
+		actions, managed := r.reconcileDesiredSetWithState(ctx, set, cache, prior.Records, allowRemovals)
 		for _, action := range actions {
 			result.AddAction(action)
-			if action.Provider != "" && action.Type != ActionSkip {
-				currentProviderMapping[hostname.Name] = appendUnique(currentProviderMapping[hostname.Name], action.Provider)
-			}
 		}
-	}
-
-	// Step 5: Orphan cleanup (if enabled)
-	if r.config.CleanupOrphans {
-		orphanActions := r.cleanupOrphans(ctx, discoveredHostnames, cache)
-		for _, action := range orphanActions {
-			result.AddAction(action)
+		if !dryRun {
+			if len(managed) == 0 {
+				delete(nextPrevious, set.Key)
+			} else {
+				nextPrevious[set.Key] = previousDesiredSet{
+					ProviderName: set.Instance.Name(),
+					Records:      managed,
+				}
+			}
 		}
 	}
 
 	// Update known hostnames and provider mapping for next orphan check
 	r.mu.Lock()
-	r.knownHostnames = make(map[string]struct{}, len(discoveredHostnames))
-	for name := range discoveredHostnames {
+	r.knownHostnames = make(map[string]struct{}, len(extracted.Unique))
+	for name := range extracted.Unique {
 		r.knownHostnames[name] = struct{}{}
 	}
-	r.hostnameProviders = currentProviderMapping
+	r.hostnameProviders = compiled.HostnameProviders
 	r.mu.Unlock()
+	if extracted.Complete && !dryRun {
+		r.rememberDesired(nextPrevious)
+	}
 
 	result.Complete()
 
@@ -289,119 +317,6 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*Result, error) {
 	)
 
 	return result, nil
-}
-
-// extractHostnames extracts hostnames from workloads and file sources.
-// Returns a map of normalized hostname -> source.Hostname.
-func (r *Reconciler) extractHostnames(ctx context.Context, workloads []workload.Workload, result *Result) map[string]*source.Hostname {
-	// Track hostname -> first workload that defined it (for duplicate detection)
-	// Use map to source.Hostname to preserve RecordHints from native labels
-	discoveredHostnames := make(map[string]*source.Hostname)
-	hostnameOrigins := make(map[string]string) // hostname -> workload name
-
-	for _, w := range workloads {
-		hostnames := r.sources.ExtractAll(ctx, w)
-
-		// Validate hostnames and log warnings for invalid ones
-		validation := hostnames.ValidateAll()
-		for _, inv := range validation.Invalid {
-			r.logger.Warn("skipping invalid hostname from workload",
-				slog.String("workload", w.Name),
-				slog.String("hostname", inv.Hostname.Name),
-				slog.String("source", inv.Hostname.Source),
-				slog.String("error", inv.Error.Error()),
-			)
-			result.HostnamesInvalid++
-		}
-		hostnames = validation.Valid
-
-		if len(hostnames) > 0 {
-			r.logger.Debug("extracted hostnames from workload",
-				slog.String("workload", w.Name),
-				slog.Int("count", len(hostnames)),
-				slog.Any("hostnames", hostnames.Names()),
-			)
-		}
-
-		for i := range hostnames {
-			hostname := &hostnames[i]
-			// Use normalized (lowercase) name as key for case-insensitive comparison (RFC 1035)
-			normalizedName := hostname.NormalizedName()
-			existingWorkload, exists := hostnameOrigins[normalizedName]
-			if !exists {
-				hostnameOrigins[normalizedName] = w.Name
-				discoveredHostnames[normalizedName] = hostname
-				continue
-			}
-
-			// A hostname collision. Resolve it by explicit precedence rather than
-			// by source-registration order: a candidate carrying per-record hints
-			// (e.g. native dnsweaver labels with proxied=false) wins over one that
-			// carries none (e.g. a Traefik router rule), so the more specific
-			// declaration is never silently dropped. See issue #159.
-			winner := mergeDuplicateHostname(discoveredHostnames[normalizedName], hostname)
-			discoveredHostnames[normalizedName] = winner
-
-			if existingWorkload != w.Name {
-				// Genuine cross-workload collision: two different workloads claim
-				// the same hostname. This usually signals a misconfiguration.
-				r.logger.Warn("duplicate hostname found in multiple workloads",
-					slog.String("hostname", hostname.Name),
-					slog.String("first_workload", existingWorkload),
-					slog.String("duplicate_workload", w.Name),
-					slog.String("selected_source", winner.Source),
-				)
-				result.HostnamesDuplicate++
-			} else {
-				// The same workload declared this hostname via multiple sources
-				// (e.g. a Traefik rule and a native dnsweaver record). This is a
-				// supported pattern, not an error — hint precedence decides which
-				// declaration wins.
-				r.logger.Debug("hostname declared by multiple sources on one workload; applying hint precedence",
-					slog.String("hostname", hostname.Name),
-					slog.String("workload", w.Name),
-					slog.String("selected_source", winner.Source),
-				)
-			}
-		}
-	}
-
-	// Discover hostnames from static config files (Traefik YAML, etc.)
-	fileHostnames := r.sources.DiscoverAll(ctx)
-	if len(fileHostnames) > 0 {
-		// Validate file-discovered hostnames
-		validation := fileHostnames.ValidateAll()
-		for _, inv := range validation.Invalid {
-			r.logger.Warn("skipping invalid hostname from file",
-				slog.String("hostname", inv.Hostname.Name),
-				slog.String("source", inv.Hostname.Source),
-				slog.String("router", inv.Hostname.Router),
-				slog.String("error", inv.Error.Error()),
-			)
-			result.HostnamesInvalid++
-		}
-		fileHostnames = validation.Valid
-
-		r.logger.Debug("discovered hostnames from files",
-			slog.Int("count", len(fileHostnames)),
-			slog.Any("hostnames", fileHostnames.Names()),
-		)
-		for i := range fileHostnames {
-			hostname := &fileHostnames[i]
-			// Use normalized (lowercase) name as key for case-insensitive comparison (RFC 1035)
-			normalizedName := hostname.NormalizedName()
-			if existing, exists := discoveredHostnames[normalizedName]; !exists {
-				discoveredHostnames[normalizedName] = hostname
-			} else {
-				// Apply the same hint precedence as workload extraction so a
-				// file-declared record with explicit hints is not shadowed by a
-				// hint-less label collision (and vice versa). See issue #159.
-				discoveredHostnames[normalizedName] = mergeDuplicateHostname(existing, hostname)
-			}
-		}
-	}
-
-	return discoveredHostnames
 }
 
 // mergeDuplicateHostname resolves a collision between an already-selected
@@ -684,6 +599,7 @@ func (r *Reconciler) recordMetrics(result *Result) {
 	// Record workload and hostname counts
 	metrics.WorkloadsScanned.Set(float64(result.WorkloadsScanned))
 	metrics.HostnamesDiscovered.Set(float64(result.HostnamesDiscovered))
+	metrics.DesiredRecordMembers.Set(float64(result.DesiredMembers))
 
 	// Record per-action metrics
 	for _, action := range result.Actions {

--- a/internal/reconciler/record_sets_test.go
+++ b/internal/reconciler/record_sets_test.go
@@ -189,6 +189,71 @@ func TestReconcile_ProviderRouteChangesAreExactLiveAndAfterRestart(t *testing.T)
 	}
 }
 
+func TestReconcile_MultiMemberProviderRouteChangeBypassesRemovalCircuitBreaker(t *testing.T) {
+	internal := newTestMockProvider("internal")
+	external := newTestMockProvider("external")
+	internalIdentity := provider.ProviderIdentity{Type: "mock", Endpoint: "internal", Zone: "example.com"}
+	externalIdentity := provider.ProviderIdentity{Type: "mock", Endpoint: "external", Zone: "example.com"}
+	internal.identity = &internalIdentity
+	external.identity = &externalIdentity
+
+	providers := testProviderRegistry(quietLogger(), internal, external)
+	providers.SetInstanceID("test-instance")
+	for _, name := range []string{"internal", "external"} {
+		if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+			Name: name, TypeName: "mock", RecordType: provider.RecordTypeA,
+			Target: "192.0.2.1", TTL: 300, Mode: provider.ModeManaged, Domains: []string{"*.example.com"},
+		}); err != nil {
+			t.Fatalf("CreateInstance(%s) error = %v", name, err)
+		}
+	}
+
+	claims := source.Hostnames{
+		*hintedA("app.example.com", "192.0.2.10"),
+		*hintedA("app.example.com", "192.0.2.11"),
+		*hintedA("app.example.com", "192.0.2.12"),
+	}
+	for i := range claims {
+		claims[i].RecordHints.Provider = "internal"
+	}
+	sourceMock := newTestMockSource("native", claims...)
+	sources := testSourceRegistry(quietLogger(), sourceMock)
+	lister := newTestMockWorkloadLister(workload.PlatformDocker)
+	lister.workloads = []workload.Workload{{ID: "app", Name: "app", Platform: workload.PlatformDocker}}
+	cfg := DefaultConfig()
+	cfg.InstanceID = "test-instance"
+	r := New([]workload.Lister{lister}, sources, providers, WithConfig(cfg), WithLogger(quietLogger()))
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("initial Reconcile() error = %v", err)
+	}
+
+	for i := range claims {
+		claims[i].RecordHints.Provider = "external"
+	}
+	sourceMock.hostnames = claims
+	restarted := New([]workload.Lister{lister}, sources, providers, WithConfig(cfg), WithLogger(quietLogger()))
+	result, err := restarted.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("route Reconcile() error = %v", err)
+	}
+	if got := result.Created(); len(got) != 3 {
+		t.Fatalf("route creates = %+v, want all three external members", got)
+	}
+	if got := result.Deleted(); len(got) != 3 {
+		t.Fatalf("route deletes = %+v, want all three internal members", got)
+	}
+	for _, action := range result.Created() {
+		if action.Provider != "external" {
+			t.Fatalf("created on provider %q, want external", action.Provider)
+		}
+	}
+	for _, action := range result.Deleted() {
+		if action.Provider != "internal" {
+			t.Fatalf("deleted from provider %q, want internal", action.Provider)
+		}
+	}
+}
+
 func TestReconcile_ProxmoxDualStackReachesProvider(t *testing.T) {
 	sourceMock := newTestMockSource("proxmox",
 		source.Hostname{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},

--- a/internal/reconciler/record_sets_test.go
+++ b/internal/reconciler/record_sets_test.go
@@ -1,0 +1,341 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+	"github.com/maxfield-allison/dnsweaver/pkg/workload"
+)
+
+func liveSetHarness(t *testing.T, caps provider.Capabilities, sourceMock *testMockSource, workloads []workload.Workload) (*Reconciler, *testMockProvider, *provider.Registry) {
+	t.Helper()
+	mock := newTestMockProvider("dns")
+	mock.capabilities = &caps
+	providers := testProviderRegistry(quietLogger(), mock)
+	providers.SetInstanceID("test-instance")
+	if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+		Name: "dns", TypeName: "mock", RecordType: provider.RecordTypeA,
+		Target: "192.0.2.1", TTL: 300, Mode: provider.ModeManaged, Domains: []string{"*.example.com"},
+	}); err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	sources := testSourceRegistry(quietLogger(), sourceMock)
+	lister := newTestMockWorkloadLister(workload.PlatformDocker)
+	lister.workloads = workloads
+	cfg := DefaultConfig()
+	cfg.InstanceID = "test-instance"
+	return New([]workload.Lister{lister}, sources, providers, WithConfig(cfg), WithLogger(quietLogger())), mock, providers
+}
+
+func TestReconcile_RecordSetLifecycleSurvivesRestart(t *testing.T) {
+	sourceMock := newTestMockSource("native",
+		*hintedA("app.example.com", "192.0.2.10"),
+		*hintedA("app.example.com", "192.0.2.11"),
+	)
+	workloads := []workload.Workload{{ID: "one", Name: "one", Platform: workload.PlatformDocker}}
+	r, mock, providers := liveSetHarness(t, setTestCapabilities(true, false), sourceMock, workloads)
+
+	first, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if first.DesiredMembers != 2 || len(first.Created()) != 2 {
+		t.Fatalf("first result = %+v, want two desired creates", first)
+	}
+
+	sourceMock.hostnames = source.Hostnames{*hintedA("app.example.com", "192.0.2.10")}
+	second, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if len(second.Deleted()) != 1 || second.Deleted()[0].Target != "192.0.2.11" {
+		t.Fatalf("second actions = %+v, want only .11 deleted", second.Actions)
+	}
+
+	// A new reconciler has no previousDesired memory. The surviving member's
+	// durable marker must still make final removal safe after restart.
+	sourceMock.hostnames = nil
+	cfg := DefaultConfig()
+	cfg.InstanceID = "test-instance"
+	restarted := New(r.listers, r.sources, providers, WithConfig(cfg), WithLogger(quietLogger()))
+	third, err := restarted.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("restart Reconcile() error = %v", err)
+	}
+	if len(third.Deleted()) != 1 || third.Deleted()[0].Target != "192.0.2.10" {
+		t.Fatalf("restart actions = %+v, want final member deleted", third.Actions)
+	}
+	if remaining := mock.GetCreatedDNSRecords(); len(remaining) != 2 {
+		// GetCreated is an audit log, not current state. Keep this assertion here
+		// only to make sure both creates occurred during the lifecycle.
+		t.Fatalf("created audit = %+v", remaining)
+	}
+}
+
+func TestReconcile_RepeatedIdenticalClaimsCreateOneMember(t *testing.T) {
+	sourceMock := newTestMockSource("traefik", source.Hostname{Name: "app.example.com", Source: "traefik"})
+	workloads := []workload.Workload{
+		{ID: "one", Name: "one", Platform: workload.PlatformDocker},
+		{ID: "two", Name: "two", Platform: workload.PlatformDocker},
+	}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(true, false), sourceMock, workloads)
+	result, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.HostnamesDiscovered != 1 || result.DesiredMembers != 1 || len(mock.GetCreatedDNSRecords()) != 1 {
+		t.Fatalf("result hostnames=%d members=%d created=%+v", result.HostnamesDiscovered, result.DesiredMembers, mock.GetCreatedDNSRecords())
+	}
+}
+
+func TestReconcile_RemovingOneOfSeveralIdenticalClaimantsKeepsMember(t *testing.T) {
+	sourceMock := newTestMockSource("traefik", source.Hostname{Name: "app.example.com", Source: "traefik"})
+	workloads := []workload.Workload{
+		{ID: "one", Name: "one", Platform: workload.PlatformDocker},
+		{ID: "two", Name: "two", Platform: workload.PlatformDocker},
+	}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(true, false), sourceMock, workloads)
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+
+	lister := r.listers[0].(*testMockWorkloadLister)
+	lister.workloads = workloads[:1]
+	second, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if len(second.Deleted()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("removing one claimant deleted shared member: actions=%+v deleted=%+v", second.Actions, mock.GetDeleted())
+	}
+
+	lister.workloads = nil
+	third, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("third Reconcile() error = %v", err)
+	}
+	if len(third.Deleted()) != 1 || third.Deleted()[0].Target != "192.0.2.1" {
+		t.Fatalf("last claimant removal actions = %+v, want one member delete", third.Actions)
+	}
+}
+
+func TestReconcile_ProviderRouteChangesAreExactLiveAndAfterRestart(t *testing.T) {
+	internal := newTestMockProvider("internal")
+	external := newTestMockProvider("external")
+	internalIdentity := provider.ProviderIdentity{Type: "mock", Endpoint: "internal", Zone: "example.com"}
+	externalIdentity := provider.ProviderIdentity{Type: "mock", Endpoint: "external", Zone: "example.com"}
+	internal.identity = &internalIdentity
+	external.identity = &externalIdentity
+	external.AddRecord(provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.99", TTL: 300})
+
+	providers := testProviderRegistry(quietLogger(), internal, external)
+	providers.SetInstanceID("test-instance")
+	for _, name := range []string{"internal", "external"} {
+		if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+			Name: name, TypeName: "mock", RecordType: provider.RecordTypeA,
+			Target: "192.0.2.1", TTL: 300, Mode: provider.ModeManaged, Domains: []string{"*.example.com"},
+		}); err != nil {
+			t.Fatalf("CreateInstance(%s) error = %v", name, err)
+		}
+	}
+
+	claim := hintedA("app.example.com", "192.0.2.10")
+	claim.RecordHints.Provider = "internal"
+	sourceMock := newTestMockSource("native", *claim)
+	sources := testSourceRegistry(quietLogger(), sourceMock)
+	lister := newTestMockWorkloadLister(workload.PlatformDocker)
+	lister.workloads = []workload.Workload{{ID: "app", Name: "app", Platform: workload.PlatformDocker}}
+	cfg := DefaultConfig()
+	cfg.InstanceID = "test-instance"
+	r := New([]workload.Lister{lister}, sources, providers, WithConfig(cfg), WithLogger(quietLogger()))
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("initial Reconcile() error = %v", err)
+	}
+
+	// Switch routes while constructing a fresh reconciler. The old internal
+	// route must be recovered from its durable member marker.
+	claim.RecordHints.Provider = "external"
+	sourceMock.hostnames = source.Hostnames{*claim}
+	restarted := New([]workload.Lister{lister}, sources, providers, WithConfig(cfg), WithLogger(quietLogger()))
+	afterRestart, err := restarted.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("restart Reconcile() error = %v", err)
+	}
+	if got := afterRestart.Deleted(); len(got) != 1 || got[0].Provider != "internal" || got[0].Target != "192.0.2.10" {
+		t.Fatalf("restart route cleanup = %+v, want exact internal member", got)
+	}
+	if got := afterRestart.Created(); len(got) != 1 || got[0].Provider != "external" || got[0].Target != "192.0.2.10" {
+		t.Fatalf("restart route creation = %+v, want exact external member", got)
+	}
+
+	// A live switch back exercises the in-memory route history. The unrelated
+	// external sibling must remain untouched.
+	claim.RecordHints.Provider = "internal"
+	sourceMock.hostnames = source.Hostnames{*claim}
+	afterLiveSwitch, err := restarted.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("live route Reconcile() error = %v", err)
+	}
+	if got := afterLiveSwitch.Deleted(); len(got) != 1 || got[0].Provider != "external" || got[0].Target != "192.0.2.10" {
+		t.Fatalf("live route cleanup = %+v, want exact external member", got)
+	}
+	for _, deleted := range external.GetDeleted() {
+		if deleted.Type == provider.RecordTypeA && deleted.Target == "192.0.2.99" {
+			t.Fatalf("route switch deleted unrelated external sibling: %+v", deleted)
+		}
+	}
+}
+
+func TestReconcile_ProxmoxDualStackReachesProvider(t *testing.T) {
+	sourceMock := newTestMockSource("proxmox",
+		source.Hostname{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "A", Target: "192.0.2.10"}},
+		source.Hostname{Name: "vm.example.com", Source: "proxmox", RecordHints: &source.RecordHints{Type: "AAAA", Target: "2001:db8::10"}},
+	)
+	workloads := []workload.Workload{{ID: "vm", Name: "vm", Platform: workload.PlatformProxmox}}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(true, false), sourceMock, workloads)
+	result, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	created := mock.GetCreatedDNSRecords()
+	if result.HostnamesDiscovered != 1 || result.DesiredMembers != 2 || len(created) != 2 {
+		t.Fatalf("result hostnames=%d members=%d created=%+v", result.HostnamesDiscovered, result.DesiredMembers, created)
+	}
+	if created[0].Type != provider.RecordTypeA || created[1].Type != provider.RecordTypeAAAA {
+		t.Fatalf("created = %+v, want A and AAAA", created)
+	}
+}
+
+func TestReconcile_PartialSourceSnapshotSuppressesRemoval(t *testing.T) {
+	sourceMock := newTestMockSource("native", *hintedA("app.example.com", "192.0.2.10"))
+	workloads := []workload.Workload{{ID: "one", Name: "one", Platform: workload.PlatformDocker}}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(false, false), sourceMock, workloads)
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+
+	sourceMock.hostnames = nil
+	sourceMock.err = errors.New("source unavailable")
+	result, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("partial Reconcile() error = %v", err)
+	}
+	if len(result.Deleted()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("partial snapshot deleted records: actions=%+v deleted=%+v", result.Actions, mock.GetDeleted())
+	}
+}
+
+func TestReconcile_NoTXTProviderFailsSafeAfterRestart(t *testing.T) {
+	sourceMock := newTestMockSource("native")
+	workloads := []workload.Workload{{ID: "one", Name: "one", Platform: workload.PlatformDocker}}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(false, false), sourceMock, workloads)
+	mock.AddRecord(provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300})
+	result, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if len(result.Deleted()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("restart without ownership deleted records: %+v", result.Actions)
+	}
+}
+
+func TestReconcile_NoTXTProviderDoesNotClaimMatchingManualMember(t *testing.T) {
+	sourceMock := newTestMockSource("native", *hintedA("app.example.com", "192.0.2.10"))
+	workloads := []workload.Workload{{ID: "one", Name: "one", Platform: workload.PlatformDocker}}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(false, false), sourceMock, workloads)
+	mock.AddRecord(provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300})
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+
+	sourceMock.hostnames = nil
+	result, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if len(result.Deleted()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("matching manual member was treated as owned: actions=%+v deleted=%+v", result.Actions, mock.GetDeleted())
+	}
+}
+
+func TestReconcile_DryRunDoesNotClaimNoTXTMember(t *testing.T) {
+	sourceMock := newTestMockSource("native", *hintedA("app.example.com", "192.0.2.10"))
+	workloads := []workload.Workload{{ID: "one", Name: "one", Platform: workload.PlatformDocker}}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(false, false), sourceMock, workloads)
+	r.SetDryRun(true)
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("dry-run Reconcile() error = %v", err)
+	}
+
+	// Simulate an operator creating the same member after the dry run. The dry
+	// run must not have recorded authority to delete it.
+	mock.AddRecord(provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300})
+	sourceMock.hostnames = nil
+	r.SetDryRun(false)
+	result, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("real Reconcile() error = %v", err)
+	}
+	if len(result.Deleted()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("dry-run state authorized a real deletion: actions=%+v deleted=%+v", result.Actions, mock.GetDeleted())
+	}
+}
+
+func TestReconcile_NoTXTRetriesOldMemberAfterReplacementFailure(t *testing.T) {
+	sourceMock := newTestMockSource("native", *hintedA("app.example.com", "192.0.2.99"))
+	workloads := []workload.Workload{{ID: "one", Name: "one", Platform: workload.PlatformDocker}}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(false, false), sourceMock, workloads)
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("initial Reconcile() error = %v", err)
+	}
+
+	sourceMock.hostnames = source.Hostnames{*hintedA("app.example.com", "192.0.2.10")}
+	mock.createFn = func(_ context.Context, record provider.Record) error {
+		if record.Type == provider.RecordTypeA && record.Target == "192.0.2.10" {
+			return errors.New("temporary create failure")
+		}
+		return nil
+	}
+	failed, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("failed replacement Reconcile() error = %v", err)
+	}
+	if len(failed.Failed()) != 1 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("failed replacement did not preserve old member: actions=%+v deleted=%+v", failed.Actions, mock.GetDeleted())
+	}
+
+	mock.createFn = nil
+	retried, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("retry Reconcile() error = %v", err)
+	}
+	if got := retried.Deleted(); len(got) != 1 || got[0].Target != "192.0.2.99" {
+		t.Fatalf("retry actions = %+v, want old member deletion after replacement succeeds", retried.Actions)
+	}
+}
+
+func TestReconcile_MemberCircuitBreakerSuppressesMassRemoval(t *testing.T) {
+	sourceMock := newTestMockSource("native",
+		*hintedA("app.example.com", "192.0.2.10"),
+		*hintedA("app.example.com", "192.0.2.11"),
+		*hintedA("app.example.com", "192.0.2.12"),
+		*hintedA("app.example.com", "192.0.2.13"),
+	)
+	workloads := []workload.Workload{{ID: "one", Name: "one", Platform: workload.PlatformDocker}}
+	r, mock, _ := liveSetHarness(t, setTestCapabilities(true, false), sourceMock, workloads)
+	if _, err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("initial Reconcile() error = %v", err)
+	}
+
+	sourceMock.hostnames = source.Hostnames{*hintedA("app.example.com", "192.0.2.10")}
+	result, err := r.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if len(result.Deleted()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("mass-removal breaker allowed member deletion: actions=%+v deleted=%+v", result.Actions, mock.GetDeleted())
+	}
+}

--- a/internal/reconciler/record_state_test.go
+++ b/internal/reconciler/record_state_test.go
@@ -135,6 +135,17 @@ func ownershipTXT(hostname string) provider.Record {
 	return provider.OwnershipRecord(hostname, 300, "", nil)
 }
 
+// memberOwnershipTXT builds a versioned ownership record for one A member.
+func memberOwnershipTXT(hostname, target string) provider.Record {
+	record := provider.Record{
+		Hostname: hostname,
+		Type:     provider.RecordTypeA,
+		Target:   target,
+		TTL:      300,
+	}
+	return provider.MemberOwnershipRecord(hostname, 300, "", record, nil)
+}
+
 // newStateTestRegistry wires prov as the only instance of a registry:
 // A records pointing at stateTestTarget for *.example.com, TTL 300.
 func newStateTestRegistry(t *testing.T, prov provider.Provider) *provider.Registry {

--- a/internal/reconciler/result.go
+++ b/internal/reconciler/result.go
@@ -93,6 +93,10 @@ type Result struct {
 	// HostnamesDiscovered is the number of unique valid hostnames found in labels.
 	HostnamesDiscovered int
 
+	// DesiredMembers is the number of distinct provider-routed DNS members in
+	// the compiled desired state.
+	DesiredMembers int
+
 	// HostnamesInvalid is the number of hostnames that failed validation.
 	HostnamesInvalid int
 
@@ -219,6 +223,7 @@ func (r *Result) Summary() string {
 	fmt.Fprintf(&sb, "Reconciliation complete (%s) in %s\n", mode, r.Duration().Round(time.Millisecond))
 	fmt.Fprintf(&sb, "  Workloads scanned: %d\n", r.WorkloadsScanned)
 	fmt.Fprintf(&sb, "  Hostnames discovered: %d\n", r.HostnamesDiscovered)
+	fmt.Fprintf(&sb, "  Desired record members: %d\n", r.DesiredMembers)
 	fmt.Fprintf(&sb, "  Records created: %d\n", r.CreatedCount())
 	fmt.Fprintf(&sb, "  Records updated: %d\n", r.UpdatedCount())
 	fmt.Fprintf(&sb, "  Records deleted: %d\n", r.DeletedCount())

--- a/internal/reconciler/sets.go
+++ b/internal/reconciler/sets.go
@@ -50,6 +50,22 @@ func (r *Reconciler) reconcileDesiredSetWithState(ctx context.Context, set *desi
 	}
 
 	actions := make([]Action, 0, len(set.Members)+len(sameType)+len(conflicting))
+	// CNAME is single-valued in practice. Reject ambiguous or self-referential
+	// desired state before deleting any conflicting records at the name.
+	if set.Key.RecordType == provider.RecordTypeCNAME {
+		if len(set.Members) > 1 || len(sameType) > 1 {
+			for _, member := range set.Members {
+				actions = append(actions, memberAction(ActionSkip, StatusSkipped, instance, member.Record, errMultipleCNAMEMembers))
+			}
+			return actions, managed
+		}
+		if len(set.Members) == 1 && isSelfReferential(set.Members[0].Record.Hostname, set.Members[0].Record.Target, provider.RecordTypeCNAME) {
+			member := set.Members[0]
+			r.warnSelfReferentialOnce(member.Record.Hostname, instance.Name(), member.Record.Target)
+			return append(actions, memberAction(ActionSkip, StatusSkipped, instance, member.Record, errSelfReferentialCNAME)), managed
+		}
+	}
+
 	if len(conflicting) > 0 {
 		adopt := setAllowsAdoption(r, set)
 		for _, record := range conflicting {
@@ -77,16 +93,9 @@ func (r *Reconciler) reconcileDesiredSetWithState(ctx context.Context, set *desi
 	legacyUpgradeComplete := hasLegacyOwnership && instance.Provider.Capabilities().SupportsOwnershipTXT
 	desiredWritesSucceeded := true
 
-	// CNAME is single-valued in practice. A target change must update the one
-	// exact existing CNAME instead of trying to create a second member first.
-	// Multiple desired or existing CNAMEs are ambiguous and are left alone.
+	// A CNAME target change must update the one exact existing CNAME instead of
+	// trying to create a second member first. Ambiguity was rejected above.
 	if set.Key.RecordType == provider.RecordTypeCNAME {
-		if len(set.Members) > 1 || len(sameType) > 1 {
-			for _, member := range set.Members {
-				actions = append(actions, memberAction(ActionSkip, StatusSkipped, instance, member.Record, errMultipleCNAMEMembers))
-			}
-			return actions, managed
-		}
 		if len(set.Members) == 1 && len(sameType) == 1 && !provider.SameRecordMember(sameType[0], set.Members[0].Record) {
 			return r.updateSingleValueMember(ctx, set, sameType[0], cache, previous, actions, managed, hasLegacyOwnership)
 		}

--- a/internal/reconciler/sets.go
+++ b/internal/reconciler/sets.go
@@ -1,0 +1,413 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+func (r *Reconciler) reconcileDesiredSet(ctx context.Context, set *desiredRecordSet, cache *recordCache, previous []provider.Record) []Action {
+	actions, _ := r.reconcileDesiredSetWithState(ctx, set, cache, previous, true)
+	return actions
+}
+
+// reconcileDesiredSetWithState also returns the members this process can
+// still prove it manages. That state is the fallback for providers that
+// cannot persist ownership TXT records; it must describe successful writes
+// and adopted records, not merely whatever appeared in desired state.
+func (r *Reconciler) reconcileDesiredSetWithState(ctx context.Context, set *desiredRecordSet, cache *recordCache, previous []provider.Record, allowRemovals bool) ([]Action, []provider.Record) {
+	instance := set.Instance
+	managed := append([]provider.Record(nil), previous...)
+	if !instance.Provider.Capabilities().SupportsRecordType(set.Key.RecordType) {
+		actions := make([]Action, 0, len(set.Members))
+		for _, member := range set.Members {
+			actions = append(actions, memberAction(ActionSkip, StatusSkipped, instance, member.Record,
+				fmt.Sprintf("record type %s is not supported by provider", member.Record.Type)))
+		}
+		return actions, managed
+	}
+	if cache == nil || !cache.providerAvailable(instance.Name()) {
+		actions := make([]Action, 0, len(set.Members))
+		for _, member := range set.Members {
+			actions = append(actions, memberAction(ActionCreate, StatusFailed, instance, member.Record,
+				"provider record snapshot unavailable"))
+		}
+		return actions, managed
+	}
+
+	existingRecords, _ := cache.getExistingRecords(instance.Name(), set.Key.Hostname)
+	var sameType, conflicting []provider.Record
+	for _, existing := range existingRecords {
+		switch {
+		case existing.Type == set.Key.RecordType:
+			sameType = append(sameType, existing)
+		case typesConflict(set.Key.RecordType, existing.Type):
+			conflicting = append(conflicting, existing)
+		}
+	}
+
+	actions := make([]Action, 0, len(set.Members)+len(sameType)+len(conflicting))
+	if len(conflicting) > 0 {
+		adopt := setAllowsAdoption(r, set)
+		for _, record := range conflicting {
+			if !allowRemovals || !r.mayDeleteMember(instance, record, cache, previous, adopt) {
+				for _, member := range set.Members {
+					actions = append(actions, memberAction(ActionSkip, StatusSkipped, instance, member.Record, errRecordTypeConflict))
+				}
+				return actions, managed
+			}
+		}
+		for _, record := range conflicting {
+			action, ok := r.deleteSetMember(ctx, instance, record, cache)
+			actions = append(actions, action)
+			if !ok {
+				return actions, managed
+			}
+			if !r.isDryRun() {
+				managed = forgetRecordMember(managed, record)
+			}
+		}
+	}
+
+	matchedExisting := make([]bool, len(sameType))
+	_, hasLegacyOwnership := cache.legacyOwnershipRecord(instance.Name(), set.Key.Hostname, instance.InstanceID)
+	legacyUpgradeComplete := hasLegacyOwnership && instance.Provider.Capabilities().SupportsOwnershipTXT
+	desiredWritesSucceeded := true
+
+	// CNAME is single-valued in practice. A target change must update the one
+	// exact existing CNAME instead of trying to create a second member first.
+	// Multiple desired or existing CNAMEs are ambiguous and are left alone.
+	if set.Key.RecordType == provider.RecordTypeCNAME {
+		if len(set.Members) > 1 || len(sameType) > 1 {
+			for _, member := range set.Members {
+				actions = append(actions, memberAction(ActionSkip, StatusSkipped, instance, member.Record, errMultipleCNAMEMembers))
+			}
+			return actions, managed
+		}
+		if len(set.Members) == 1 && len(sameType) == 1 && !provider.SameRecordMember(sameType[0], set.Members[0].Record) {
+			return r.updateSingleValueMember(ctx, set, sameType[0], cache, previous, actions, managed, hasLegacyOwnership)
+		}
+	}
+
+	for _, desiredMember := range set.Members {
+		record := desiredMember.Record
+		existingIndex := -1
+		for i := range sameType {
+			if !matchedExisting[i] && provider.SameRecordMember(sameType[i], record) {
+				existingIndex = i
+				break
+			}
+		}
+
+		if existingIndex < 0 {
+			action := memberAction(ActionCreate, StatusSuccess, instance, record, "")
+			if r.isDryRun() {
+				actions = append(actions, action)
+				continue
+			}
+			if err := instance.CreateRecordWithValues(ctx, record.Hostname, record.Type, record.Target, record.TTL, record.SRV, record.Metadata); err != nil {
+				action.Status = StatusFailed
+				action.Error = err.Error()
+				legacyUpgradeComplete = false
+				desiredWritesSucceeded = false
+			} else {
+				managed = rememberRecordMember(managed, record)
+				if err := r.ensureMemberOwnership(ctx, instance, record, cache); err != nil {
+					r.logger.Warn("failed to create member ownership record",
+						slog.String("provider", instance.Name()),
+						slog.String("hostname", record.Hostname),
+						slog.String("target", record.Target),
+						slog.String("error", err.Error()),
+					)
+					legacyUpgradeComplete = false
+					desiredWritesSucceeded = false
+				}
+			}
+			actions = append(actions, action)
+			continue
+		}
+
+		matchedExisting[existingIndex] = true
+		existing := sameType[existingIndex]
+		_, hasMemberOwnership := cache.memberOwnershipRecord(instance.Name(), record, instance.InstanceID)
+		adopt := r.effectiveAdoptExisting(desiredMember.Claim, instance)
+		mayManage := !r.config.OwnershipTracking || !instance.Mode.RequiresOwnership() ||
+			hasMemberOwnership || adopt || hasLegacyOwnership
+		if mayManage && !r.isDryRun() {
+			managed = rememberRecordMember(managed, existing)
+		}
+
+		if instance.RecordNeedsUpdate(existing, record) {
+			canUpdate := mayManage
+			if instance.Mode == provider.ModeAdditive && !instance.Provider.Capabilities().SupportsNativeUpdate {
+				canUpdate = false
+			}
+			if !canUpdate {
+				actions = append(actions, memberAction(ActionSkip, StatusSkipped, instance, record, errRecordAlreadyExists))
+				legacyUpgradeComplete = false
+				continue
+			}
+
+			action := memberAction(ActionUpdate, StatusSuccess, instance, record, "")
+			if !r.isDryRun() {
+				if err := instance.UpdateRecord(ctx, existing, record); err != nil {
+					action.Status = StatusFailed
+					action.Error = err.Error()
+					legacyUpgradeComplete = false
+					desiredWritesSucceeded = false
+				} else if err := r.ensureMemberOwnership(ctx, instance, record, cache); err != nil {
+					legacyUpgradeComplete = false
+					desiredWritesSucceeded = false
+					r.logger.Warn("failed to create member ownership record",
+						slog.String("provider", instance.Name()),
+						slog.String("hostname", record.Hostname),
+						slog.String("target", record.Target),
+						slog.String("error", err.Error()),
+					)
+				} else {
+					managed = rememberRecordMember(managed, record)
+				}
+			}
+			actions = append(actions, action)
+			continue
+		}
+
+		actions = append(actions, memberAction(ActionSkip, StatusSkipped, instance, record, errRecordAlreadyExists))
+		if mayManage && !r.isDryRun() {
+			if err := r.ensureMemberOwnership(ctx, instance, record, cache); err != nil {
+				legacyUpgradeComplete = false
+				r.logger.Warn("failed to create member ownership record",
+					slog.String("provider", instance.Name()),
+					slog.String("hostname", record.Hostname),
+					slog.String("target", record.Target),
+					slog.String("error", err.Error()),
+				)
+			}
+		} else if hasLegacyOwnership {
+			legacyUpgradeComplete = false
+		}
+	}
+
+	if allowRemovals && desiredWritesSucceeded && instance.Mode.AllowsDelete() {
+		for i, existing := range sameType {
+			if matchedExisting[i] || !r.mayDeleteMember(instance, existing, cache, previous, false) {
+				continue
+			}
+			action, _ := r.deleteSetMember(ctx, instance, existing, cache)
+			actions = append(actions, action)
+			if action.Status == StatusSuccess && !r.isDryRun() {
+				managed = forgetRecordMember(managed, existing)
+			}
+		}
+	}
+
+	if legacyUpgradeComplete && !r.isDryRun() {
+		legacy, found := cache.legacyOwnershipRecord(instance.Name(), set.Key.Hostname, instance.InstanceID)
+		if found {
+			if err := instance.DeleteMember(ctx, legacy); err != nil {
+				r.logger.Warn("failed to remove upgraded legacy ownership record",
+					slog.String("provider", instance.Name()),
+					slog.String("hostname", set.Key.Hostname),
+					slog.String("error", err.Error()),
+				)
+			}
+		}
+	}
+
+	return actions, managed
+}
+
+func rememberRecordMember(records []provider.Record, record provider.Record) []provider.Record {
+	for _, existing := range records {
+		if provider.SameRecordMember(existing, record) {
+			return records
+		}
+	}
+	return append(records, record)
+}
+
+func forgetRecordMember(records []provider.Record, record provider.Record) []provider.Record {
+	kept := records[:0]
+	for _, existing := range records {
+		if !provider.SameRecordMember(existing, record) {
+			kept = append(kept, existing)
+		}
+	}
+	return kept
+}
+
+func (r *Reconciler) mayDeleteMember(instance *provider.ProviderInstance, record provider.Record, cache *recordCache, previous []provider.Record, adopt bool) bool {
+	if !instance.Mode.AllowsDelete() {
+		return false
+	}
+	if !instance.Mode.RequiresOwnership() || !r.config.OwnershipTracking || adopt {
+		return true
+	}
+	if _, owned := cache.memberOwnershipRecord(instance.Name(), record, instance.InstanceID); owned {
+		return true
+	}
+	if instance.Provider.Capabilities().SupportsOwnershipTXT {
+		return false
+	}
+	for _, prior := range previous {
+		if provider.SameRecordMember(prior, record) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Reconciler) deleteSetMember(ctx context.Context, instance *provider.ProviderInstance, record provider.Record, cache *recordCache) (Action, bool) {
+	action := memberAction(ActionDelete, StatusSuccess, instance, record, "")
+	if r.isDryRun() {
+		return action, true
+	}
+	if err := instance.DeleteMember(ctx, record); err != nil && !errors.Is(err, provider.ErrNotFound) {
+		action.Status = StatusFailed
+		action.Error = err.Error()
+		return action, false
+	}
+	if marker, owned := cache.memberOwnershipRecord(instance.Name(), record, instance.InstanceID); owned {
+		if err := instance.DeleteMember(ctx, marker); err != nil && !errors.Is(err, provider.ErrNotFound) {
+			r.logger.Warn("failed to delete member ownership record",
+				slog.String("provider", instance.Name()),
+				slog.String("hostname", record.Hostname),
+				slog.String("target", record.Target),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+	return action, true
+}
+
+func (r *Reconciler) ensureMemberOwnership(ctx context.Context, instance *provider.ProviderInstance, record provider.Record, cache *recordCache) error {
+	if !r.config.OwnershipTracking || !instance.Provider.Capabilities().SupportsOwnershipTXT {
+		return nil
+	}
+	desired := provider.MemberOwnershipRecord(record.Hostname, instance.TTL, instance.InstanceID, record, record.Metadata)
+	existing, found := cache.memberOwnershipRecord(instance.Name(), record, instance.InstanceID)
+	if found && existing.Target == desired.Target {
+		return nil
+	}
+	if err := instance.CreateMemberOwnershipRecord(ctx, record, record.Metadata); err != nil {
+		return err
+	}
+	if found {
+		if err := instance.DeleteMember(ctx, existing); err != nil && !errors.Is(err, provider.ErrNotFound) {
+			return fmt.Errorf("deleting stale member ownership marker: %w", err)
+		}
+	}
+	return nil
+}
+
+func memberAction(actionType ActionType, status ActionStatus, instance *provider.ProviderInstance, record provider.Record, actionError string) Action {
+	return Action{
+		Type:       actionType,
+		Status:     status,
+		Provider:   instance.Name(),
+		Hostname:   record.Hostname,
+		RecordType: string(record.Type),
+		Target:     record.Target,
+		Error:      actionError,
+	}
+}
+
+func setAllowsAdoption(r *Reconciler, set *desiredRecordSet) bool {
+	for _, member := range set.Members {
+		if r.effectiveAdoptExisting(member.Claim, set.Instance) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Reconciler) updateSingleValueMember(
+	ctx context.Context,
+	set *desiredRecordSet,
+	existing provider.Record,
+	cache *recordCache,
+	previous []provider.Record,
+	actions []Action,
+	managed []provider.Record,
+	hasLegacyOwnership bool,
+) ([]Action, []provider.Record) {
+	instance := set.Instance
+	desiredMember := set.Members[0]
+	desired := desiredMember.Record
+	_, hasMemberOwnership := cache.memberOwnershipRecord(instance.Name(), existing, instance.InstanceID)
+	managedInMemory := recordMemberPresent(previous, existing)
+	adopt := r.effectiveAdoptExisting(desiredMember.Claim, instance)
+	mayManage := !r.config.OwnershipTracking || !instance.Mode.RequiresOwnership() ||
+		hasMemberOwnership || adopt || hasLegacyOwnership ||
+		(!instance.Provider.Capabilities().SupportsOwnershipTXT && managedInMemory)
+	if !mayManage || (instance.Mode == provider.ModeAdditive && !instance.Provider.Capabilities().SupportsNativeUpdate) {
+		return append(actions, memberAction(ActionSkip, StatusSkipped, instance, desired, errRecordAlreadyExists)), managed
+	}
+
+	action := memberAction(ActionUpdate, StatusSuccess, instance, desired, "")
+	if r.isDryRun() {
+		return append(actions, action), managed
+	}
+
+	var newMarker provider.Record
+	markerCreated := false
+	if r.config.OwnershipTracking && instance.Provider.Capabilities().SupportsOwnershipTXT {
+		if _, exists := cache.memberOwnershipRecord(instance.Name(), desired, instance.InstanceID); !exists {
+			newMarker = provider.MemberOwnershipRecord(desired.Hostname, instance.TTL, instance.InstanceID, desired, desired.Metadata)
+			if err := instance.CreateMemberOwnershipRecord(ctx, desired, desired.Metadata); err != nil {
+				action.Status = StatusFailed
+				action.Error = fmt.Sprintf("creating replacement ownership marker: %v", err)
+				return append(actions, action), managed
+			}
+			markerCreated = true
+		}
+	}
+
+	if err := instance.UpdateRecord(ctx, existing, desired); err != nil {
+		action.Status = StatusFailed
+		action.Error = err.Error()
+		if markerCreated {
+			if cleanupErr := instance.DeleteMember(ctx, newMarker); cleanupErr != nil && !errors.Is(cleanupErr, provider.ErrNotFound) {
+				r.logger.Warn("failed to roll back replacement ownership marker",
+					slog.String("provider", instance.Name()),
+					slog.String("hostname", desired.Hostname),
+					slog.String("error", cleanupErr.Error()),
+				)
+			}
+		}
+		return append(actions, action), managed
+	}
+
+	managed = forgetRecordMember(managed, existing)
+	managed = rememberRecordMember(managed, desired)
+	if oldMarker, exists := cache.memberOwnershipRecord(instance.Name(), existing, instance.InstanceID); exists {
+		if err := instance.DeleteMember(ctx, oldMarker); err != nil && !errors.Is(err, provider.ErrNotFound) {
+			r.logger.Warn("failed to remove replaced member ownership record",
+				slog.String("provider", instance.Name()),
+				slog.String("hostname", desired.Hostname),
+				slog.String("error", err.Error()),
+			)
+		}
+	} else if legacy, exists := cache.legacyOwnershipRecord(instance.Name(), existing.Hostname, instance.InstanceID); exists {
+		if err := instance.DeleteMember(ctx, legacy); err != nil && !errors.Is(err, provider.ErrNotFound) {
+			r.logger.Warn("failed to remove upgraded legacy ownership record",
+				slog.String("provider", instance.Name()),
+				slog.String("hostname", desired.Hostname),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+	return append(actions, action), managed
+}
+
+func recordMemberPresent(records []provider.Record, record provider.Record) bool {
+	for _, existing := range records {
+		if provider.SameRecordMember(existing, record) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/reconciler/sets_test.go
+++ b/internal/reconciler/sets_test.go
@@ -1,0 +1,198 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+	"github.com/maxfield-allison/dnsweaver/pkg/source"
+)
+
+func setTestHarness(t *testing.T, mode provider.OperationalMode, caps provider.Capabilities, records []provider.Record, claims ...*source.Hostname) (*Reconciler, *testMockProvider, *desiredRecordSet, *recordCache) {
+	t.Helper()
+	mock := newTestMockProvider("dns")
+	mock.capabilities = &caps
+	for _, record := range records {
+		mock.AddRecord(record)
+	}
+	providers := testProviderRegistry(quietLogger(), mock)
+	providers.SetInstanceID("test-instance")
+	if err := providers.CreateInstance(provider.ProviderInstanceConfig{
+		Name: "dns", TypeName: "mock", RecordType: provider.RecordTypeA,
+		Target: "192.0.2.1", TTL: 300, Mode: mode, Domains: []string{"*.example.com"},
+	}); err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	cfg := DefaultConfig()
+	cfg.InstanceID = "test-instance"
+	r := New(nil, source.NewRegistry(quietLogger()), providers, WithConfig(cfg), WithLogger(quietLogger()))
+	compiled := r.compileDesiredRecordSets(claims)
+	if len(compiled.Sets) != 1 {
+		t.Fatalf("compiled sets = %+v, want one", compiled.Sets)
+	}
+	cache := newRecordCache(context.Background(), providers, quietLogger())
+	return r, mock, compiled.Sets[0], cache
+}
+
+func setTestCapabilities(ownership, nativeUpdate bool) provider.Capabilities {
+	return provider.Capabilities{
+		SupportsOwnershipTXT: ownership,
+		SupportsNativeUpdate: nativeUpdate,
+		SupportedRecordTypes: []provider.RecordType{provider.RecordTypeA, provider.RecordTypeAAAA, provider.RecordTypeCNAME, provider.RecordTypeSRV, provider.RecordTypeTXT},
+	}
+}
+
+func hintedA(hostname, target string) *source.Hostname {
+	return &source.Hostname{Name: hostname, Source: "native", RecordHints: &source.RecordHints{Type: "A", Target: target}}
+}
+
+func TestReconcileDesiredSet_CreatesEveryDistinctMember(t *testing.T) {
+	r, mock, set, cache := setTestHarness(t, provider.ModeManaged, setTestCapabilities(true, false), nil,
+		hintedA("app.example.com", "192.0.2.10"),
+		hintedA("app.example.com", "192.0.2.11"),
+	)
+	actions := r.reconcileDesiredSet(context.Background(), set, cache, nil)
+	if len(actions) != 2 || actions[0].Type != ActionCreate || actions[1].Type != ActionCreate {
+		t.Fatalf("actions = %+v, want two creates", actions)
+	}
+	if got := mock.GetCreatedDNSRecords(); len(got) != 2 {
+		t.Fatalf("created data records = %+v, want two", got)
+	}
+	if got := mock.GetCreatedOwnershipRecords(); len(got) != 2 {
+		t.Fatalf("created ownership records = %+v, want one per member", got)
+	}
+}
+
+func TestReconcileDesiredSet_ManagedDeletesOnlyOwnedMissingMember(t *testing.T) {
+	first := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300}
+	second := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.11", TTL: 300}
+	records := []provider.Record{
+		first,
+		second,
+		provider.MemberOwnershipRecord(first.Hostname, 300, "test-instance", first, nil),
+		provider.MemberOwnershipRecord(second.Hostname, 300, "test-instance", second, nil),
+	}
+	r, mock, set, cache := setTestHarness(t, provider.ModeManaged, setTestCapabilities(true, false), records,
+		hintedA(first.Hostname, first.Target),
+	)
+	actions := r.reconcileDesiredSet(context.Background(), set, cache, nil)
+	if len(actions) != 2 || actions[1].Type != ActionDelete || actions[1].Target != second.Target {
+		t.Fatalf("actions = %+v, want only second member deleted", actions)
+	}
+	deleted := mock.GetDeleted()
+	if len(deleted) != 2 || !provider.SameRecordMember(deleted[0], second) || deleted[1].Type != provider.RecordTypeTXT {
+		t.Fatalf("deleted records = %+v, want second member and its marker", deleted)
+	}
+}
+
+func TestReconcileDesiredSet_LegacyMarkerUpgradesOnlyDesiredMember(t *testing.T) {
+	first := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300}
+	manualSibling := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.99", TTL: 300}
+	legacy := provider.OwnershipRecord(first.Hostname, 300, "test-instance", nil)
+	r, mock, set, cache := setTestHarness(t, provider.ModeManaged, setTestCapabilities(true, false),
+		[]provider.Record{first, manualSibling, legacy}, hintedA(first.Hostname, first.Target))
+	r.reconcileDesiredSet(context.Background(), set, cache, nil)
+
+	created := mock.GetCreatedOwnershipRecords()
+	if len(created) != 1 || !provider.MatchesMemberOwnership(created[0].Target, "test-instance", first) {
+		t.Fatalf("created ownership = %+v, want exact desired member marker", created)
+	}
+	deleted := mock.GetDeleted()
+	if len(deleted) != 1 || deleted[0].Target != legacy.Target {
+		t.Fatalf("deleted = %+v, want legacy marker only", deleted)
+	}
+}
+
+func TestReconcileDesiredSet_NoTXTUsesOnlyPreviousInMemoryMembers(t *testing.T) {
+	first := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300}
+	second := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.11", TTL: 300}
+	caps := setTestCapabilities(false, false)
+
+	r, mock, set, cache := setTestHarness(t, provider.ModeManaged, caps, []provider.Record{first, second}, hintedA(first.Hostname, first.Target))
+	r.reconcileDesiredSet(context.Background(), set, cache, []provider.Record{first, second})
+	if deleted := mock.GetDeleted(); len(deleted) != 1 || deleted[0].Target != second.Target {
+		t.Fatalf("deleted with previous state = %+v, want second member", deleted)
+	}
+
+	r, mock, set, cache = setTestHarness(t, provider.ModeManaged, caps, []provider.Record{first, second}, hintedA(first.Hostname, first.Target))
+	r.reconcileDesiredSet(context.Background(), set, cache, nil)
+	if deleted := mock.GetDeleted(); len(deleted) != 0 {
+		t.Fatalf("deleted after simulated restart without durable ownership = %+v", deleted)
+	}
+}
+
+func TestReconcileDesiredSet_AuthoritativeRemovesUnownedSibling(t *testing.T) {
+	first := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300}
+	second := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.11", TTL: 300}
+	r, mock, set, cache := setTestHarness(t, provider.ModeAuthoritative, setTestCapabilities(true, false),
+		[]provider.Record{first, second}, hintedA(first.Hostname, first.Target))
+	r.reconcileDesiredSet(context.Background(), set, cache, nil)
+	if deleted := mock.GetDeleted(); len(deleted) != 1 || deleted[0].Target != second.Target {
+		t.Fatalf("deleted = %+v, want unowned sibling in authoritative mode", deleted)
+	}
+}
+
+func TestReconcileDesiredSet_AdditiveDoesNotDeleteOrFallbackUpdate(t *testing.T) {
+	existing := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 60}
+	sibling := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.11", TTL: 300}
+	claim := hintedA(existing.Hostname, existing.Target)
+	claim.RecordHints.TTL = 300
+	r, mock, set, cache := setTestHarness(t, provider.ModeAdditive, setTestCapabilities(true, false),
+		[]provider.Record{existing, sibling}, claim)
+	actions := r.reconcileDesiredSet(context.Background(), set, cache, nil)
+	if len(actions) != 1 || actions[0].Type != ActionSkip {
+		t.Fatalf("actions = %+v, want update skipped", actions)
+	}
+	if len(mock.GetDeleted()) != 0 || len(mock.GetCreatedDNSRecords()) != 0 {
+		t.Fatalf("additive mode mutated records: created=%+v deleted=%+v", mock.GetCreated(), mock.GetDeleted())
+	}
+}
+
+func TestReconcileDesiredSet_CNAMEUsesSingleValueUpdate(t *testing.T) {
+	old := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeCNAME, Target: "old.example.com", TTL: 300}
+	marker := provider.MemberOwnershipRecord(old.Hostname, 300, "test-instance", old, nil)
+	claim := &source.Hostname{
+		Name:   old.Hostname,
+		Source: "native",
+		RecordHints: &source.RecordHints{
+			Type:   string(provider.RecordTypeCNAME),
+			Target: "new.example.com",
+		},
+	}
+	r, mock, set, cache := setTestHarness(t, provider.ModeManaged, setTestCapabilities(true, false), []provider.Record{old, marker}, claim)
+	oldDeleted := false
+	mock.deleteFn = func(_ context.Context, record provider.Record) error {
+		if record.Type == provider.RecordTypeCNAME && provider.SameRecordMember(record, old) {
+			oldDeleted = true
+		}
+		return nil
+	}
+	mock.createFn = func(_ context.Context, record provider.Record) error {
+		if record.Type == provider.RecordTypeCNAME && !oldDeleted {
+			return provider.ErrConflict
+		}
+		return nil
+	}
+
+	actions := r.reconcileDesiredSet(context.Background(), set, cache, nil)
+	if len(actions) != 1 || actions[0].Type != ActionUpdate || actions[0].Status != StatusSuccess {
+		t.Fatalf("actions = %+v, want one successful CNAME update", actions)
+	}
+	created := mock.GetCreatedDNSRecords()
+	if len(created) != 1 || created[0].Target != "new.example.com" {
+		t.Fatalf("created = %+v, want replacement CNAME after old deletion", created)
+	}
+}
+
+func TestReconcileDesiredSet_RejectsMultipleCNAMEMembers(t *testing.T) {
+	first := &source.Hostname{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "CNAME", Target: "one.example.com"}}
+	second := &source.Hostname{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "CNAME", Target: "two.example.com"}}
+	r, mock, set, cache := setTestHarness(t, provider.ModeManaged, setTestCapabilities(true, true), nil, first, second)
+	actions := r.reconcileDesiredSet(context.Background(), set, cache, nil)
+	if len(actions) != 2 || actions[0].Error != errMultipleCNAMEMembers || actions[1].Error != errMultipleCNAMEMembers {
+		t.Fatalf("actions = %+v, want both CNAME members rejected", actions)
+	}
+	if len(mock.GetCreated()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("ambiguous CNAME set mutated provider: created=%+v deleted=%+v", mock.GetCreated(), mock.GetDeleted())
+	}
+}

--- a/internal/reconciler/sets_test.go
+++ b/internal/reconciler/sets_test.go
@@ -196,3 +196,41 @@ func TestReconcileDesiredSet_RejectsMultipleCNAMEMembers(t *testing.T) {
 		t.Fatalf("ambiguous CNAME set mutated provider: created=%+v deleted=%+v", mock.GetCreated(), mock.GetDeleted())
 	}
 }
+
+func TestReconcileDesiredSet_RejectsSelfReferentialCNAMEBeforeMutation(t *testing.T) {
+	existing := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300}
+	desired := &source.Hostname{
+		Name:   "app.example.com",
+		Source: "native",
+		RecordHints: &source.RecordHints{
+			Type:   "CNAME",
+			Target: "app.example.com",
+		},
+	}
+	r, mock, set, cache := setTestHarness(t, provider.ModeAuthoritative, setTestCapabilities(true, true), []provider.Record{existing}, desired)
+
+	actions := r.reconcileDesiredSet(context.Background(), set, cache, nil)
+
+	if len(actions) != 1 || actions[0].Type != ActionSkip || actions[0].Error != errSelfReferentialCNAME {
+		t.Fatalf("actions = %+v, want self-referential CNAME skip", actions)
+	}
+	if len(mock.GetCreated()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("self-referential CNAME mutated provider: created=%+v deleted=%+v", mock.GetCreated(), mock.GetDeleted())
+	}
+}
+
+func TestReconcileDesiredSet_RejectsMultipleCNAMEMembersBeforeConflictDeletion(t *testing.T) {
+	existing := provider.Record{Hostname: "app.example.com", Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 300}
+	first := &source.Hostname{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "CNAME", Target: "one.example.com"}}
+	second := &source.Hostname{Name: "app.example.com", Source: "native", RecordHints: &source.RecordHints{Type: "CNAME", Target: "two.example.com"}}
+	r, mock, set, cache := setTestHarness(t, provider.ModeAuthoritative, setTestCapabilities(true, true), []provider.Record{existing}, first, second)
+
+	actions := r.reconcileDesiredSet(context.Background(), set, cache, nil)
+
+	if len(actions) != 2 || actions[0].Error != errMultipleCNAMEMembers || actions[1].Error != errMultipleCNAMEMembers {
+		t.Fatalf("actions = %+v, want both CNAME members rejected", actions)
+	}
+	if len(mock.GetCreated()) != 0 || len(mock.GetDeleted()) != 0 {
+		t.Fatalf("ambiguous CNAME set mutated provider: created=%+v deleted=%+v", mock.GetCreated(), mock.GetDeleted())
+	}
+}

--- a/internal/reconciler/testutil_test.go
+++ b/internal/reconciler/testutil_test.go
@@ -241,6 +241,7 @@ func (m *testMockProvider) GetCreatedOwnershipRecords() []provider.Record {
 type testMockSource struct {
 	name      string
 	hostnames []source.Hostname
+	err       error
 }
 
 //nolint:unused // Reserved for future Reconcile() function tests
@@ -256,7 +257,7 @@ func (m *testMockSource) Name() string { return m.name }
 
 //nolint:unused // Reserved for future Reconcile() function tests
 func (m *testMockSource) Extract(_ context.Context, _ workload.Workload) ([]source.Hostname, error) {
-	return m.hostnames, nil
+	return m.hostnames, m.err
 }
 
 //nolint:unused // Reserved for future Reconcile() function tests

--- a/pkg/provider/instance.go
+++ b/pkg/provider/instance.go
@@ -379,6 +379,22 @@ func (pi *ProviderInstance) DeleteRecordByTarget(ctx context.Context, hostname s
 	return err
 }
 
+// DeleteMember removes the exact provider record supplied by a List snapshot,
+// preserving provider IDs and type-specific identity fields.
+func (pi *ProviderInstance) DeleteMember(ctx context.Context, record Record) error {
+	start := time.Now()
+	err := pi.Provider.Delete(ctx, record)
+	duration := time.Since(start).Seconds()
+
+	status := statusSuccess
+	if err != nil {
+		status = statusError
+	}
+	metrics.ProviderAPIRequestsTotal.WithLabelValues(pi.Name(), "delete", status).Inc()
+	metrics.ProviderAPIDuration.WithLabelValues(pi.Name(), "delete").Observe(duration)
+	return err
+}
+
 // DeleteSRVRecord removes a specific SRV record by hostname, target, and SRV data.
 // This is needed because multiple SRV records can have the same target but different
 // priority/weight/port values.

--- a/pkg/provider/instance.go
+++ b/pkg/provider/instance.go
@@ -431,6 +431,28 @@ func (pi *ProviderInstance) CreateOwnershipRecord(ctx context.Context, hostname 
 	return err
 }
 
+// CreateMemberOwnershipRecord creates a versioned TXT marker for one logical
+// DNS record member.
+func (pi *ProviderInstance) CreateMemberOwnershipRecord(ctx context.Context, member Record, metadata map[string]string) error {
+	record := MemberOwnershipRecord(member.Hostname, pi.TTL, pi.InstanceID, member, metadata)
+
+	start := time.Now()
+	err := pi.Provider.Create(ctx, record)
+	duration := time.Since(start).Seconds()
+
+	status := statusSuccess
+	if err != nil {
+		if IsConflict(err) {
+			return nil
+		}
+		status = statusError
+	}
+
+	metrics.ProviderAPIRequestsTotal.WithLabelValues(pi.Name(), "create_member_ownership", status).Inc()
+	metrics.ProviderAPIDuration.WithLabelValues(pi.Name(), "create_member_ownership").Observe(duration)
+	return err
+}
+
 // DeleteOwnershipRecord removes the TXT ownership record for a hostname.
 func (pi *ProviderInstance) DeleteOwnershipRecord(ctx context.Context, hostname string) error {
 	record := OwnershipRecord(hostname, pi.TTL, pi.InstanceID, nil)
@@ -447,6 +469,24 @@ func (pi *ProviderInstance) DeleteOwnershipRecord(ctx context.Context, hostname 
 	metrics.ProviderAPIRequestsTotal.WithLabelValues(pi.Name(), "delete_ownership", status).Inc()
 	metrics.ProviderAPIDuration.WithLabelValues(pi.Name(), "delete_ownership").Observe(duration)
 
+	return err
+}
+
+// DeleteMemberOwnershipRecord deletes the exact TXT marker for one logical DNS
+// record member, leaving markers for sibling values unchanged.
+func (pi *ProviderInstance) DeleteMemberOwnershipRecord(ctx context.Context, member Record, metadata map[string]string) error {
+	record := MemberOwnershipRecord(member.Hostname, pi.TTL, pi.InstanceID, member, metadata)
+
+	start := time.Now()
+	err := pi.Provider.Delete(ctx, record)
+	duration := time.Since(start).Seconds()
+
+	status := statusSuccess
+	if err != nil {
+		status = statusError
+	}
+	metrics.ProviderAPIRequestsTotal.WithLabelValues(pi.Name(), "delete_member_ownership", status).Inc()
+	metrics.ProviderAPIDuration.WithLabelValues(pi.Name(), "delete_member_ownership").Observe(duration)
 	return err
 }
 
@@ -480,6 +520,22 @@ func (pi *ProviderInstance) HasOwnershipRecord(ctx context.Context, hostname str
 	return false, nil
 }
 
+// HasMemberOwnershipRecord checks for an exact versioned ownership marker.
+func (pi *ProviderInstance) HasMemberOwnershipRecord(ctx context.Context, member Record) (bool, error) {
+	ownershipName := OwnershipRecordName(member.Hostname)
+	records, err := pi.Provider.List(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, record := range records {
+		if record.Type == RecordTypeTXT && strings.EqualFold(record.Hostname, ownershipName) &&
+			MatchesMemberOwnership(record.Target, pi.InstanceID, member) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // RecoveredHostname represents a hostname recovered from ownership TXT records,
 // along with any metadata that was persisted in the ownership value.
 type RecoveredHostname struct {
@@ -489,6 +545,40 @@ type RecoveredHostname struct {
 	// Metadata contains key-value pairs recovered from the ownership TXT value.
 	// For old-format records (no metadata), this will be nil.
 	Metadata map[string]string
+}
+
+// RecoveredMember represents one exact DNS member recovered from a versioned
+// ownership marker.
+type RecoveredMember struct {
+	Record   Record
+	Metadata map[string]string
+}
+
+// RecoverOwnedMembers scans the provider for versioned member markers owned by
+// this dnsweaver instance. Legacy hostname-level markers are deliberately not
+// returned because they cannot identify a safe deletion target.
+func (pi *ProviderInstance) RecoverOwnedMembers(ctx context.Context) ([]RecoveredMember, error) {
+	records, err := pi.Provider.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var recovered []RecoveredMember
+	for _, record := range records {
+		if record.Type != RecordTypeTXT || !IsOwnershipRecord(record.Hostname) {
+			continue
+		}
+		owned, instanceID, member, metadata := ParseMemberOwnershipValue(record.Target)
+		if !owned || instanceID != pi.InstanceID || member == nil {
+			continue
+		}
+		member.Hostname = ExtractHostnameFromOwnership(record.Hostname)
+		if member.Hostname == "" {
+			continue
+		}
+		recovered = append(recovered, RecoveredMember{Record: *member, Metadata: metadata})
+	}
+	return recovered, nil
 }
 
 // RecoverOwnedHostnames scans the provider for ownership TXT records and returns

--- a/pkg/provider/instance_test.go
+++ b/pkg/provider/instance_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"testing"
 
 	"github.com/maxfield-allison/dnsweaver/internal/matcher"
@@ -588,5 +589,65 @@ func TestProviderInstance_RecordNeedsUpdate(t *testing.T) {
 				t.Errorf("comparer consulted %d times, want %d", cmp.calls, tt.wantCalls)
 			}
 		})
+	}
+}
+
+func TestProviderInstance_MemberOwnershipLifecycle(t *testing.T) {
+	mock := &mockProvider{name: "mock", typeName: "mock"}
+	inst := &ProviderInstance{Provider: mock, TTL: 300, InstanceID: "instance-a"}
+	member := Record{Hostname: "app.example.com", Type: RecordTypeA, Target: "192.0.2.10"}
+	metadata := map[string]string{"proxied": "false"}
+
+	if err := inst.CreateMemberOwnershipRecord(context.Background(), member, metadata); err != nil {
+		t.Fatalf("CreateMemberOwnershipRecord() error = %v", err)
+	}
+	if len(mock.created) != 1 || !MatchesMemberOwnership(mock.created[0].Target, "instance-a", member) {
+		t.Fatalf("created records = %+v", mock.created)
+	}
+	_, _, _, createdMetadata := ParseMemberOwnershipValue(mock.created[0].Target)
+	if createdMetadata["proxied"] != "false" {
+		t.Fatalf("created metadata = %v", createdMetadata)
+	}
+
+	if err := inst.DeleteMemberOwnershipRecord(context.Background(), member, metadata); err != nil {
+		t.Fatalf("DeleteMemberOwnershipRecord() error = %v", err)
+	}
+	if len(mock.deleted) != 1 || mock.deleted[0].Target != mock.created[0].Target {
+		t.Fatalf("deleted marker = %+v, want exact created marker %+v", mock.deleted, mock.created)
+	}
+}
+
+func TestProviderInstance_HasAndRecoversExactMemberOwnership(t *testing.T) {
+	member := Record{Hostname: "app.example.com", Type: RecordTypeA, Target: "192.0.2.10"}
+	other := Record{Hostname: "app.example.com", Type: RecordTypeA, Target: "192.0.2.11"}
+	mock := &mockProvider{
+		name:     "mock",
+		typeName: "mock",
+		records: []Record{
+			MemberOwnershipRecord(member.Hostname, 300, "instance-a", member, map[string]string{"source": "native"}),
+			MemberOwnershipRecord(other.Hostname, 300, "instance-b", other, nil),
+			OwnershipRecord(member.Hostname, 300, "instance-a", nil),
+		},
+	}
+	inst := &ProviderInstance{Provider: mock, InstanceID: "instance-a"}
+
+	hasMember, err := inst.HasMemberOwnershipRecord(context.Background(), member)
+	if err != nil || !hasMember {
+		t.Fatalf("HasMemberOwnershipRecord(member) = %v, %v", hasMember, err)
+	}
+	hasOther, err := inst.HasMemberOwnershipRecord(context.Background(), other)
+	if err != nil || hasOther {
+		t.Fatalf("HasMemberOwnershipRecord(other) = %v, %v", hasOther, err)
+	}
+
+	recovered, err := inst.RecoverOwnedMembers(context.Background())
+	if err != nil {
+		t.Fatalf("RecoverOwnedMembers() error = %v", err)
+	}
+	if len(recovered) != 1 || !SameRecordMember(recovered[0].Record, member) {
+		t.Fatalf("recovered = %+v, want only exact owned member", recovered)
+	}
+	if recovered[0].Record.Hostname != member.Hostname || recovered[0].Metadata["source"] != "native" {
+		t.Fatalf("recovered = %+v", recovered[0])
 	}
 }

--- a/pkg/provider/instance_test.go
+++ b/pkg/provider/instance_test.go
@@ -604,7 +604,10 @@ func TestProviderInstance_MemberOwnershipLifecycle(t *testing.T) {
 	if len(mock.created) != 1 || !MatchesMemberOwnership(mock.created[0].Target, "instance-a", member) {
 		t.Fatalf("created records = %+v", mock.created)
 	}
-	_, _, _, createdMetadata := ParseMemberOwnershipValue(mock.created[0].Target)
+	owned, instanceID, createdMember, createdMetadata := ParseMemberOwnershipValue(mock.created[0].Target)
+	if !owned || instanceID != "instance-a" || createdMember == nil {
+		t.Fatalf("created marker did not parse: owned=%v instance=%q member=%+v", owned, instanceID, createdMember)
+	}
 	if createdMetadata["proxied"] != "false" {
 		t.Fatalf("created metadata = %v", createdMetadata)
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -199,6 +199,8 @@ func ParseMemberOwnershipValue(value string) (isOwned bool, instanceID string, m
 
 	record := &Record{Type: recordType, Target: target}
 	switch recordType {
+	case RecordTypeA, RecordTypeAAAA, RecordTypeCNAME, RecordTypeTXT:
+		// Target fully identifies these member types.
 	case RecordTypeSRV:
 		priority, priorityOK := parseOwnershipUint16(fields[keyRecordSRVPriority])
 		weight, weightOK := parseOwnershipUint16(fields[keyRecordSRVWeight])
@@ -234,6 +236,18 @@ func validOwnershipRecordType(recordType RecordType) bool {
 func MatchesMemberOwnership(value, instanceID string, record Record) bool {
 	isOwned, markerInstance, member, _ := ParseMemberOwnershipValue(value)
 	return isOwned && markerInstance == instanceID && member != nil && SameRecordMember(*member, record)
+}
+
+// MatchesLegacyOwnership reports whether value is a pre-member ownership
+// marker for the requested instance. Malformed versioned markers are not
+// treated as legacy because doing so would restore hostname-wide authority.
+func MatchesLegacyOwnership(value, instanceID string) bool {
+	isOwned, markerInstance, fields := ParseOwnershipValue(value)
+	if !isOwned || markerInstance != instanceID {
+		return false
+	}
+	_, versioned := fields[keyRecordVersion]
+	return !versioned
 }
 
 // SameRecordMember compares the fields that identify a member of an RRset.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -3,7 +3,10 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
+	"net"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -33,6 +36,17 @@ const ownershipHeritage = "heritage=dnsweaver"
 const (
 	keyHeritage = "heritage"
 	keyInstance = "instance"
+
+	memberOwnershipVersion   = "2"
+	keyRecordVersion         = "record-version"
+	keyRecordType            = "record-type"
+	keyRecordTarget          = "record-target"
+	keyRecordSRVPriority     = "record-srv-priority"
+	keyRecordSRVWeight       = "record-srv-weight"
+	keyRecordSRVPort         = "record-srv-port"
+	keyRecordHTTPSPriority   = "record-https-priority"
+	keyRecordHTTPSTargetName = "record-https-target-name"
+	keyRecordHTTPSALPN       = "record-https-alpn"
 )
 
 // MakeOwnershipValue returns the ownership TXT record value for the given instance ID and metadata.
@@ -129,6 +143,176 @@ func MatchesOwnership(value, ourInstanceID string) bool {
 func IsDnsweaverOwned(value string) bool {
 	isOwned, _, _ := ParseOwnershipValue(value)
 	return isOwned
+}
+
+// MakeMemberOwnershipValue returns a versioned ownership marker for one DNS
+// record member. Target-like strings are base64url encoded so commas and other
+// TXT metadata delimiters cannot make the marker ambiguous.
+func MakeMemberOwnershipValue(instanceID string, record Record, metadata map[string]string) string {
+	fields := make(map[string]string, len(metadata)+8)
+	for key, value := range metadata {
+		fields[key] = value
+	}
+	fields[keyRecordVersion] = memberOwnershipVersion
+	fields[keyRecordType] = string(record.Type)
+	fields[keyRecordTarget] = encodeOwnershipField(record.Target)
+
+	if record.Type == RecordTypeSRV && record.SRV != nil {
+		fields[keyRecordSRVPriority] = strconv.FormatUint(uint64(record.SRV.Priority), 10)
+		fields[keyRecordSRVWeight] = strconv.FormatUint(uint64(record.SRV.Weight), 10)
+		fields[keyRecordSRVPort] = strconv.FormatUint(uint64(record.SRV.Port), 10)
+	}
+	if record.Type == RecordTypeHTTPS && record.HTTPS != nil {
+		fields[keyRecordHTTPSPriority] = strconv.FormatUint(uint64(record.HTTPS.Priority), 10)
+		fields[keyRecordHTTPSTargetName] = encodeOwnershipField(record.HTTPS.TargetName)
+		fields[keyRecordHTTPSALPN] = encodeOwnershipField(record.HTTPS.ALPN)
+	}
+
+	return MakeOwnershipValue(instanceID, fields)
+}
+
+// ParseMemberOwnershipValue parses a versioned member marker. Legacy or
+// malformed markers remain recognizable as dnsweaver ownership but return a
+// nil member, which forces callers to treat them as ambiguous.
+func ParseMemberOwnershipValue(value string) (isOwned bool, instanceID string, member *Record, metadata map[string]string) {
+	isOwned, instanceID, fields := ParseOwnershipValue(value)
+	if !isOwned {
+		return false, "", nil, nil
+	}
+	if fields[keyRecordVersion] != memberOwnershipVersion {
+		return true, instanceID, nil, fields
+	}
+
+	recordTypeValue, hasRecordType := fields[keyRecordType]
+	recordType := RecordType(recordTypeValue)
+	if !hasRecordType || !validOwnershipRecordType(recordType) {
+		return true, instanceID, nil, stripMemberOwnershipFields(fields)
+	}
+	encodedTarget, hasTarget := fields[keyRecordTarget]
+	if !hasTarget {
+		return true, instanceID, nil, stripMemberOwnershipFields(fields)
+	}
+	target, err := decodeOwnershipField(encodedTarget)
+	if err != nil {
+		return true, instanceID, nil, stripMemberOwnershipFields(fields)
+	}
+
+	record := &Record{Type: recordType, Target: target}
+	switch recordType {
+	case RecordTypeSRV:
+		priority, priorityOK := parseOwnershipUint16(fields[keyRecordSRVPriority])
+		weight, weightOK := parseOwnershipUint16(fields[keyRecordSRVWeight])
+		port, portOK := parseOwnershipUint16(fields[keyRecordSRVPort])
+		if !priorityOK || !weightOK || !portOK {
+			return true, instanceID, nil, stripMemberOwnershipFields(fields)
+		}
+		record.SRV = &SRVData{Priority: priority, Weight: weight, Port: port}
+	case RecordTypeHTTPS:
+		priority, priorityOK := parseOwnershipUint16(fields[keyRecordHTTPSPriority])
+		targetName, targetErr := decodeOwnershipField(fields[keyRecordHTTPSTargetName])
+		alpn, alpnErr := decodeOwnershipField(fields[keyRecordHTTPSALPN])
+		if !priorityOK || targetErr != nil || alpnErr != nil {
+			return true, instanceID, nil, stripMemberOwnershipFields(fields)
+		}
+		record.HTTPS = &HTTPSData{Priority: priority, TargetName: targetName, ALPN: alpn}
+	}
+
+	return true, instanceID, record, stripMemberOwnershipFields(fields)
+}
+
+func validOwnershipRecordType(recordType RecordType) bool {
+	switch recordType {
+	case RecordTypeA, RecordTypeAAAA, RecordTypeCNAME, RecordTypeTXT, RecordTypeSRV, RecordTypeHTTPS:
+		return true
+	default:
+		return false
+	}
+}
+
+// MatchesMemberOwnership reports whether value is a valid member marker for
+// the requested dnsweaver instance and logical DNS record member.
+func MatchesMemberOwnership(value, instanceID string, record Record) bool {
+	isOwned, markerInstance, member, _ := ParseMemberOwnershipValue(value)
+	return isOwned && markerInstance == instanceID && member != nil && SameRecordMember(*member, record)
+}
+
+// SameRecordMember compares the fields that identify a member of an RRset.
+// Hostname and TTL are intentionally excluded: ownership record names carry
+// the hostname, and TTL is mutable state rather than member identity.
+func SameRecordMember(a, b Record) bool {
+	if a.Type != b.Type || canonicalRecordTarget(a) != canonicalRecordTarget(b) {
+		return false
+	}
+	if a.Type == RecordTypeSRV {
+		return sameSRVData(a.SRV, b.SRV)
+	}
+	if a.Type == RecordTypeHTTPS {
+		return sameHTTPSData(a.HTTPS, b.HTTPS)
+	}
+	return true
+}
+
+func canonicalRecordTarget(record Record) string {
+	if record.Type == RecordTypeA || record.Type == RecordTypeAAAA {
+		if ip := net.ParseIP(strings.TrimSpace(record.Target)); ip != nil {
+			return ip.String()
+		}
+	}
+	if record.Type == RecordTypeCNAME || record.Type == RecordTypeSRV {
+		return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(record.Target), "."))
+	}
+	return record.Target
+}
+
+func sameSRVData(a, b *SRVData) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Priority == b.Priority && a.Weight == b.Weight && a.Port == b.Port
+}
+
+func sameHTTPSData(a, b *HTTPSData) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Priority == b.Priority &&
+		strings.EqualFold(strings.TrimSuffix(a.TargetName, "."), strings.TrimSuffix(b.TargetName, ".")) &&
+		a.ALPN == b.ALPN
+}
+
+func encodeOwnershipField(value string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(value))
+}
+
+func decodeOwnershipField(value string) (string, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	return string(decoded), err
+}
+
+func parseOwnershipUint16(value string) (uint16, bool) {
+	parsed, err := strconv.ParseUint(value, 10, 16)
+	return uint16(parsed), err == nil
+}
+
+func stripMemberOwnershipFields(fields map[string]string) map[string]string {
+	if len(fields) == 0 {
+		return nil
+	}
+	metadata := make(map[string]string, len(fields))
+	for key, value := range fields {
+		switch key {
+		case keyRecordVersion, keyRecordType, keyRecordTarget,
+			keyRecordSRVPriority, keyRecordSRVWeight, keyRecordSRVPort,
+			keyRecordHTTPSPriority, keyRecordHTTPSTargetName, keyRecordHTTPSALPN:
+			continue
+		default:
+			metadata[key] = value
+		}
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
 }
 
 // SRVData contains SRV record-specific fields.
@@ -344,6 +528,17 @@ func OwnershipRecord(hostname string, ttl int, instanceID string, metadata map[s
 		Hostname: OwnershipRecordName(hostname),
 		Type:     RecordTypeTXT,
 		Target:   MakeOwnershipValue(instanceID, metadata),
+		TTL:      ttl,
+	}
+}
+
+// MemberOwnershipRecord creates a versioned TXT ownership record for one
+// logical DNS record member.
+func MemberOwnershipRecord(hostname string, ttl int, instanceID string, member Record, metadata map[string]string) Record {
+	return Record{
+		Hostname: OwnershipRecordName(hostname),
+		Type:     RecordTypeTXT,
+		Target:   MakeMemberOwnershipValue(instanceID, member, metadata),
 		TTL:      ttl,
 	}
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -702,3 +702,106 @@ func TestOwnershipRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestMemberOwnershipRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		record Record
+	}{
+		{name: "A", record: Record{Type: RecordTypeA, Target: "192.0.2.10"}},
+		{name: "AAAA", record: Record{Type: RecordTypeAAAA, Target: "2001:db8::10"}},
+		{name: "CNAME", record: Record{Type: RecordTypeCNAME, Target: "target.example.com."}},
+		{name: "TXT with delimiter", record: Record{Type: RecordTypeTXT, Target: "one,two=three"}},
+		{name: "SRV", record: Record{Type: RecordTypeSRV, Target: "sip.example.com", SRV: &SRVData{Priority: 10, Weight: 20, Port: 5060}}},
+		{name: "HTTPS", record: Record{Type: RecordTypeHTTPS, Target: "", HTTPS: &HTTPSData{Priority: 1, TargetName: ".", ALPN: "h2,h3"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := MakeMemberOwnershipValue("instance-a", tt.record, map[string]string{"source": "traefik"})
+			owned, instanceID, member, metadata := ParseMemberOwnershipValue(value)
+			if !owned || instanceID != "instance-a" {
+				t.Fatalf("ownership parse = owned:%v instance:%q", owned, instanceID)
+			}
+			if member == nil || !SameRecordMember(*member, tt.record) {
+				t.Fatalf("member = %+v, want %+v", member, tt.record)
+			}
+			if metadata["source"] != "traefik" {
+				t.Fatalf("metadata = %v, want source=traefik", metadata)
+			}
+		})
+	}
+}
+
+func TestParseMemberOwnershipValue_LegacyIsAmbiguous(t *testing.T) {
+	owned, instanceID, member, metadata := ParseMemberOwnershipValue("heritage=dnsweaver,instance=instance-a,proxied=true")
+	if !owned || instanceID != "instance-a" {
+		t.Fatalf("ownership parse = owned:%v instance:%q", owned, instanceID)
+	}
+	if member != nil {
+		t.Fatalf("legacy marker produced member %+v", member)
+	}
+	if metadata["proxied"] != "true" {
+		t.Fatalf("metadata = %v, want proxied=true", metadata)
+	}
+}
+
+func TestParseMemberOwnershipValue_MalformedV2IsAmbiguous(t *testing.T) {
+	value := "heritage=dnsweaver,instance=instance-a,record-target=not+base64,record-type=A,record-version=2"
+	owned, instanceID, member, _ := ParseMemberOwnershipValue(value)
+	if !owned || instanceID != "instance-a" {
+		t.Fatalf("ownership parse = owned:%v instance:%q", owned, instanceID)
+	}
+	if member != nil {
+		t.Fatalf("malformed marker produced member %+v", member)
+	}
+}
+
+func TestMatchesMemberOwnership(t *testing.T) {
+	record := Record{Type: RecordTypeA, Target: "192.0.2.10"}
+	value := MakeMemberOwnershipValue("instance-a", record, nil)
+	if !MatchesMemberOwnership(value, "instance-a", record) {
+		t.Fatal("exact member ownership did not match")
+	}
+	if MatchesMemberOwnership(value, "instance-b", record) {
+		t.Fatal("member ownership matched another instance")
+	}
+	if MatchesMemberOwnership(value, "instance-a", Record{Type: RecordTypeA, Target: "192.0.2.11"}) {
+		t.Fatal("member ownership matched another target")
+	}
+	if MatchesMemberOwnership("heritage=dnsweaver,instance=instance-a", "instance-a", record) {
+		t.Fatal("legacy ownership marker matched an exact member")
+	}
+}
+
+func TestSameRecordMemberCanonicalizesDNSValues(t *testing.T) {
+	if !SameRecordMember(
+		Record{Type: RecordTypeAAAA, Target: "2001:0db8:0:0:0:0:0:1"},
+		Record{Type: RecordTypeAAAA, Target: "2001:db8::1"},
+	) {
+		t.Fatal("equivalent IPv6 values did not match")
+	}
+	if !SameRecordMember(
+		Record{Type: RecordTypeCNAME, Target: "Target.Example.COM."},
+		Record{Type: RecordTypeCNAME, Target: "target.example.com"},
+	) {
+		t.Fatal("equivalent CNAME values did not match")
+	}
+	if SameRecordMember(
+		Record{Type: RecordTypeSRV, Target: "sip.example.com", SRV: &SRVData{Priority: 10, Weight: 20, Port: 5060}},
+		Record{Type: RecordTypeSRV, Target: "sip.example.com", SRV: &SRVData{Priority: 20, Weight: 20, Port: 5060}},
+	) {
+		t.Fatal("different SRV members matched")
+	}
+}
+
+func TestMemberOwnershipRecord(t *testing.T) {
+	member := Record{Hostname: "app.example.com", Type: RecordTypeA, Target: "192.0.2.10"}
+	ownership := MemberOwnershipRecord(member.Hostname, 300, "instance-a", member, nil)
+	if ownership.Hostname != "_dnsweaver.app.example.com" || ownership.Type != RecordTypeTXT || ownership.TTL != 300 {
+		t.Fatalf("ownership record = %+v", ownership)
+	}
+	if !MatchesMemberOwnership(ownership.Target, "instance-a", member) {
+		t.Fatalf("ownership target does not identify member: %q", ownership.Target)
+	}
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -774,6 +774,20 @@ func TestMatchesMemberOwnership(t *testing.T) {
 	}
 }
 
+func TestMatchesLegacyOwnershipRejectsVersionedMarkers(t *testing.T) {
+	if !MatchesLegacyOwnership("heritage=dnsweaver,instance=instance-a", "instance-a") {
+		t.Fatal("legacy marker did not match")
+	}
+	member := Record{Type: RecordTypeA, Target: "192.0.2.10"}
+	if MatchesLegacyOwnership(MakeMemberOwnershipValue("instance-a", member, nil), "instance-a") {
+		t.Fatal("member marker matched as legacy")
+	}
+	malformed := "heritage=dnsweaver,instance=instance-a,record-version=2,record-type=A,record-target=not+base64"
+	if MatchesLegacyOwnership(malformed, "instance-a") {
+		t.Fatal("malformed versioned marker matched as legacy")
+	}
+}
+
 func TestSameRecordMemberCanonicalizesDNSValues(t *testing.T) {
 	if !SameRecordMember(
 		Record{Type: RecordTypeAAAA, Target: "2001:0db8:0:0:0:0:0:1"},

--- a/pkg/provider/registry_test.go
+++ b/pkg/provider/registry_test.go
@@ -13,14 +13,22 @@ type mockProvider struct {
 	typeName string
 	pingErr  error
 	records  []Record
+	created  []Record
+	deleted  []Record
 }
 
 func (m *mockProvider) Name() string                               { return m.name }
 func (m *mockProvider) Type() string                               { return m.typeName }
 func (m *mockProvider) Ping(ctx context.Context) error             { return m.pingErr }
 func (m *mockProvider) List(ctx context.Context) ([]Record, error) { return m.records, nil }
-func (m *mockProvider) Create(ctx context.Context, r Record) error { return nil }
-func (m *mockProvider) Delete(ctx context.Context, r Record) error { return nil }
+func (m *mockProvider) Create(ctx context.Context, r Record) error {
+	m.created = append(m.created, r)
+	return nil
+}
+func (m *mockProvider) Delete(ctx context.Context, r Record) error {
+	m.deleted = append(m.deleted, r)
+	return nil
+}
 func (m *mockProvider) Capabilities() Capabilities {
 	return Capabilities{
 		SupportsOwnershipTXT: true,

--- a/pkg/source/registry.go
+++ b/pkg/source/registry.go
@@ -98,13 +98,22 @@ func (r *Registry) Count() int {
 // If a source returns an error, extraction continues with remaining sources.
 // Errors are logged but not returned to allow partial results.
 func (r *Registry) ExtractAll(ctx context.Context, w workload.Workload) Hostnames {
+	hostnames, _ := r.ExtractAllWithStatus(ctx, w)
+	return hostnames
+}
+
+// ExtractAllWithStatus is ExtractAll plus a completeness signal. complete is
+// false when any applicable source failed, even when other sources returned
+// usable claims. Reconciliation uses this to suppress removals from a partial
+// desired-state snapshot.
+func (r *Registry) ExtractAllWithStatus(ctx context.Context, w workload.Workload) (hostnames Hostnames, complete bool) {
 	// Global opt-out: dnsweaver.enabled=false skips ALL sources.
 	// Check Docker labels first, then K8s annotations.
 	if isWorkloadDisabled(w) {
 		r.logger.Debug("workload disabled via dnsweaver.enabled=false, skipping all sources",
 			slog.String("workload", w.Name),
 		)
-		return nil
+		return nil, true
 	}
 
 	workloadAdopt, adoptKey, adoptValid := workloadAdoptExistingHint(w)
@@ -121,6 +130,7 @@ func (r *Registry) ExtractAll(ctx context.Context, w workload.Workload) Hostname
 	r.mu.RUnlock()
 
 	var allHostnames Hostnames
+	complete = true
 
 	for _, src := range sources {
 		// Skip sources that don't support this workload's platform
@@ -130,6 +140,7 @@ func (r *Registry) ExtractAll(ctx context.Context, w workload.Workload) Hostname
 
 		hostnames, err := src.Extract(ctx, w)
 		if err != nil {
+			complete = false
 			r.logger.Warn("source extraction failed",
 				slog.String("source", src.Name()),
 				slog.String("error", err.Error()),
@@ -148,7 +159,7 @@ func (r *Registry) ExtractAll(ctx context.Context, w workload.Workload) Hostname
 		}
 	}
 
-	return allHostnames
+	return allHostnames, complete
 }
 
 // sourceSupports returns true if the source supports the given platform.
@@ -199,12 +210,20 @@ func isWorkloadDisabled(w workload.Workload) bool {
 // If a source returns an error, discovery continues with remaining sources.
 // Errors are logged but not returned to allow partial results.
 func (r *Registry) DiscoverAll(ctx context.Context) Hostnames {
+	hostnames, _ := r.DiscoverAllWithStatus(ctx)
+	return hostnames
+}
+
+// DiscoverAllWithStatus is DiscoverAll plus a completeness signal. complete
+// is false when any discoverable source failed.
+func (r *Registry) DiscoverAllWithStatus(ctx context.Context) (hostnames Hostnames, complete bool) {
 	r.mu.RLock()
 	sources := make([]Source, len(r.sources))
 	copy(sources, r.sources)
 	r.mu.RUnlock()
 
 	var allHostnames Hostnames
+	complete = true
 
 	for _, src := range sources {
 		if !src.SupportsDiscovery() {
@@ -213,6 +232,7 @@ func (r *Registry) DiscoverAll(ctx context.Context) Hostnames {
 
 		hostnames, err := src.Discover(ctx)
 		if err != nil {
+			complete = false
 			r.logger.Warn("source file discovery failed",
 				slog.String("source", src.Name()),
 				slog.String("error", err.Error()),
@@ -230,7 +250,7 @@ func (r *Registry) DiscoverAll(ctx context.Context) Hostnames {
 		}
 	}
 
-	return allHostnames
+	return allHostnames, complete
 }
 
 // DiscoverableSources returns sources that have file discovery configured.

--- a/pkg/source/registry_test.go
+++ b/pkg/source/registry_test.go
@@ -201,6 +201,14 @@ func TestRegistry_ExtractAll_WithErrors(t *testing.T) {
 	if hostnames[1].Name != "good2.example.com" {
 		t.Errorf("hostnames[1].Name = %q, want %q", hostnames[1].Name, "good2.example.com")
 	}
+
+	statusHostnames, complete := r.ExtractAllWithStatus(context.Background(), w)
+	if complete {
+		t.Fatal("ExtractAllWithStatus reported a complete snapshot after a source failed")
+	}
+	if len(statusHostnames) != 2 {
+		t.Fatalf("ExtractAllWithStatus returned %d hostnames, want 2 partial results", len(statusHostnames))
+	}
 }
 
 func TestRegistry_ExtractAll_Empty(t *testing.T) {
@@ -312,6 +320,14 @@ func TestRegistry_DiscoverAll_ErrorHandling(t *testing.T) {
 
 	if len(hostnames) != 1 {
 		t.Errorf("DiscoverAll returned %d hostnames, want 1 (from ok source)", len(hostnames))
+	}
+
+	statusHostnames, complete := r.DiscoverAllWithStatus(context.Background())
+	if complete {
+		t.Fatal("DiscoverAllWithStatus reported a complete snapshot after a source failed")
+	}
+	if len(statusHostnames) != 1 {
+		t.Fatalf("DiscoverAllWithStatus returned %d hostnames, want 1 partial result", len(statusHostnames))
 	}
 }
 

--- a/providers/cloudflare/client.go
+++ b/providers/cloudflare/client.go
@@ -399,9 +399,8 @@ func (c *Client) UpdateRecord(ctx context.Context, zoneID, recordID, recordType,
 	return nil
 }
 
-// FindRecord finds a DNS record by name and type in the given zone.
-// Returns the record if found, nil otherwise.
-func (c *Client) FindRecord(ctx context.Context, zoneID, recordType, name string) (*dnsRecord, error) {
+// FindRecords finds DNS records by name and type in the given zone.
+func (c *Client) FindRecords(ctx context.Context, zoneID, recordType, name string) ([]dnsRecord, error) {
 	params := url.Values{}
 	params.Set("type", recordType)
 	params.Set("name", name)
@@ -417,9 +416,21 @@ func (c *Client) FindRecord(ctx context.Context, zoneID, recordType, name string
 		return nil, fmt.Errorf("parsing records response: %w", err)
 	}
 
-	if len(records.Result) == 0 {
+	return records.Result, nil
+}
+
+// FindRecord finds the first DNS record by name and type in the given zone.
+// Callers that need to distinguish members of a multi-value RRset must use
+// FindRecords and match the record value before mutating it.
+func (c *Client) FindRecord(ctx context.Context, zoneID, recordType, name string) (*dnsRecord, error) {
+	records, err := c.FindRecords(ctx, zoneID, recordType, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(records) == 0 {
 		return nil, nil // Not found
 	}
 
-	return &records.Result[0], nil
+	return &records[0], nil
 }

--- a/providers/cloudflare/provider.go
+++ b/providers/cloudflare/provider.go
@@ -361,8 +361,9 @@ func (p *Provider) Delete(ctx context.Context, record provider.Record) error {
 		return fmt.Errorf("getting zone ID: %w", err)
 	}
 
-	// Find the record to get its ID
-	apiRecord, err := p.client.FindRecord(ctx, zoneID, string(record.Type), record.Hostname)
+	// Resolve the exact member. A hostname and type can have multiple values,
+	// so selecting the first API result can delete an unrelated sibling.
+	apiRecord, err := p.findRecord(ctx, zoneID, record)
 	if err != nil {
 		return fmt.Errorf("finding record: %w", err)
 	}
@@ -397,8 +398,8 @@ func (p *Provider) Update(ctx context.Context, existing, desired provider.Record
 		return fmt.Errorf("getting zone ID: %w", err)
 	}
 
-	// Find the existing record to get its ID
-	apiRecord, err := p.client.FindRecord(ctx, zoneID, string(existing.Type), existing.Hostname)
+	// Resolve the exact existing member before updating it.
+	apiRecord, err := p.findRecord(ctx, zoneID, existing)
 	if err != nil {
 		return fmt.Errorf("finding record: %w", err)
 	}
@@ -455,6 +456,54 @@ func (p *Provider) Update(ctx context.Context, existing, desired provider.Record
 	)
 
 	return nil
+}
+
+// findRecord resolves the Cloudflare API record for one logical DNS member.
+// ProviderID is authoritative when the record came from List. Records built by
+// cleanup paths may not carry an ID, so those are matched by their full value.
+func (p *Provider) findRecord(ctx context.Context, zoneID string, record provider.Record) (*dnsRecord, error) {
+	if record.ProviderID != "" {
+		return &dnsRecord{ID: record.ProviderID}, nil
+	}
+
+	records, err := p.client.FindRecords(ctx, zoneID, string(record.Type), record.Hostname)
+	if err != nil {
+		return nil, err
+	}
+	for i := range records {
+		if cloudflareRecordMatches(records[i], record) {
+			return &records[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func cloudflareRecordMatches(apiRecord dnsRecord, record provider.Record) bool {
+	if !strings.EqualFold(strings.TrimSuffix(apiRecord.Name, "."), strings.TrimSuffix(record.Hostname, ".")) ||
+		!strings.EqualFold(apiRecord.Type, string(record.Type)) {
+		return false
+	}
+
+	if record.Type == provider.RecordTypeSRV {
+		if apiRecord.Data == nil || record.SRV == nil {
+			return false
+		}
+		return strings.EqualFold(strings.TrimSuffix(apiRecord.Data.Target, "."), strings.TrimSuffix(record.Target, ".")) &&
+			apiRecord.Data.Priority == record.SRV.Priority &&
+			apiRecord.Data.Weight == record.SRV.Weight &&
+			apiRecord.Data.Port == record.SRV.Port
+	}
+
+	if record.Type == provider.RecordTypeA || record.Type == provider.RecordTypeAAAA {
+		apiIP, recordIP := net.ParseIP(apiRecord.Content), net.ParseIP(record.Target)
+		return apiIP != nil && recordIP != nil && apiIP.Equal(recordIP)
+	}
+
+	if record.Type == provider.RecordTypeCNAME {
+		return strings.EqualFold(strings.TrimSuffix(apiRecord.Content, "."), strings.TrimSuffix(record.Target, "."))
+	}
+
+	return apiRecord.Content == record.Target
 }
 
 // RecordNeedsUpdate implements provider.RecordComparer. It reports whether the

--- a/providers/cloudflare/provider_test.go
+++ b/providers/cloudflare/provider_test.go
@@ -381,6 +381,66 @@ func TestProvider_Delete_Success(t *testing.T) {
 	}
 }
 
+func TestProvider_Delete_SelectsMatchingTarget(t *testing.T) {
+	var deletedID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/zones/zone-123/dns_records":
+			_ = json.NewEncoder(w).Encode(successProviderResponse([]map[string]interface{}{
+				{"id": "sibling", "type": "A", "name": "app.example.com", "content": "10.0.0.2"},
+				{"id": "wanted", "type": "A", "name": "app.example.com", "content": "10.0.0.1"},
+			}))
+		case r.Method == http.MethodDelete:
+			deletedID = strings.TrimPrefix(r.URL.Path, "/zones/zone-123/dns_records/")
+			_ = json.NewEncoder(w).Encode(successProviderResponse(map[string]interface{}{"id": deletedID}))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server.URL)
+	err := p.Delete(context.Background(), provider.Record{
+		Hostname: "app.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.1",
+	})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if deletedID != "wanted" {
+		t.Fatalf("deleted record %q, want exact target record %q", deletedID, "wanted")
+	}
+}
+
+func TestProvider_Delete_DoesNotDeleteWhenTargetMissing(t *testing.T) {
+	deleteCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodDelete {
+			deleteCalled = true
+		}
+		_ = json.NewEncoder(w).Encode(successProviderResponse([]map[string]interface{}{
+			{"id": "sibling", "type": "A", "name": "app.example.com", "content": "10.0.0.2"},
+		}))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server.URL)
+	err := p.Delete(context.Background(), provider.Record{
+		Hostname: "app.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.1",
+	})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if deleteCalled {
+		t.Fatal("Delete() removed a sibling when the requested target was absent")
+	}
+}
+
 func TestProvider_Delete_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/providers/ovh/provider.go
+++ b/providers/ovh/provider.go
@@ -290,14 +290,7 @@ func (p *Provider) findRecord(ctx context.Context, record provider.Record) (*ovh
 
 	wantTarget, err := p.toOVHTarget(record)
 	if err != nil {
-		// Target could not be rendered (e.g. SRV without data); fall back to
-		// matching by subdomain and type alone.
-		wantTarget = ""
-	}
-
-	// With a single match, or no target to disambiguate, take the first.
-	if len(ids) == 1 || wantTarget == "" {
-		return p.client.GetRecord(ctx, p.zone, ids[0])
+		return nil, fmt.Errorf("rendering record target: %w", err)
 	}
 
 	for _, id := range ids {
@@ -305,13 +298,34 @@ func (p *Provider) findRecord(ctx context.Context, record provider.Record) (*ovh
 		if err != nil {
 			return nil, fmt.Errorf("getting record %d: %w", id, err)
 		}
-		if rec.Target == wantTarget {
+		if ovhTargetsEqual(record.Type, rec.Target, wantTarget) {
 			return rec, nil
 		}
 	}
 
-	// No target match; fall back to the first record of this name and type.
-	return p.client.GetRecord(ctx, p.zone, ids[0])
+	// A name and type may contain several record values. Falling back to the
+	// first one would mutate an unrelated sibling when the requested value is
+	// absent.
+	return nil, nil
+}
+
+func ovhTargetsEqual(recordType provider.RecordType, actual, desired string) bool {
+	switch recordType {
+	case provider.RecordTypeTXT:
+		return unquoteTXT(actual) == desired
+	case provider.RecordTypeCNAME:
+		return strings.EqualFold(strings.TrimSuffix(actual, "."), strings.TrimSuffix(desired, "."))
+	case provider.RecordTypeSRV:
+		actualSRV, actualTarget, actualOK := parseSRVTarget(actual)
+		desiredSRV, desiredTarget, desiredOK := parseSRVTarget(desired)
+		return actualOK && desiredOK &&
+			actualSRV.Priority == desiredSRV.Priority &&
+			actualSRV.Weight == desiredSRV.Weight &&
+			actualSRV.Port == desiredSRV.Port &&
+			strings.EqualFold(strings.TrimSuffix(actualTarget, "."), strings.TrimSuffix(desiredTarget, "."))
+	default:
+		return actual == desired
+	}
 }
 
 // toProviderRecord converts an OVH API record into a provider.Record.

--- a/providers/ovh/provider_test.go
+++ b/providers/ovh/provider_test.go
@@ -298,6 +298,98 @@ func TestProvider_Delete_NotFound(t *testing.T) {
 	}
 }
 
+func TestProvider_Delete_SelectsMatchingTarget(t *testing.T) {
+	var deletedPath string
+	srv := ovhMux(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/refresh"):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/record"):
+			_ = json.NewEncoder(w).Encode([]int64{41, 42})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/record/41"):
+			_ = json.NewEncoder(w).Encode(ovhRecord{ID: 41, SubDomain: "app", FieldType: "A", Target: "10.0.0.2"})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/record/42"):
+			_ = json.NewEncoder(w).Encode(ovhRecord{ID: 42, SubDomain: "app", FieldType: "A", Target: "10.0.0.1"})
+		case r.Method == http.MethodDelete:
+			deletedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer srv.Close()
+
+	p := testProvider(t, srv.URL)
+	err := p.Delete(context.Background(), provider.Record{
+		Hostname: "app.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.1",
+	})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if !strings.HasSuffix(deletedPath, "/record/42") {
+		t.Fatalf("deleted path %q, want exact target record 42", deletedPath)
+	}
+}
+
+func TestProvider_Delete_DoesNotDeleteWhenTargetMissing(t *testing.T) {
+	deleteCalled := false
+	refreshCalled := false
+	srv := ovhMux(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/refresh"):
+			refreshCalled = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/record"):
+			_ = json.NewEncoder(w).Encode([]int64{41})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/record/41"):
+			_ = json.NewEncoder(w).Encode(ovhRecord{ID: 41, SubDomain: "app", FieldType: "A", Target: "10.0.0.2"})
+		case r.Method == http.MethodDelete:
+			deleteCalled = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer srv.Close()
+
+	p := testProvider(t, srv.URL)
+	err := p.Delete(context.Background(), provider.Record{
+		Hostname: "app.example.com",
+		Type:     provider.RecordTypeA,
+		Target:   "10.0.0.1",
+	})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if deleteCalled || refreshCalled {
+		t.Fatal("Delete() mutated the zone when the requested target was absent")
+	}
+}
+
+func TestOVHTargetsEqual(t *testing.T) {
+	tests := []struct {
+		name       string
+		recordType provider.RecordType
+		actual     string
+		desired    string
+		want       bool
+	}{
+		{name: "quoted TXT", recordType: provider.RecordTypeTXT, actual: `"heritage=dnsweaver"`, desired: "heritage=dnsweaver", want: true},
+		{name: "CNAME trailing dot", recordType: provider.RecordTypeCNAME, actual: "target.example.com.", desired: "target.example.com", want: true},
+		{name: "SRV trailing dot", recordType: provider.RecordTypeSRV, actual: "10 20 5060 sip.example.com.", desired: "10 20 5060 sip.example.com", want: true},
+		{name: "different SRV member", recordType: provider.RecordTypeSRV, actual: "10 20 5060 sip-2.example.com.", desired: "10 20 5060 sip-1.example.com", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ovhTargetsEqual(tt.recordType, tt.actual, tt.desired); got != tt.want {
+				t.Fatalf("ovhTargetsEqual(%q, %q) = %v, want %v", tt.actual, tt.desired, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProvider_Update(t *testing.T) {
 	var updated recordUpdateRequest
 	updateCalled := false

--- a/providers/pihole/client_test.go
+++ b/providers/pihole/client_test.go
@@ -500,6 +500,20 @@ func TestProvider_Mode(t *testing.T) {
 	}
 }
 
+func TestProvider_CapabilitiesDoNotClaimTXTSupport(t *testing.T) {
+	p := &Provider{mode: ModeAPI}
+	caps := p.Capabilities()
+	if caps.SupportsOwnershipTXT {
+		t.Fatal("Pi-hole API mode claims ownership TXT support but Create and Delete skip TXT records")
+	}
+	if caps.SupportsRecordType(provider.RecordTypeTXT) {
+		t.Fatal("Pi-hole API mode advertises TXT as a supported record type")
+	}
+	if caps.SupportsNativeUpdate {
+		t.Fatal("Pi-hole API mode claims native update support but does not implement provider.Updater")
+	}
+}
+
 func TestProvider_UnsupportedRecordTypes(t *testing.T) {
 	config := &Config{
 		Mode:       ModeAPI,

--- a/providers/pihole/provider.go
+++ b/providers/pihole/provider.go
@@ -213,14 +213,14 @@ func (p *Provider) Identity() provider.ProviderIdentity {
 
 // Capabilities returns the provider's feature support.
 // Pi-hole capabilities depend on the operating mode:
-// - API mode: full TXT support and native update via the Pi-hole API
+// - API mode: no TXT ownership or native update support
 // - File mode: no TXT ownership (uses dnsmasq file format), no native update
 func (p *Provider) Capabilities() provider.Capabilities {
 	switch p.mode {
 	case ModeAPI:
 		return provider.Capabilities{
-			SupportsOwnershipTXT: true,
-			SupportsNativeUpdate: true,
+			SupportsOwnershipTXT: false,
+			SupportsNativeUpdate: false,
 			SupportedRecordTypes: []provider.RecordType{
 				provider.RecordTypeA,
 				provider.RecordTypeCNAME,

--- a/providers/rfc2136/provider.go
+++ b/providers/rfc2136/provider.go
@@ -210,7 +210,7 @@ func (p *Provider) List(ctx context.Context) ([]provider.Record, error) {
 
 		// Query common record types for this hostname
 		hostnameFQDN := p.ensureFQDN(hostname)
-		for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeCNAME, dns.TypeSRV} {
+		for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeCNAME, dns.TypeTXT, dns.TypeSRV} {
 			dnsRecords, err := p.client.Query(ctx, hostnameFQDN, qtype)
 			if err != nil {
 				p.logger.Debug("query failed for hostname",
@@ -278,9 +278,9 @@ func (p *Provider) Create(ctx context.Context, record provider.Record) error {
 	return nil
 }
 
-// Delete removes a DNS record.
-// For non-TXT records (data records), the hostname is also removed from the catalog.
-// Ownership TXT records are not tracked in the catalog.
+// Delete removes one exact DNS record. A data hostname remains in the catalog
+// while any other supported member still exists at that name. Ownership TXT
+// records are not tracked in the catalog.
 func (p *Provider) Delete(ctx context.Context, record provider.Record) error {
 	dnsRecord, err := p.toRFC2136Record(record)
 	if err != nil {
@@ -291,15 +291,25 @@ func (p *Provider) Delete(ctx context.Context, record provider.Record) error {
 		return fmt.Errorf("deleting record %s: %w", record.Hostname, err)
 	}
 
-	// Remove from catalog if this is NOT an ownership TXT record
+	// Remove the hostname from the catalog only after confirming that the exact
+	// deletion removed its final supported data member. Keeping the catalog
+	// entry is required for List to rediscover surviving siblings after restart.
 	if p.catalog != nil && !provider.IsOwnershipRecord(record.Hostname) {
-		if err := p.catalog.Remove(ctx, record.Hostname); err != nil {
-			// Log but don't fail - the DNS record was deleted successfully
-			// Catalog can be repaired later
-			p.logger.Warn("failed to remove hostname from catalog",
+		hasSiblings, err := p.hasDataRecords(ctx, record.Hostname)
+		if err != nil {
+			p.logger.Warn("failed to verify whether hostname has surviving records; keeping catalog entry",
 				slog.String("hostname", record.Hostname),
 				slog.String("error", err.Error()),
 			)
+		} else if !hasSiblings {
+			if err := p.catalog.Remove(ctx, record.Hostname); err != nil {
+				// Log but don't fail - the DNS record was deleted successfully
+				// Catalog can be repaired later
+				p.logger.Warn("failed to remove hostname from catalog",
+					slog.String("hostname", record.Hostname),
+					slog.String("error", err.Error()),
+				)
+			}
 		}
 	}
 
@@ -310,6 +320,20 @@ func (p *Provider) Delete(ctx context.Context, record provider.Record) error {
 	)
 
 	return nil
+}
+
+func (p *Provider) hasDataRecords(ctx context.Context, hostname string) (bool, error) {
+	name := p.ensureFQDN(hostname)
+	for _, recordType := range []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeCNAME, dns.TypeTXT, dns.TypeSRV} {
+		records, err := p.client.Query(ctx, name, recordType)
+		if err != nil {
+			return false, fmt.Errorf("querying %s records: %w", dns.TypeToString[recordType], err)
+		}
+		if len(records) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // Update modifies an existing DNS record in place.

--- a/providers/rfc2136/provider_integration_test.go
+++ b/providers/rfc2136/provider_integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package rfc2136
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maxfield-allison/dnsweaver/pkg/provider"
+)
+
+func integrationConfig(t *testing.T) *Config {
+	t.Helper()
+	server := os.Getenv("DNSUPDATE_TEST_SERVER")
+	zone := os.Getenv("DNSUPDATE_TEST_ZONE")
+	if server == "" || zone == "" {
+		t.Skip("DNSUPDATE_TEST_SERVER and DNSUPDATE_TEST_ZONE must be set")
+	}
+	if !strings.HasSuffix(zone, ".") {
+		zone += "."
+	}
+	return &Config{
+		Server:        server,
+		Zone:          zone,
+		TSIGKeyName:   os.Getenv("DNSUPDATE_TEST_TSIG_NAME"),
+		TSIGSecret:    os.Getenv("DNSUPDATE_TEST_TSIG_SECRET"),
+		TSIGAlgorithm: os.Getenv("DNSUPDATE_TEST_TSIG_ALGORITHM"),
+		Timeout:       DefaultTimeout,
+		UseTCP:        os.Getenv("DNSUPDATE_TEST_TCP") == "true",
+		TTL:           60,
+	}
+}
+
+func TestIntegration_DeleteKeepsCatalogUntilFinalMember(t *testing.T) {
+	cfg := integrationConfig(t)
+	hostname := fmt.Sprintf("dnsweaver-rfc2136-set-%d.%s", time.Now().UnixNano(), strings.TrimSuffix(cfg.Zone, "."))
+	first := provider.Record{Hostname: hostname, Type: provider.RecordTypeA, Target: "192.0.2.10", TTL: 60}
+	second := provider.Record{Hostname: hostname, Type: provider.RecordTypeA, Target: "192.0.2.11", TTL: 60}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	p, err := New("integration", cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = p.Delete(cleanupCtx, first)
+		_ = p.Delete(cleanupCtx, second)
+	})
+
+	if err := p.Create(ctx, first); err != nil {
+		t.Fatalf("Create(first) error = %v", err)
+	}
+	if err := p.Create(ctx, second); err != nil {
+		t.Fatalf("Create(second) error = %v", err)
+	}
+	if err := p.Delete(ctx, first); err != nil {
+		t.Fatalf("Delete(first) error = %v", err)
+	}
+
+	// Constructing a new provider simulates a dnsweaver restart. It has to
+	// reload the catalog from DNS and still discover the surviving member.
+	restarted, err := New("integration-restarted", cfg)
+	if err != nil {
+		t.Fatalf("New(restarted) error = %v", err)
+	}
+	records, err := restarted.List(ctx)
+	if err != nil {
+		t.Fatalf("List(after restart) error = %v", err)
+	}
+	if !containsRecord(records, second) {
+		t.Fatalf("surviving member missing after restart: records=%+v", records)
+	}
+	if containsRecord(records, first) {
+		t.Fatalf("deleted member returned after restart: records=%+v", records)
+	}
+
+	if err := restarted.Delete(ctx, second); err != nil {
+		t.Fatalf("Delete(second) error = %v", err)
+	}
+	final, err := New("integration-final", cfg)
+	if err != nil {
+		t.Fatalf("New(final) error = %v", err)
+	}
+	records, err = final.List(ctx)
+	if err != nil {
+		t.Fatalf("List(after final delete) error = %v", err)
+	}
+	if containsRecord(records, first) || containsRecord(records, second) {
+		t.Fatalf("members remain after final delete: records=%+v", records)
+	}
+}
+
+func containsRecord(records []provider.Record, want provider.Record) bool {
+	for _, record := range records {
+		if record.Hostname == want.Hostname && record.Type == want.Type && record.Target == want.Target {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/technitium/companion.go
+++ b/providers/technitium/companion.go
@@ -107,6 +107,18 @@ func (p *Provider) deleteCompanionHTTPS(ctx context.Context, hostname string, re
 	if !hadCompanionHTTPS(recordType) {
 		return nil
 	}
+	if needsCompanionHTTPS(recordType) {
+		hasAddress, err := p.hasAddressRecord(ctx, hostname)
+		if err != nil {
+			return err
+		}
+		if hasAddress {
+			p.logger.Debug("keeping companion HTTPS record for remaining address member",
+				slog.String("hostname", hostname),
+			)
+			return nil
+		}
+	}
 
 	svcParams := buildSvcParams(p.autoHTTPSALPN)
 	if err := p.client.DeleteHTTPSRecord(ctx, p.zone, hostname, companionHTTPSSvcPriority, companionHTTPSTargetName, svcParams); err != nil {
@@ -119,6 +131,22 @@ func (p *Provider) deleteCompanionHTTPS(ctx context.Context, hostname string, re
 	)
 
 	return nil
+}
+
+// hasAddressRecord reports whether an A or AAAA member remains at hostname.
+// Companion HTTPS records belong to the address RRsets as a whole, so deleting
+// one round-robin member must not remove the companion while a sibling remains.
+func (p *Provider) hasAddressRecord(ctx context.Context, hostname string) (bool, error) {
+	records, err := p.client.GetRecords(ctx, p.zone, hostname)
+	if err != nil {
+		return false, fmt.Errorf("checking remaining address records for %s: %w", hostname, err)
+	}
+	for _, record := range records {
+		if record.Type == string(provider.RecordTypeA) || record.Type == string(provider.RecordTypeAAAA) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // hasHTTPSRecord checks whether any HTTPS record exists for the given hostname.

--- a/providers/technitium/companion_test.go
+++ b/providers/technitium/companion_test.go
@@ -93,3 +93,34 @@ func TestCompanionSkippedForCNAME(t *testing.T) {
 		t.Errorf("expected leftover companion cleanup for a CNAME, got %d delete call(s)", deleteCalls)
 	}
 }
+
+func TestDeleteCompanionHTTPSKeepsItWhileAddressSiblingRemains(t *testing.T) {
+	deleteCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/zones/records/get":
+			_, _ = w.Write([]byte(`{"status":"ok","response":{"zone":{"name":"zone"},"name":"app.example.com","records":[{"name":"app.example.com","type":"A","ttl":300,"rData":{"ipAddress":"192.0.2.11"}}]}}`))
+		case "/api/zones/records/delete":
+			deleteCalls++
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL, Token: "token", Zone: "zone", TTL: 300, AutoHTTPSRecords: true, AutoHTTPSALPN: "h2"}
+	p, err := New("inst", cfg)
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+	p.client = NewClient(server.URL, "token")
+
+	if err := p.deleteCompanionHTTPS(context.Background(), "app.example.com", provider.RecordTypeA); err != nil {
+		t.Fatalf("deleteCompanionHTTPS failed: %v", err)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("deleted companion while an A sibling remained: %d delete call(s)", deleteCalls)
+	}
+}

--- a/providers/technitium/factory.go
+++ b/providers/technitium/factory.go
@@ -53,6 +53,7 @@ func NewWithHTTPClient(name string, config *Config, httpClient *http.Client, log
 
 	p := &Provider{
 		name:             name,
+		url:              config.URL,
 		zone:             config.Zone,
 		ttl:              config.TTL,
 		autoHTTPSRecords: config.AutoHTTPSRecords,

--- a/providers/technitium/provider_test.go
+++ b/providers/technitium/provider_test.go
@@ -67,6 +67,25 @@ func TestProvider_Zone(t *testing.T) {
 	}
 }
 
+func TestFactory_PreservesBackendURLInIdentity(t *testing.T) {
+	p, err := Factory()(provider.FactoryConfig{
+		Name: "internal",
+		ProviderConfig: map[string]string{
+			"URL":   "http://dns-a:5380",
+			"TOKEN": "token",
+			"ZONE":  "example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Factory() error = %v", err)
+	}
+
+	identity := provider.IdentityOf(p)
+	if identity.Endpoint != "http://dns-a:5380" || identity.Zone != "example.com" {
+		t.Fatalf("Identity() = %+v, want configured URL and zone", identity)
+	}
+}
+
 func TestProvider_New_NilConfig(t *testing.T) {
 	_, err := New("test", nil)
 	if err == nil {

--- a/providers/webhook/client.go
+++ b/providers/webhook/client.go
@@ -36,8 +36,10 @@ type SRVData struct {
 
 // DeleteRequest is the request body for delete operations.
 type DeleteRequest struct {
-	Hostname string `json:"hostname"`
-	Type     string `json:"type,omitempty"`
+	Hostname string   `json:"hostname"`
+	Type     string   `json:"type,omitempty"`
+	Value    string   `json:"value"`
+	SRV      *SRVData `json:"srv,omitempty"`
 }
 
 // RecordResponse represents a single DNS record returned by the webhook.
@@ -351,10 +353,12 @@ func (c *Client) CreateSRV(ctx context.Context, hostname string, priority, weigh
 
 // Delete sends a request to delete a DNS record.
 // Sends DELETE /delete with DeleteRequest body.
-func (c *Client) Delete(ctx context.Context, hostname, recordType string) error {
+func (c *Client) Delete(ctx context.Context, hostname, recordType, value string, srv *SRVData) error {
 	reqBody := DeleteRequest{
 		Hostname: hostname,
 		Type:     recordType,
+		Value:    value,
+		SRV:      srv,
 	}
 
 	bodyBytes, err := json.Marshal(reqBody)

--- a/providers/webhook/client_test.go
+++ b/providers/webhook/client_test.go
@@ -240,7 +240,7 @@ func TestClient_Delete(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(server.URL, 5*time.Second, "", "", WithRetries(0))
-		err := client.Delete(context.Background(), "app.example.com", "A")
+		err := client.Delete(context.Background(), "app.example.com", "A", "10.0.0.1", nil)
 		if err != nil {
 			t.Errorf("Delete() unexpected error: %v", err)
 		}
@@ -253,7 +253,7 @@ func TestClient_Delete(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(server.URL, 5*time.Second, "", "", WithRetries(0))
-		err := client.Delete(context.Background(), "app.example.com", "A")
+		err := client.Delete(context.Background(), "app.example.com", "A", "10.0.0.1", nil)
 		if err != nil {
 			t.Errorf("Delete() unexpected error: %v", err)
 		}
@@ -266,7 +266,7 @@ func TestClient_Delete(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(server.URL, 5*time.Second, "", "", WithRetries(0))
-		err := client.Delete(context.Background(), "nonexistent.example.com", "A")
+		err := client.Delete(context.Background(), "nonexistent.example.com", "A", "10.0.0.1", nil)
 		if err != nil {
 			t.Errorf("Delete() unexpected error for 404: %v", err)
 		}
@@ -283,7 +283,7 @@ func TestClient_Delete(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(server.URL, 5*time.Second, "", "", WithRetries(0))
-		err := client.Delete(context.Background(), "app.example.com", "A")
+		err := client.Delete(context.Background(), "app.example.com", "A", "10.0.0.1", nil)
 		if err == nil {
 			t.Error("Delete() expected error, got nil")
 		}

--- a/providers/webhook/provider.go
+++ b/providers/webhook/provider.go
@@ -265,7 +265,15 @@ func (p *Provider) Create(ctx context.Context, record provider.Record) error {
 
 // Delete removes a DNS record via the webhook.
 func (p *Provider) Delete(ctx context.Context, record provider.Record) error {
-	err := p.client.Delete(ctx, record.Hostname, string(record.Type))
+	var srv *SRVData
+	if record.SRV != nil {
+		srv = &SRVData{
+			Priority: record.SRV.Priority,
+			Weight:   record.SRV.Weight,
+			Port:     record.SRV.Port,
+		}
+	}
+	err := p.client.Delete(ctx, record.Hostname, string(record.Type), record.Target, srv)
 	if err != nil {
 		return fmt.Errorf("deleting %s record: %w", record.Type, err)
 	}

--- a/providers/webhook/provider_test.go
+++ b/providers/webhook/provider_test.go
@@ -320,6 +320,38 @@ func TestProvider_Delete(t *testing.T) {
 		if received.Type != "A" {
 			t.Errorf("received.Type = %q, want %q", received.Type, "A")
 		}
+		if received.Value != "10.0.0.1" {
+			t.Errorf("received.Value = %q, want %q", received.Value, "10.0.0.1")
+		}
+	})
+
+	t.Run("includes complete SRV member identity", func(t *testing.T) {
+		var received DeleteRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&received)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		p, err := New("test", &Config{URL: server.URL, Timeout: 5 * time.Second, Retries: 0})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		record := provider.Record{
+			Hostname: "_sip._tcp.example.com",
+			Type:     provider.RecordTypeSRV,
+			Target:   "sip-1.example.com",
+			SRV:      &provider.SRVData{Priority: 10, Weight: 20, Port: 5060},
+		}
+		if err := p.Delete(context.Background(), record); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		if received.Value != record.Target || received.SRV == nil {
+			t.Fatalf("delete request = %+v, want target and SRV identity", received)
+		}
+		if received.SRV.Priority != 10 || received.SRV.Weight != 20 || received.SRV.Port != 5060 {
+			t.Fatalf("delete SRV data = %+v, want priority=10 weight=20 port=5060", received.SRV)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

Source claims now compile into provider-scoped desired record sets after routing and target resolution. Repeated claims for the same member collapse, while distinct A and AAAA targets remain separate members.

Ownership is now member-specific through versioned TXT markers. Legacy hostname markers migrate only onto exact desired members. Provider deletion paths were made exact across Cloudflare, OVH, RFC 2136, Technitium, and webhook so removing or replacing one member doesn't select an unrelated sibling.

Member removal and provider-route changes now reconcile at the member level. The same model covers partial discovery, dry-run, restart recovery, all operational modes, and the mass-deletion circuit breaker. Providers without durable ownership markers still fail safe after restart: dnsweaver can remove members observed by the current process, but it won't delete ownership it can't recover or prove.

A focused built-image route test caught a Technitium provider identity bug. The factory left the configured API URL out of the identity, so two same-zone instances on different servers were grouped as one backend and left the removed route stale. The factory now preserves the endpoint. A regression test covers the same construction path the binary uses.

The Kubernetes source now scopes informer list/watch calls to configured namespaces. This belongs in #177 because the isolated lifecycle test uses namespace-only Ingress RBAC and couldn't start while the source populated a cluster-wide cache before applying its namespace filter.

## Validation

- `go test -race ./...`
- `golangci-lint run --config .golangci.yml --timeout 5m`
- static `linux/amd64` binary build
- final image build and `scripts/test-image-healthcheck.sh`
- provider integration tests against official PowerDNS 5.1.4 and BIND 9.20/RFC 2136 images
- built-image create-two, remove-one, restart, remove-final lifecycle against disposable Technitium, PowerDNS, and BIND zones
- the same lifecycle in an isolated Kubernetes namespace with namespace-only Ingress RBAC and disposable Technitium
- the same lifecycle against a unique throwaway zone on an existing Technitium server
- focused built-image abuse tests covering all operational modes, dry-run behavior, the circuit breaker, legacy ownership migration, and invalid CNAME sets
- a three-member built-image migration between two Technitium servers

Every lifecycle check verified the data records and member ownership markers after each transition. The Technitium checks also verified that its HTTPS companion remains until the final A/AAAA sibling is removed. Cleanup removed all throwaway zones, Kubernetes resources, containers, networks, and credentials afterward.

Fixes #177.
